### PR TITLE
Implement Clone for CsrMatrix and clean up lifetimes

### DIFF
--- a/src/matrix/sparse.rs
+++ b/src/matrix/sparse.rs
@@ -19,6 +19,7 @@ use faer::traits::ComplexField;
 //use faer::sparse::linalg::matmul::sparse_dense_matmul;
 
 /// CSR matrix wrapper for Faer sparse matrices.
+#[derive(Clone)]
 pub struct CsrMatrix<T> {
     inner: SparseRowMat<usize, T>,
 }

--- a/src/preconditioner/ilu.rs
+++ b/src/preconditioner/ilu.rs
@@ -450,7 +450,7 @@ impl<T: Clone> IluWorkspace<T> {
     }
 
     /// Get temporary workspace for triangular solve operations (zero-allocation)
-    pub fn get_temp_workspace(&self) -> std::cell::RefMut<Vec<T>> {
+    pub fn get_temp_workspace(&self) -> std::cell::RefMut<'_, Vec<T>> {
         self.temp1.borrow_mut()
     }
 }

--- a/src/solver/superlu_dist.rs
+++ b/src/solver/superlu_dist.rs
@@ -70,7 +70,7 @@ use crate::error::KError;
 use crate::solver::LinearSolver;
 use crate::utils::convergence::{SolveStats, ConvergedReason};
 use crate::parallel::{UniverseComm, Comm};
-use crate::matrix::sparse::{CsrMatrix, SparseMatrix};
+use crate::matrix::sparse::CsrMatrix;
 use std::collections::HashMap;
 use faer::MatMut;
 


### PR DESCRIPTION
## Summary
- derive `Clone` for `CsrMatrix` so sparse matrices can be duplicated safely
- clarify lifetime on ILU workspace accessor
- drop unused `SparseMatrix` import in SuperLU-DIST solver

## Testing
- `cargo check --no-default-features --features="logging"`
- `cargo test` *(fails: missing MPI library)*

------
https://chatgpt.com/codex/tasks/task_e_68a55e8e43148329b3382bbed4978eb3