### PR TITLE
Fix Jacobi iteration and add configurable damping

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -1,12 +1,12 @@
 //! Algebraic Multigrid (AMG) preconditioner for kryst.
 //!
-//! This module implements a production-grade AMG preconditioner inspired by HYPRE's BoomerAMG, 
+//! This module implements a production-grade AMG preconditioner inspired by HYPRE's BoomerAMG,
 //! supporting both serial and parallel (Rayon/MPI) execution with comprehensive safety checks,
 //! robust defaults, and optimized workspace utilization.
 //!
 //! # Overview
 //!
-//! Algebraic Multigrid (AMG) is a multilevel preconditioner for large sparse linear systems, 
+//! Algebraic Multigrid (AMG) is a multilevel preconditioner for large sparse linear systems,
 //! especially those arising from discretized PDEs. This implementation includes:
 //!
 //! - HYPRE-inspired robust defaults and safety checks
@@ -36,7 +36,7 @@
 //! ```rust
 //! // HYPRE-style robust construction with defaults
 //! let amg = AMG::new_with_defaults(&matrix)?;
-//! 
+//!
 //! // Advanced configuration
 //! let amg = AMG::builder()
 //!     .max_levels(25)                    // HYPRE default: 25
@@ -53,18 +53,18 @@
 //!     .build(&matrix)?;
 //! ```
 
-use crate::preconditioner::Preconditioner;
 use crate::error::KError;
 use crate::matrix::sparse::{CsrMatrix, SparseMatrix};
 use crate::matrix::utils;
-use faer::Mat;
 use crate::parallel::Comm;
-#[cfg(feature = "rayon")]
-use rayon::prelude::*;
-#[cfg(feature = "rayon")]
-use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator};
+use crate::preconditioner::Preconditioner;
+use faer::Mat;
 #[cfg(feature = "logging")]
 use log::{debug, info, trace, warn};
+#[cfg(feature = "rayon")]
+use rayon::iter::{IntoParallelIterator, IntoParallelRefIterator, IntoParallelRefMutIterator};
+#[cfg(feature = "rayon")]
+use rayon::prelude::*;
 
 /// Workspace for AMG operations to avoid repeated allocations
 #[derive(Debug)]
@@ -92,7 +92,7 @@ impl AMGWorkspace {
             fine_correction: vec![0.0; max_size],
         }
     }
-    
+
     /// Resize workspace to accommodate given size
     pub fn resize(&mut self, size: usize) {
         if self.temp_vector.len() < size {
@@ -103,13 +103,13 @@ impl AMGWorkspace {
             self.fine_correction.resize(size, 0.0);
         }
     }
-    
+
     /// Get a temporary vector slice of given size
     pub fn get_temp(&mut self, size: usize) -> &mut [f64] {
         self.resize(size);
         &mut self.temp_vector[..size]
     }
-    
+
     /// Get a work vector slice of given size
     pub fn get_work(&mut self, size: usize) -> &mut [f64] {
         self.resize(size);
@@ -138,23 +138,25 @@ impl MatVecOp for Mat<f64> {
         if x.len() != cols {
             return Err(KError::InvalidInput(format!(
                 "Matrix-vector dimension mismatch: {}x{} matrix, vector length {}",
-                rows, cols, x.len()
+                rows,
+                cols,
+                x.len()
             )));
         }
         if y.len() != rows {
             return Err(KError::InvalidInput(format!(
                 "Matrix-vector result dimension mismatch: {}x{} matrix, result length {}",
-                rows, cols, y.len()
+                rows,
+                cols,
+                y.len()
             )));
         }
-        
+
         #[cfg(feature = "rayon")]
         {
-            y.par_iter_mut()
-                .enumerate()
-                .for_each(|(i, yi)| {
-                    *yi = (0..cols).map(|j| self[(i, j)] * x[j]).sum();
-                });
+            y.par_iter_mut().enumerate().for_each(|(i, yi)| {
+                *yi = (0..cols).map(|j| self[(i, j)] * x[j]).sum();
+            });
         }
         #[cfg(not(feature = "rayon"))]
         {
@@ -164,7 +166,7 @@ impl MatVecOp for Mat<f64> {
         }
         Ok(())
     }
-    
+
     fn dims(&self) -> (usize, usize) {
         (self.nrows(), self.ncols())
     }
@@ -274,32 +276,38 @@ pub struct AMGConfig {
     pub ieee_checks: bool,
     /// Workspace optimization enabled
     pub optimize_workspace: bool,
+    /// Damping factor for Jacobi smoother
+    pub jacobi_omega: f64,
+    /// Chebyshev degree (0 disables)
+    pub chebyshev_degree: usize,
 }
 
 impl Default for AMGConfig {
     /// HYPRE-inspired robust defaults
     fn default() -> Self {
         Self {
-            max_levels: 25,              // HYPRE default
-            strong_threshold: 0.25,      // HYPRE default
-            coarse_threshold: 9,         // HYPRE default
-            max_coarse_size: 9,          // HYPRE default
-            min_coarse_size: 1,          // HYPRE minimum
-            truncation_factor: 0.0,      // HYPRE default: no truncation
-            max_elements_per_row: 0,     // HYPRE default: unlimited
-            interpolation_truncation: 0.0, // HYPRE default
-            pre_sweeps: 1,               // HYPRE default
-            post_sweeps: 1,              // HYPRE default
-            coarsen_type: CoarsenType::HMIS, // HYPRE default
-            interp_type: InterpType::Extended, // Robust choice
+            max_levels: 25,                     // HYPRE default
+            strong_threshold: 0.25,             // HYPRE default
+            coarse_threshold: 9,                // HYPRE default
+            max_coarse_size: 9,                 // HYPRE default
+            min_coarse_size: 1,                 // HYPRE minimum
+            truncation_factor: 0.0,             // HYPRE default: no truncation
+            max_elements_per_row: 0,            // HYPRE default: unlimited
+            interpolation_truncation: 0.0,      // HYPRE default
+            pre_sweeps: 1,                      // HYPRE default
+            post_sweeps: 1,                     // HYPRE default
+            coarsen_type: CoarsenType::HMIS,    // HYPRE default
+            interp_type: InterpType::Extended,  // Robust choice
             relax_type: RelaxType::GaussSeidel, // HYPRE default
-            logging_level: 0,            // No logging by default
-            print_level: 0,              // No printing by default
-            tolerance: 1e-6,             // HYPRE default for standalone solver
-            max_iterations: 20,          // HYPRE default for cycles
-            min_iterations: 0,           // HYPRE default
-            ieee_checks: true,           // Safety first
-            optimize_workspace: true,    // Performance optimization
+            logging_level: 0,                   // No logging by default
+            print_level: 0,                     // No printing by default
+            tolerance: 1e-6,                    // HYPRE default for standalone solver
+            max_iterations: 20,                 // HYPRE default for cycles
+            min_iterations: 0,                  // HYPRE default
+            ieee_checks: true,                  // Safety first
+            optimize_workspace: true,           // Performance optimization
+            jacobi_omega: 2.0 / 3.0,            // Safe default damping
+            chebyshev_degree: 0,                // Disabled by default
         }
     }
 }
@@ -356,6 +364,18 @@ impl AMGBuilder {
     /// Set interpolation truncation (HYPRE: interpolation truncation)
     pub fn interpolation_truncation(mut self, factor: f64) -> Self {
         self.config.interpolation_truncation = factor;
+        self
+    }
+
+    /// Set Jacobi damping factor ω
+    pub fn jacobi_omega(mut self, omega: f64) -> Self {
+        self.config.jacobi_omega = omega;
+        self
+    }
+
+    /// Set Chebyshev smoother degree (0 disables)
+    pub fn chebyshev_degree(mut self, k: usize) -> Self {
+        self.config.chebyshev_degree = k;
         self
     }
 
@@ -453,16 +473,15 @@ struct AMGLevel {
 }
 
 impl AMG {
-
     /// HYPRE-inspired input validation
     fn validate_matrix(matrix: &Mat<f64>) -> Result<(), KError> {
         if matrix.nrows() == 0 || matrix.ncols() == 0 {
             return Err(KError::InvalidInput("Matrix cannot be empty".to_string()));
         }
-        
+
         if matrix.nrows() != matrix.ncols() {
             return Err(KError::InvalidInput(
-                "AMG requires square matrices".to_string()
+                "AMG requires square matrices".to_string(),
             ));
         }
 
@@ -474,10 +493,10 @@ impl AMG {
                 weak_diagonal_count += 1;
             }
         }
-        
+
         if weak_diagonal_count > matrix.nrows() / 2 {
             return Err(KError::InvalidInput(
-                "Matrix has too many weak diagonal entries for stable AMG".to_string()
+                "Matrix has too many weak diagonal entries for stable AMG".to_string(),
             ));
         }
 
@@ -489,30 +508,38 @@ impl AMG {
         if config.max_levels == 0 {
             return Err(KError::InvalidInput("max_levels must be > 0".to_string()));
         }
-        
+
         if config.strong_threshold < 0.0 || config.strong_threshold > 1.0 {
             return Err(KError::InvalidInput(
-                "strong_threshold must be in [0.0, 1.0]".to_string()
+                "strong_threshold must be in [0.0, 1.0]".to_string(),
             ));
         }
-        
+
         if config.coarse_threshold == 0 {
-            return Err(KError::InvalidInput("coarse_threshold must be > 0".to_string()));
+            return Err(KError::InvalidInput(
+                "coarse_threshold must be > 0".to_string(),
+            ));
         }
-        
+
         if config.max_coarse_size < config.min_coarse_size {
             return Err(KError::InvalidInput(
-                "max_coarse_size must be >= min_coarse_size".to_string()
+                "max_coarse_size must be >= min_coarse_size".to_string(),
             ));
         }
-        
+
         if config.tolerance <= 0.0 {
             return Err(KError::InvalidInput("tolerance must be > 0".to_string()));
         }
-        
+
         if config.truncation_factor < 0.0 || config.truncation_factor > 1.0 {
             return Err(KError::InvalidInput(
-                "truncation_factor must be in [0.0, 1.0]".to_string()
+                "truncation_factor must be in [0.0, 1.0]".to_string(),
+            ));
+        }
+
+        if !(0.0 < config.jacobi_omega && config.jacobi_omega <= 1.0) {
+            return Err(KError::InvalidInput(
+                "jacobi_omega must be in (0, 1]".to_string(),
             ));
         }
 
@@ -539,11 +566,25 @@ impl AMG {
             // Coarsest level: direct solve or heavy smoothing
             if level < self.levels.len() {
                 let level_data = &self.levels[level];
-                Self::smooth_jacobi_parallel_workspace_sparse(&level_data.coarse_matrix, &level_data.diag_inv, r, z, 20, workspace);
+                self.smooth_jacobi_parallel_workspace_sparse(
+                    &level_data.coarse_matrix,
+                    &level_data.diag_inv,
+                    r,
+                    z,
+                    20,
+                    workspace,
+                )?;
             } else {
                 // Fallback for edge case
                 let diag_inv = utils::extract_diagonal_inverse(&self.matrix);
-                Self::smooth_jacobi_parallel_workspace(&self.matrix, &diag_inv, r, z, 10, workspace);
+                self.smooth_jacobi_parallel_workspace(
+                    &self.matrix,
+                    &diag_inv,
+                    r,
+                    z,
+                    10,
+                    workspace,
+                )?;
             }
             return Ok(());
         }
@@ -551,12 +592,16 @@ impl AMG {
         let level_data = &self.levels[level];
         let current_matrix = &level_data.coarse_matrix;
         let next_level_matrix = &self.levels[level + 1].coarse_matrix;
-        
+
         // Validate dimensions
         if r.len() != current_matrix.nrows() || z.len() != current_matrix.nrows() {
             return Err(KError::InvalidInput(format!(
                 "Dimension mismatch at level {}: matrix {}x{}, r.len()={}, z.len()={}",
-                level, current_matrix.nrows(), current_matrix.ncols(), r.len(), z.len()
+                level,
+                current_matrix.nrows(),
+                current_matrix.ncols(),
+                r.len(),
+                z.len()
             )));
         }
 
@@ -564,28 +609,60 @@ impl AMG {
         workspace.resize(current_matrix.nrows().max(next_level_matrix.nrows()));
 
         // Pre-smoothing
-        Self::smooth_jacobi_parallel_workspace_sparse(current_matrix, &level_data.diag_inv, r, z, self.nu_pre, workspace);
+        self.smooth_jacobi_parallel_workspace_sparse(
+            current_matrix,
+            &level_data.diag_inv,
+            r,
+            z,
+            self.nu_pre,
+            workspace,
+        )?;
 
         // Compute residual: res = r - A * z
-        kernel.matvec(1.0, current_matrix, z, 0.0, &mut workspace.residual[..current_matrix.nrows()])?;
+        kernel.matvec(
+            1.0,
+            current_matrix,
+            z,
+            0.0,
+            &mut workspace.residual[..current_matrix.nrows()],
+        )?;
         for i in 0..current_matrix.nrows() {
             workspace.residual[i] = r[i] - workspace.residual[i]; // r - A*z
         }
 
         // Restrict residual to coarse level
         let coarse_size = next_level_matrix.nrows();
-        kernel.matvec(1.0, &level_data.restriction, &workspace.residual[..current_matrix.nrows()], 0.0, &mut workspace.coarse_solution[..coarse_size])?;
+        kernel.matvec(
+            1.0,
+            &level_data.restriction,
+            &workspace.residual[..current_matrix.nrows()],
+            0.0,
+            &mut workspace.coarse_solution[..coarse_size],
+        )?;
 
         // Recursive solve on coarse level - need separate workspace to avoid borrowing issues
         let coarse_rhs: Vec<f64> = workspace.coarse_solution[..coarse_size].to_vec();
         let mut coarse_correction = vec![0.0; coarse_size];
-        
+
         // Create a minimal temporary workspace for recursion
         let mut temp_workspace = AMGWorkspace::new(coarse_size);
-        self.apply_cycle(level + 1, &coarse_rhs, &mut coarse_correction, &mut temp_workspace, kernel, comm)?;
+        self.apply_cycle(
+            level + 1,
+            &coarse_rhs,
+            &mut coarse_correction,
+            &mut temp_workspace,
+            kernel,
+            comm,
+        )?;
 
-        // Interpolate correction back to fine level  
-        kernel.matvec(1.0, &level_data.interpolation, &coarse_correction, 0.0, &mut workspace.fine_correction[..current_matrix.nrows()])?;
+        // Interpolate correction back to fine level
+        kernel.matvec(
+            1.0,
+            &level_data.interpolation,
+            &coarse_correction,
+            0.0,
+            &mut workspace.fine_correction[..current_matrix.nrows()],
+        )?;
 
         // Add correction: z = z + fine_correction
         for i in 0..current_matrix.nrows() {
@@ -593,7 +670,14 @@ impl AMG {
         }
 
         // Post-smoothing
-        Self::smooth_jacobi_parallel_workspace_sparse(current_matrix, &level_data.diag_inv, r, z, self.nu_post, workspace);
+        self.smooth_jacobi_parallel_workspace_sparse(
+            current_matrix,
+            &level_data.diag_inv,
+            r,
+            z,
+            self.nu_post,
+            workspace,
+        )?;
 
         Ok(())
     }
@@ -603,11 +687,11 @@ impl AMG {
         // HYPRE-style input validation
         Self::validate_matrix(matrix)?;
         Self::validate_config(&config)?;
-        
+
         // IEEE safety checks if enabled
         if config.ieee_checks {
             utils::check_ieee_values(matrix)?;
-            
+
             #[cfg(feature = "logging")]
             if config.logging_level > 0 {
                 info!("AMG: IEEE safety checks passed");
@@ -617,10 +701,17 @@ impl AMG {
         #[cfg(feature = "logging")]
         if config.logging_level > 0 {
             let (nnz, diag_dominance, diag_sum) = utils::analyze_matrix_properties(matrix);
-            info!("AMG Setup: Starting with {} x {} matrix (nnz={}, diag_dominance={:.2})", 
-                  matrix.nrows(), matrix.ncols(), nnz, diag_dominance);
-            debug!("AMG Config: max_levels={}, strong_threshold={:.3}, coarsen_type={:?}",
-                   config.max_levels, config.strong_threshold, config.coarsen_type);
+            info!(
+                "AMG Setup: Starting with {} x {} matrix (nnz={}, diag_dominance={:.2})",
+                matrix.nrows(),
+                matrix.ncols(),
+                nnz,
+                diag_dominance
+            );
+            debug!(
+                "AMG Config: max_levels={}, strong_threshold={:.3}, coarsen_type={:?}",
+                config.max_levels, config.strong_threshold, config.coarsen_type
+            );
             if diag_sum < 1e-12 {
                 warn!("AMG: Matrix has very weak diagonal (sum={:.2e})", diag_sum);
             }
@@ -634,7 +725,7 @@ impl AMG {
 
         for level_idx in 0..config.max_levels {
             let n = current_matrix.nrows();
-            
+
             #[cfg(feature = "logging")]
             if config.logging_level > 1 {
                 // Calculate nnz manually for faer matrices
@@ -653,8 +744,10 @@ impl AMG {
             if n <= config.coarse_threshold {
                 #[cfg(feature = "logging")]
                 if config.logging_level > 0 {
-                    debug!("AMG: Stopped coarsening at level {} (size={} <= threshold={})", 
-                           level_idx, n, config.coarse_threshold);
+                    debug!(
+                        "AMG: Stopped coarsening at level {} (size={} <= threshold={})",
+                        level_idx, n, config.coarse_threshold
+                    );
                 }
                 break;
             }
@@ -668,8 +761,9 @@ impl AMG {
             }
 
             // Compute adaptive threshold based on anisotropy
-            let adaptive_threshold = utils::compute_adaptive_threshold(&current_matrix, config.strong_threshold);
-            
+            let adaptive_threshold =
+                utils::compute_adaptive_threshold(&current_matrix, config.strong_threshold);
+
             // Generate interpolation and restriction operators with HYPRE-style coarsening
             let (mut interpolation, restriction) = Self::generate_operators_with_config(
                 &current_matrix,
@@ -682,14 +776,18 @@ impl AMG {
             if interpolation.nrows() != current_matrix.nrows() {
                 return Err(KError::FactorError(format!(
                     "Interpolation matrix dimension mismatch at level {}: expected {} rows, got {}",
-                    level_idx, current_matrix.nrows(), interpolation.nrows()
+                    level_idx,
+                    current_matrix.nrows(),
+                    interpolation.nrows()
                 )));
             }
 
             if restriction.ncols() != current_matrix.ncols() {
                 return Err(KError::FactorError(format!(
                     "Restriction matrix dimension mismatch at level {}: expected {} cols, got {}",
-                    level_idx, current_matrix.ncols(), restriction.ncols()
+                    level_idx,
+                    current_matrix.ncols(),
+                    restriction.ncols()
                 )));
             }
 
@@ -711,36 +809,38 @@ impl AMG {
 
             // Build coarse matrix (Galerkin product: R * A * P) with error checking
             let coarse_matrix = &restriction * &current_matrix * &interpolation;
-            
+
             // Convert to sparse format for storage and operations
             let sparse_interpolation = utils::to_sparse_with_tolerance(&interpolation, 1e-12);
             let sparse_restriction = utils::to_sparse_with_tolerance(&restriction, 1e-12);
             let sparse_matrix = utils::to_sparse_with_tolerance(&current_matrix, 1e-12);
-            
+
             // Sparse Galerkin product: coarse_matrix = R * A * P
             let sparse_coarse_matrix = utils::sparse_galerkin_product(
-                &sparse_restriction, 
-                &sparse_matrix, 
-                &sparse_interpolation
+                &sparse_restriction,
+                &sparse_matrix,
+                &sparse_interpolation,
             )?;
-            
+
             // Convert back to dense for validation (TODO: implement sparse validation)
             let coarse_matrix = sparse_coarse_matrix.to_dense();
-            
+
             // Validate coarse matrix properties
             if coarse_matrix.nrows() == 0 || coarse_matrix.ncols() == 0 {
                 return Err(KError::FactorError(format!(
-                    "Generated empty coarse matrix at level {}", level_idx
+                    "Generated empty coarse matrix at level {}",
+                    level_idx
                 )));
             }
-            
+
             // Check for numerical issues in coarse matrix
             if utils::has_numerical_issues(&coarse_matrix) {
                 return Err(KError::FactorError(format!(
-                    "Numerical issues detected in coarse matrix at level {}", level_idx
+                    "Numerical issues detected in coarse matrix at level {}",
+                    level_idx
                 )));
             }
-            
+
             let coarse_diag = utils::extract_diagonal_inverse(&coarse_matrix);
 
             // HYPRE-style complexity tracking using sparse nnz
@@ -755,7 +855,7 @@ impl AMG {
                 nnz: coarse_nnz,
             });
 
-            // Update for next iteration using sparse matrix  
+            // Update for next iteration using sparse matrix
             current_matrix = coarse_matrix;
             current_diag = coarse_diag;
 
@@ -763,7 +863,10 @@ impl AMG {
             if current_matrix.nrows() >= n {
                 #[cfg(feature = "logging")]
                 if config.logging_level > 0 {
-                    warn!("AMG: Coarsening stalled at level {} (no size reduction)", level_idx);
+                    warn!(
+                        "AMG: Coarsening stalled at level {} (no size reduction)",
+                        level_idx
+                    );
                 }
                 break;
             }
@@ -773,7 +876,7 @@ impl AMG {
         let final_size = current_matrix.nrows();
         let final_sparse_matrix = utils::to_sparse_with_tolerance(&current_matrix, 1e-12);
         let final_nnz = final_sparse_matrix.nnz();
-        
+
         levels.push(AMGLevel {
             interpolation: CsrMatrix::identity(final_size),
             restriction: CsrMatrix::identity(final_size),
@@ -784,11 +887,16 @@ impl AMG {
 
         #[cfg(feature = "logging")]
         if config.logging_level > 0 {
-            info!("AMG Setup Complete: {} levels, complexity={:.2}", 
-                  levels.len(), setup_complexity);
+            info!(
+                "AMG Setup Complete: {} levels, complexity={:.2}",
+                levels.len(),
+                setup_complexity
+            );
             if config.print_level > 0 {
-                println!("AMG Setup: {} -> {} (complexity: {:.2})", 
-                        original_size, final_size, setup_complexity);
+                println!(
+                    "AMG Setup: {} -> {} (complexity: {:.2})",
+                    original_size, final_size, setup_complexity
+                );
             }
         }
 
@@ -811,7 +919,7 @@ impl AMG {
     ) -> (Mat<f64>, Mat<f64>) {
         // Use configuration-driven coarsening and interpolation
         let strength_matrix = compute_strength_matrix(a, threshold);
-        
+
         let aggregates = match config.coarsen_type {
             CoarsenType::HMIS => {
                 // HYPRE's modified independent set (fallback to double pairwise for now)
@@ -830,7 +938,7 @@ impl AMG {
                 double_pairwise_aggregation(&strength_matrix)
             }
         };
-        
+
         let prolongation = match config.interp_type {
             InterpType::Extended => construct_prolongation(a, &aggregates),
             InterpType::Standard => construct_prolongation(a, &aggregates),
@@ -838,7 +946,7 @@ impl AMG {
             InterpType::Direct => construct_prolongation(a, &aggregates),
             InterpType::Multipass => construct_prolongation(a, &aggregates),
         };
-        
+
         let restriction = prolongation.transpose().to_owned();
         (prolongation, restriction)
     }
@@ -856,12 +964,12 @@ impl AMG {
             strong_threshold: base_threshold,
             ..Default::default()
         };
-        
+
         Self::new_with_config(a, config).unwrap_or_else(|e| {
             // Fallback to original implementation for compatibility
             #[cfg(feature = "logging")]
             warn!("AMG: Falling back to legacy constructor due to: {}", e);
-            
+
             Self::with_smoothing(a, max_levels, base_threshold, 1, 1)
         })
     }
@@ -880,7 +988,13 @@ impl AMG {
     /// * `base_threshold` - Base strength-of-connection threshold
     /// * `nu_pre` - Number of pre-smoothing iterations
     /// * `nu_post` - Number of post-smoothing iterations
-    pub fn with_smoothing(a: &Mat<f64>, max_levels: usize, base_threshold: f64, nu_pre: usize, nu_post: usize) -> Self {
+    pub fn with_smoothing(
+        a: &Mat<f64>,
+        max_levels: usize,
+        base_threshold: f64,
+        nu_pre: usize,
+        nu_post: usize,
+    ) -> Self {
         let mut levels = Vec::new();
         let mut current_matrix = a.clone();
         let mut current_diag = utils::extract_diagonal_inverse(&current_matrix);
@@ -890,25 +1004,23 @@ impl AMG {
                 break;
             }
             // Compute adaptive threshold based on anisotropy
-            let adaptive_threshold = utils::compute_adaptive_threshold(&current_matrix, base_threshold);
+            let adaptive_threshold =
+                utils::compute_adaptive_threshold(&current_matrix, base_threshold);
             // Generate interpolation and restriction operators
-            let (mut interpolation, restriction) = AMG::generate_operators(
-                &current_matrix,
-                adaptive_threshold,
-                true,
-            );
+            let (mut interpolation, restriction) =
+                AMG::generate_operators(&current_matrix, adaptive_threshold, true);
             // Smooth and normalize interpolation
             smooth_interpolation(&mut interpolation, &current_matrix, 0.5);
             minimize_energy(&mut interpolation, &current_matrix);
             // Convert to sparse for consistency with unified AMG approach
             let sparse_interpolation = utils::to_sparse_with_tolerance(&interpolation, 1e-12);
             let sparse_restriction = utils::to_sparse_with_tolerance(&restriction, 1e-12);
-            
+
             // Build coarse matrix using sparse Galerkin product
             let sparse_coarse_matrix = match utils::sparse_galerkin_product(
-                &sparse_restriction, 
-                &utils::to_sparse_with_tolerance(&current_matrix, 1e-12), 
-                &sparse_interpolation
+                &sparse_restriction,
+                &utils::to_sparse_with_tolerance(&current_matrix, 1e-12),
+                &sparse_interpolation,
             ) {
                 Ok(matrix) => matrix,
                 Err(_) => {
@@ -918,12 +1030,12 @@ impl AMG {
                     utils::to_sparse_with_tolerance(&coarse_dense, 1e-12)
                 }
             };
-            
+
             // Extract diagonal for smoothing
             let coarse_matrix_dense = sparse_coarse_matrix.to_dense();
             let coarse_diag = utils::extract_diagonal_inverse(&coarse_matrix_dense);
             let coarse_nnz = sparse_coarse_matrix.nnz();
-            
+
             levels.push(AMGLevel {
                 interpolation: sparse_interpolation,
                 restriction: sparse_restriction,
@@ -1006,125 +1118,183 @@ impl AMG {
     /// Parallel Jacobi smoother for a given matrix and right-hand side.
     ///
     /// Applies a fixed number of Jacobi iterations to z, using the diagonal inverse.
-    fn smooth_jacobi_parallel(a: &Mat<f64>, diag_inv: &[f64], r: &[f64], z: &mut [f64], iterations: usize) {
+    fn smooth_jacobi_parallel(
+        &self,
+        a: &Mat<f64>,
+        diag_inv: &[f64],
+        r: &[f64],
+        z: &mut [f64],
+        iterations: usize,
+    ) -> Result<(), KError> {
         let n = r.len();
+        if diag_inv.len() != n || z.len() != n {
+            return Err(KError::InvalidInput(
+                "Jacobi(simple): dimension mismatch".to_string(),
+            ));
+        }
+        if iterations == 0 {
+            return Ok(());
+        }
+
+        let omega = self.config.jacobi_omega;
+
         let mut z_vec = z.to_vec();
         let mut temp = vec![0.0; n];
         for _ in 0..iterations {
-            let _ = utils::parallel_mat_vec(a, &z_vec, &mut temp);
+            utils::parallel_mat_vec(a, &z_vec, &mut temp)?;
             #[cfg(feature = "rayon")]
             {
                 temp.par_iter_mut().enumerate().for_each(|(i, val)| {
                     *val = r[i] - *val;
                 });
-                z_vec.par_iter_mut().enumerate().for_each(|(i, val)| *val += diag_inv[i] * temp[i]);
+                z_vec
+                    .par_iter_mut()
+                    .enumerate()
+                    .for_each(|(i, val)| *val += omega * diag_inv[i] * temp[i]);
             }
             #[cfg(not(feature = "rayon"))]
             {
                 temp.iter_mut().enumerate().for_each(|(i, val)| {
                     *val = r[i] - *val;
                 });
-                z_vec.iter_mut().enumerate().for_each(|(i, val)| *val += diag_inv[i] * temp[i]);
+                z_vec
+                    .iter_mut()
+                    .enumerate()
+                    .for_each(|(i, val)| *val += omega * diag_inv[i] * temp[i]);
             }
         }
         z.copy_from_slice(&z_vec);
+        Ok(())
     }
 
     /// Workspace-aware Jacobi smoothing - reuses allocated vectors for better performance
     /// Sparse version of Jacobi smoothing
     fn smooth_jacobi_parallel_workspace_sparse(
-        a: &CsrMatrix<f64>, 
-        diag_inv: &[f64], 
-        r: &[f64], 
-        z: &mut [f64], 
+        &self,
+        a: &CsrMatrix<f64>,
+        diag_inv: &[f64],
+        r: &[f64],
+        z: &mut [f64],
         iterations: usize,
-        workspace: &mut AMGWorkspace
-    ) {
+        workspace: &mut AMGWorkspace,
+    ) -> Result<(), KError> {
         let n = r.len();
+        if diag_inv.len() != n || z.len() != n {
+            return Err(KError::InvalidInput(
+                "Jacobi: dimension mismatch".to_string(),
+            ));
+        }
+        if iterations == 0 {
+            return Ok(());
+        }
+
         workspace.resize(n);
-        
-        // Copy current solution to workspace temp vector for iteration
         workspace.temp_vector[..n].copy_from_slice(z);
-        
+        let omega = self.config.jacobi_omega;
+
         for _ in 0..iterations {
-            // Sparse A * temp_vector -> work_vector
-            let _ = a.spmv_scaled(1.0, &workspace.temp_vector[..n], 0.0, &mut workspace.work_vector[..n]);
-            
-            // Jacobi update: temp_vector = z + D^(-1) * (r - A*temp_vector)
+            a.spmv_scaled(
+                1.0,
+                &workspace.temp_vector[..n],
+                0.0,
+                &mut workspace.work_vector[..n],
+            )?;
             for i in 0..n {
-                workspace.temp_vector[i] = z[i] + diag_inv[i] * (r[i] - workspace.work_vector[i]);
+                let corr = diag_inv[i] * (r[i] - workspace.work_vector[i]);
+                workspace.temp_vector[i] += omega * corr;
             }
         }
-        
-        // Copy result back
+
         z[..n].copy_from_slice(&workspace.temp_vector[..n]);
+        Ok(())
     }
 
     fn smooth_jacobi_parallel_workspace(
-        a: &Mat<f64>, 
-        diag_inv: &[f64], 
-        r: &[f64], 
-        z: &mut [f64], 
+        &self,
+        a: &Mat<f64>,
+        diag_inv: &[f64],
+        r: &[f64],
+        z: &mut [f64],
         iterations: usize,
-        workspace: &mut AMGWorkspace
-    ) {
+        workspace: &mut AMGWorkspace,
+    ) -> Result<(), KError> {
         let n = r.len();
+        if diag_inv.len() != n || z.len() != n {
+            return Err(KError::InvalidInput(
+                "Jacobi(dense): dimension mismatch".to_string(),
+            ));
+        }
+        if iterations == 0 {
+            return Ok(());
+        }
+
         workspace.resize(n);
-        
-        // Copy current solution to workspace temp vector for iteration
         workspace.temp_vector[..n].copy_from_slice(z);
-        
+        let omega = self.config.jacobi_omega;
+
         for _ in 0..iterations {
-            // A * temp_vector -> work_vector
-            let _ = utils::parallel_mat_vec(a, &workspace.temp_vector[..n], &mut workspace.work_vector[..n]);
-            
-            // temp_vector += diag_inv * (r - work_vector)
+            utils::parallel_mat_vec(
+                a,
+                &workspace.temp_vector[..n],
+                &mut workspace.work_vector[..n],
+            )?;
+
             #[cfg(feature = "rayon")]
             {
-                workspace.temp_vector[..n].par_iter_mut()
+                workspace.temp_vector[..n]
+                    .par_iter_mut()
                     .zip(workspace.work_vector[..n].par_iter())
                     .zip(r.par_iter())
                     .zip(diag_inv.par_iter())
                     .for_each(|(((temp, &work), &residual), &d_inv)| {
-                        *temp += d_inv * (residual - work);
+                        *temp += omega * d_inv * (residual - work);
                     });
             }
             #[cfg(not(feature = "rayon"))]
             {
                 for i in 0..n {
-                    workspace.temp_vector[i] += diag_inv[i] * (r[i] - workspace.work_vector[i]);
+                    let corr = diag_inv[i] * (r[i] - workspace.work_vector[i]);
+                    workspace.temp_vector[i] += omega * corr;
                 }
             }
         }
-        
-        // Copy result back to z
+
         z.copy_from_slice(&workspace.temp_vector[..n]);
+        Ok(())
     }
     /// Recursive AMG V-cycle application (serial/Rayon).
     ///
     /// Applies pre-smoothing, restricts the residual, recursively solves on the coarse grid, prolongates the correction, and post-smooths.
-    fn apply_recursive(&self, level: usize, r: &[f64], z: &mut [f64], workspace: &mut AMGWorkspace) {
+    fn apply_recursive(
+        &self,
+        level: usize,
+        r: &[f64],
+        z: &mut [f64],
+        workspace: &mut AMGWorkspace,
+    ) -> Result<(), KError> {
         if level + 1 == self.levels.len() {
             AMG::solve_direct_sparse(&self.levels[level].coarse_matrix, r, z);
-            return;
+            return Ok(());
         }
         let a = &self.levels[level].coarse_matrix;
         let diag_inv = &self.levels[level].diag_inv;
         let restriction = &self.levels[level].restriction;
         let interpolation = &self.levels[level].interpolation;
         let coarse_matrix = &self.levels[level + 1].coarse_matrix;
-        
+
         // Ensure workspace is large enough
         workspace.resize(a.nrows().max(coarse_matrix.nrows()));
-        
+
         // Pre-smoothing
-        Self::smooth_jacobi_parallel_workspace_sparse(a, diag_inv, r, z, self.nu_pre, workspace);
-        
+        self.smooth_jacobi_parallel_workspace_sparse(a, diag_inv, r, z, self.nu_pre, workspace)?;
+
         // Compute residual: r - A*z using workspace
-        let _ = utils::parallel_mat_vec_sparse(a, z, &mut workspace.residual[..a.nrows()]);
+        utils::parallel_mat_vec_sparse(a, z, &mut workspace.residual[..a.nrows()])?;
         #[cfg(feature = "rayon")]
         {
-            workspace.residual[..a.nrows()].par_iter_mut().zip(r.par_iter())
+            workspace.residual[..a.nrows()]
+                .par_iter_mut()
+                .zip(r.par_iter())
                 .for_each(|(res, &ri)| *res = ri - *res);
         }
         #[cfg(not(feature = "rayon"))]
@@ -1133,26 +1303,33 @@ impl AMG {
                 workspace.residual[i] = r[i] - workspace.residual[i];
             }
         }
-        
+
         // Restrict residual to coarse grid
-        let _ = utils::parallel_mat_vec_sparse(restriction, &workspace.residual[..a.nrows()], 
-                        &mut workspace.coarse_solution[..coarse_matrix.nrows()]);
-        
+        utils::parallel_mat_vec_sparse(
+            restriction,
+            &workspace.residual[..a.nrows()],
+            &mut workspace.coarse_solution[..coarse_matrix.nrows()],
+        )?;
+
         // Make owned copies for recursive call to avoid borrowing conflicts
         let coarse_residual = workspace.coarse_solution[..coarse_matrix.nrows()].to_vec();
         let mut coarse_solution = vec![0.0; coarse_matrix.nrows()];
-        
+
         // Recursive coarse solve
-        self.apply_recursive(level + 1, &coarse_residual, &mut coarse_solution, workspace);
-        
+        self.apply_recursive(level + 1, &coarse_residual, &mut coarse_solution, workspace)?;
+
         // Prolongate correction
-        let _ = utils::parallel_mat_vec_sparse(interpolation, &coarse_solution, 
-                        &mut workspace.fine_correction[..a.nrows()]);
-        
+        utils::parallel_mat_vec_sparse(
+            interpolation,
+            &coarse_solution,
+            &mut workspace.fine_correction[..a.nrows()],
+        )?;
+
         // Add correction to solution
         #[cfg(feature = "rayon")]
         {
-            z.par_iter_mut().zip(workspace.fine_correction[..a.nrows()].par_iter())
+            z.par_iter_mut()
+                .zip(workspace.fine_correction[..a.nrows()].par_iter())
                 .for_each(|(zi, &correction)| *zi += correction);
         }
         #[cfg(not(feature = "rayon"))]
@@ -1161,79 +1338,86 @@ impl AMG {
                 z[i] += workspace.fine_correction[i];
             }
         }
-        
+
         // Post-smoothing
-        Self::smooth_jacobi_parallel_workspace_sparse(a, diag_inv, r, z, self.nu_post, workspace);
+        self.smooth_jacobi_parallel_workspace_sparse(a, diag_inv, r, z, self.nu_post, workspace)?;
+        Ok(())
     }
     /// Direct solve on coarsest level using sparse matrix
     /// Uses iterative CG for small sparse systems to avoid densification
     fn solve_direct_sparse(a: &CsrMatrix<f64>, r: &[f64], z: &mut [f64]) {
         let n = a.nrows();
-        
+
         // For very small matrices, use dense direct solve
         if n <= 10 {
             let a_dense = a.to_dense();
             Self::solve_direct(&a_dense, r, z);
             return;
         }
-        
+
         // Use sparse iterative solver (CG) for larger coarse grids
         // This avoids the O(n³) cost of dense factorization
-        
+
         // Initialize solution to zero
         z.fill(0.0);
-        
+
         // CG workspace
         let mut p = vec![0.0; n];
         let mut ap = vec![0.0; n];
         let mut residual = vec![0.0; n];
-        
+
         // r = b - A*x (x = 0, so r = b)
         residual.copy_from_slice(r);
         p.copy_from_slice(r);
-        
+
         let mut rsold = residual.iter().map(|x| x * x).sum::<f64>();
         let tolerance = 1e-10 * rsold.sqrt().max(1e-12);
-        
-        for _iter in 0..n.min(50) { // Limit iterations for coarse grid
+
+        for _iter in 0..n.min(50) {
+            // Limit iterations for coarse grid
             // ap = A * p
             a.spmv(&p, &mut ap);
-            
+
             // alpha = rsold / (p^T * A * p)
             let ptap: f64 = p.iter().zip(ap.iter()).map(|(pi, api)| pi * api).sum();
             if ptap.abs() < 1e-14 {
                 break;
             }
             let alpha = rsold / ptap;
-            
+
             // x = x + alpha * p
             for i in 0..n {
                 z[i] += alpha * p[i];
             }
-            
+
             // r = r - alpha * ap
             for i in 0..n {
                 residual[i] -= alpha * ap[i];
             }
-            
+
             let rsnew: f64 = residual.iter().map(|x| x * x).sum();
             if rsnew.sqrt() < tolerance {
                 break;
             }
-            
+
             let beta = rsnew / rsold;
-            
+
             // p = r + beta * p
             for i in 0..n {
                 p[i] = residual[i] + beta * p[i];
             }
-            
+
             rsold = rsnew;
         }
     }
 
     /// Direct solve using sparse matrix with MPI communication
-    fn solve_direct_sparse_with_comm(a: &CsrMatrix<f64>, r: &[f64], z: &mut [f64], comm: &crate::parallel::UniverseComm) {
+    fn solve_direct_sparse_with_comm(
+        a: &CsrMatrix<f64>,
+        r: &[f64],
+        z: &mut [f64],
+        comm: &crate::parallel::UniverseComm,
+    ) {
         // Convert to dense for direct solve temporarily
         let a_dense = a.to_dense();
         Self::solve_direct_with_comm(&a_dense, r, z, comm);
@@ -1256,26 +1440,43 @@ impl AMG {
         // initial residual norm
         let mut rr_new = {
             #[cfg(feature = "rayon")]
-            { residual.par_iter().map(|&v| v * v).sum::<f64>() }
+            {
+                residual.par_iter().map(|&v| v * v).sum::<f64>()
+            }
             #[cfg(not(feature = "rayon"))]
-            { residual.iter().map(|&v| v * v).sum::<f64>() }
+            {
+                residual.iter().map(|&v| v * v).sum::<f64>()
+            }
         };
         let mut rr_old;
         for _ in 0..n {
             let _ = utils::parallel_mat_vec(a, &p, &mut ap);
             #[cfg(feature = "rayon")]
-            let denominator = p.par_iter().zip(ap.par_iter()).map(|(&pi, &api)| pi * api).sum::<f64>();
+            let denominator = p
+                .par_iter()
+                .zip(ap.par_iter())
+                .map(|(&pi, &api)| pi * api)
+                .sum::<f64>();
             #[cfg(not(feature = "rayon"))]
-            let denominator = p.iter().zip(ap.iter()).map(|(&pi, &api)| pi * api).sum::<f64>();
+            let denominator = p
+                .iter()
+                .zip(ap.iter())
+                .map(|(&pi, &api)| pi * api)
+                .sum::<f64>();
             alpha = rr_new / denominator;
             #[cfg(feature = "rayon")]
-            x.par_iter_mut().zip(p.par_iter()).for_each(|(xi, &pi)| *xi += alpha * pi);
+            x.par_iter_mut()
+                .zip(p.par_iter())
+                .for_each(|(xi, &pi)| *xi += alpha * pi);
             #[cfg(not(feature = "rayon"))]
             for (xi, &pi) in x.iter_mut().zip(p.iter()) {
                 *xi += alpha * pi;
             }
             #[cfg(feature = "rayon")]
-            residual.par_iter_mut().zip(ap.par_iter()).for_each(|(ri, &api)| *ri -= alpha * api);
+            residual
+                .par_iter_mut()
+                .zip(ap.par_iter())
+                .for_each(|(ri, &api)| *ri -= alpha * api);
             #[cfg(not(feature = "rayon"))]
             for (ri, &api) in residual.iter_mut().zip(ap.iter()) {
                 *ri -= alpha * api;
@@ -1284,16 +1485,22 @@ impl AMG {
             rr_old = rr_new;
             rr_new = {
                 #[cfg(feature = "rayon")]
-                { residual.par_iter().map(|&v| v * v).sum::<f64>() }
+                {
+                    residual.par_iter().map(|&v| v * v).sum::<f64>()
+                }
                 #[cfg(not(feature = "rayon"))]
-                { residual.iter().map(|&v| v * v).sum::<f64>() }
+                {
+                    residual.iter().map(|&v| v * v).sum::<f64>()
+                }
             };
             if rr_new.sqrt() < 1e-10 {
                 break;
             }
             beta = rr_new / rr_old;
             #[cfg(feature = "rayon")]
-            p.par_iter_mut().zip(residual.par_iter()).for_each(|(pi, &ri)| *pi = ri + beta * *pi);
+            p.par_iter_mut()
+                .zip(residual.par_iter())
+                .for_each(|(pi, &ri)| *pi = ri + beta * *pi);
             #[cfg(not(feature = "rayon"))]
             for (pi, &ri) in p.iter_mut().zip(residual.iter()) {
                 *pi = ri + beta * *pi;
@@ -1304,7 +1511,12 @@ impl AMG {
     /// Direct solver for coarse grid using distributed collectives.
     ///
     /// Uses the Conjugate Gradient method with distributed dot products and mat-vecs.
-    fn solve_direct_with_comm(a: &Mat<f64>, r: &[f64], z: &mut [f64], comm: &crate::parallel::UniverseComm) {
+    fn solve_direct_with_comm(
+        a: &Mat<f64>,
+        r: &[f64],
+        z: &mut [f64],
+        comm: &crate::parallel::UniverseComm,
+    ) {
         let n = r.len();
         assert_eq!(a.ncols(), n);
         assert_eq!(a.nrows(), n);
@@ -1321,32 +1533,45 @@ impl AMG {
             comm.parallel_mat_vec(a, &p, &mut ap);
             let denominator = Comm::dot(comm, &p, &ap);
             alpha = rr_new / denominator;
-            x.iter_mut().zip(p.iter()).for_each(|(xi, &pi)| *xi += alpha * pi);
-            residual.iter_mut().zip(ap.iter()).for_each(|(ri, &api)| *ri -= alpha * api);
+            x.iter_mut()
+                .zip(p.iter())
+                .for_each(|(xi, &pi)| *xi += alpha * pi);
+            residual
+                .iter_mut()
+                .zip(ap.iter())
+                .for_each(|(ri, &api)| *ri -= alpha * api);
             rr_old = rr_new;
             rr_new = Comm::dot(comm, &residual, &residual);
             if rr_new.sqrt() < 1e-10 {
                 break;
             }
             beta = rr_new / rr_old;
-            p.iter_mut().zip(residual.iter()).for_each(|(pi, &ri)| *pi = ri + beta * *pi);
+            p.iter_mut()
+                .zip(residual.iter())
+                .for_each(|(pi, &ri)| *pi = ri + beta * *pi);
         }
         z.copy_from_slice(&x);
     }
     /// AMG V-cycle with distributed collectives and mat-vecs via Comm abstraction.
     ///
     /// Applies the V-cycle recursively using distributed operations.
-    pub fn apply_recursive_with_comm(&self, level: usize, r: &[f64], z: &mut [f64], comm: &crate::parallel::UniverseComm) {
+    pub fn apply_recursive_with_comm(
+        &self,
+        level: usize,
+        r: &[f64],
+        z: &mut [f64],
+        comm: &crate::parallel::UniverseComm,
+    ) -> Result<(), KError> {
         if level + 1 == self.levels.len() {
             AMG::solve_direct_sparse_with_comm(&self.levels[level].coarse_matrix, r, z, comm);
-            return;
+            return Ok(());
         }
         let a = &self.levels[level].coarse_matrix;
         let diag_inv = &self.levels[level].diag_inv;
         let restriction = &self.levels[level].restriction;
         let interpolation = &self.levels[level].interpolation;
         // Pre-smoothing
-        AMG::smooth_jacobi_parallel_with_comm_sparse(a, diag_inv, r, z, self.nu_pre, comm);
+        self.smooth_jacobi_parallel_with_comm_sparse(a, diag_inv, r, z, self.nu_pre, comm)?;
         // Compute residual: az = r - A z
         let mut az = vec![0.0; a.nrows()];
         let a_dense = a.to_dense();
@@ -1360,7 +1585,7 @@ impl AMG {
         comm.parallel_mat_vec(&restriction_dense, &az, &mut coarse_residual);
         // Recursive coarse solve
         let mut coarse_solution = vec![0.0; coarse_residual.len()];
-        self.apply_recursive_with_comm(level + 1, &coarse_residual, &mut coarse_solution, comm);
+        self.apply_recursive_with_comm(level + 1, &coarse_residual, &mut coarse_solution, comm)?;
         // Prolongate correction
         let mut fine_correction = vec![0.0; interpolation.nrows()];
         let interpolation_dense = interpolation.to_dense();
@@ -1369,7 +1594,8 @@ impl AMG {
             z[i] += fine_correction[i];
         }
         // Post-smoothing
-        AMG::smooth_jacobi_parallel_with_comm_sparse(a, diag_inv, r, z, self.nu_post, comm);
+        self.smooth_jacobi_parallel_with_comm_sparse(a, diag_inv, r, z, self.nu_post, comm)?;
+        Ok(())
     }
 
     /// Distributed Jacobi smoother using Comm abstraction.
@@ -1377,53 +1603,76 @@ impl AMG {
     /// Applies a fixed number of Jacobi iterations using distributed mat-vecs.
     /// Sparse version of Jacobi smoothing with MPI communication
     fn smooth_jacobi_parallel_with_comm_sparse(
+        &self,
         a: &CsrMatrix<f64>,
         diag_inv: &[f64],
         r: &[f64],
         z: &mut [f64],
         iterations: usize,
-        comm: &crate::parallel::UniverseComm
-    ) {
+        comm: &crate::parallel::UniverseComm,
+    ) -> Result<(), KError> {
         let n = r.len();
+        if diag_inv.len() != n || z.len() != n {
+            return Err(KError::InvalidInput(
+                "Jacobi(MPI): dimension mismatch".to_string(),
+            ));
+        }
+        if iterations == 0 {
+            return Ok(());
+        }
+
+        let omega = self.config.jacobi_omega;
         let mut temp = vec![0.0; n];
         let mut work = vec![0.0; n];
-        
+
         temp.copy_from_slice(z);
-        
+
         for _ in 0..iterations {
-            // Sparse matrix-vector product with communication
-            // For now, convert to dense temporarily
+            // TODO: replace with comm.parallel_spmv_csr when available
             let a_dense = a.to_dense();
             comm.parallel_mat_vec(&a_dense, &temp, &mut work);
-            
-            // Jacobi update
+
             for i in 0..n {
-                temp[i] = z[i] + diag_inv[i] * (r[i] - work[i]);
+                let corr = diag_inv[i] * (r[i] - work[i]);
+                temp[i] += omega * corr;
             }
         }
-        
+
         z.copy_from_slice(&temp);
+        Ok(())
     }
 
     fn smooth_jacobi_parallel_with_comm(
+        &self,
         a: &Mat<f64>,
         diag_inv: &[f64],
         r: &[f64],
         z: &mut [f64],
         iterations: usize,
         comm: &crate::parallel::UniverseComm,
-    ) {
+    ) -> Result<(), KError> {
         let n = r.len();
+        if diag_inv.len() != n || z.len() != n {
+            return Err(KError::InvalidInput(
+                "Jacobi(simple MPI): dimension mismatch".to_string(),
+            ));
+        }
+        if iterations == 0 {
+            return Ok(());
+        }
+
+        let omega = self.config.jacobi_omega;
         let mut z_vec = z.to_vec();
         let mut temp = vec![0.0; n];
         for _ in 0..iterations {
             comm.parallel_mat_vec(a, &z_vec, &mut temp);
-            temp.iter_mut().enumerate().for_each(|(i, val)| {
-                *val = r[i] - *val;
-            });
-            z_vec.iter_mut().enumerate().for_each(|(i, val)| *val += diag_inv[i] * temp[i]);
+            for i in 0..n {
+                let corr = diag_inv[i] * (r[i] - temp[i]);
+                z_vec[i] += omega * corr;
+            }
         }
         z.copy_from_slice(&z_vec);
+        Ok(())
     }
 
     /// Distributed AMG entry point.
@@ -1434,108 +1683,143 @@ impl AMG {
         r: &[f64],
         z: &mut [f64],
         comm: &crate::parallel::UniverseComm,
-    ) {
+    ) -> Result<(), KError> {
         let residual = r;
         let mut solution = vec![0.0; residual.len()];
         if self.levels.is_empty() {
             let diag_inv = AMG::extract_diagonal_inverse(&self.matrix);
-            AMG::smooth_jacobi_parallel_with_comm(&self.matrix, &diag_inv, residual, &mut solution, 10, comm);
+            self.smooth_jacobi_parallel_with_comm(
+                &self.matrix,
+                &diag_inv,
+                residual,
+                &mut solution,
+                10,
+                comm,
+            )?;
         } else {
-            self.apply_recursive_with_comm(0, residual, &mut solution, comm);
+            self.apply_recursive_with_comm(0, residual, &mut solution, comm)?;
         }
         z.copy_from_slice(&solution);
+        Ok(())
     }
 }
 
 impl Preconditioner<Mat<f64>, Vec<f64>> for AMG {
     /// Apply the AMG preconditioner: z = M⁻¹ r.
-    fn apply(&self, _side: crate::preconditioner::PcSide, r: &Vec<f64>, z: &mut Vec<f64>) -> Result<(), KError> {
+    fn apply(
+        &self,
+        _side: crate::preconditioner::PcSide,
+        r: &Vec<f64>,
+        z: &mut Vec<f64>,
+    ) -> Result<(), KError> {
         // Input validation
         if r.len() != z.len() {
             return Err(KError::InvalidInput(format!(
-                "Vector dimension mismatch: r.len()={}, z.len()={}", r.len(), z.len()
+                "Vector dimension mismatch: r.len()={}, z.len()={}",
+                r.len(),
+                z.len()
             )));
         }
-        
+
         if r.is_empty() {
-            return Err(KError::InvalidInput("Cannot apply preconditioner to empty vectors".to_string()));
+            return Err(KError::InvalidInput(
+                "Cannot apply preconditioner to empty vectors".to_string(),
+            ));
         }
-        
+
         // Check for NaN/Inf in input
         for (i, &val) in r.iter().enumerate() {
             if val.is_nan() || val.is_infinite() {
                 return Err(KError::InvalidInput(format!(
-                    "Invalid value {} detected in input vector at position {}", val, i
+                    "Invalid value {} detected in input vector at position {}",
+                    val, i
                 )));
             }
         }
-        
-        if self.levels.is_empty() || r.len() <= 10 { // Force simple smoothing for small problems
+
+        if self.levels.is_empty() || r.len() <= 10 {
+            // Force simple smoothing for small problems
             // Direct smoother application for matrix without multilevel setup OR small matrices
             if r.len() != self.matrix.nrows() {
                 return Err(KError::InvalidInput(format!(
-                    "Vector size {} doesn't match matrix size {}", r.len(), self.matrix.nrows()
+                    "Vector size {} doesn't match matrix size {}",
+                    r.len(),
+                    self.matrix.nrows()
                 )));
             }
-            
+
             let diag_inv = AMG::extract_diagonal_inverse(&self.matrix);
-            AMG::smooth_jacobi_parallel(&self.matrix, &diag_inv, r, z, 10);
+            self.smooth_jacobi_parallel(&self.matrix, &diag_inv, r, z, 10)?;
         } else {
             // Multilevel V-cycle application with unified kernel approach
             let mut local_workspace = AMGWorkspace::new(r.len());
             let local_kernel = crate::core::traits::LocalAmgKernel::new();
             let local_comm = crate::parallel::NoComm;
-            
+
             // First apply matrix to the fine level
             // Pre-smooth
             let diag_inv = Self::extract_diagonal_inverse(&self.matrix);
-            Self::smooth_jacobi_parallel(&self.matrix, &diag_inv, r, z, self.nu_pre);
-            
+            self.smooth_jacobi_parallel(&self.matrix, &diag_inv, r, z, self.nu_pre)?;
+
             // Compute residual
             local_workspace.resize(r.len());
-            let _ = utils::parallel_mat_vec(&self.matrix, z, &mut local_workspace.residual[..r.len()]);
+            utils::parallel_mat_vec(&self.matrix, z, &mut local_workspace.residual[..r.len()])?;
             for i in 0..r.len() {
                 local_workspace.residual[i] = r[i] - local_workspace.residual[i];
             }
-            
+
             // Restrict to coarse level (level 0 in levels array)
             if !self.levels.is_empty() {
                 let coarse_size = self.levels[0].coarse_matrix.nrows();
-                let _ = utils::parallel_mat_vec_sparse(&self.levels[0].restriction, &local_workspace.residual[..r.len()], 
-                                &mut local_workspace.coarse_solution[..coarse_size]);
-                
+                utils::parallel_mat_vec_sparse(
+                    &self.levels[0].restriction,
+                    &local_workspace.residual[..r.len()],
+                    &mut local_workspace.coarse_solution[..coarse_size],
+                )?;
+
                 // Recursive solve starting from level 0
                 let coarse_rhs: Vec<f64> = local_workspace.coarse_solution[..coarse_size].to_vec();
                 let mut coarse_correction = vec![0.0; coarse_size];
                 let mut temp_workspace = AMGWorkspace::new(coarse_size);
-                
-                if let Err(e) = self.apply_cycle(0, &coarse_rhs, &mut coarse_correction, &mut temp_workspace, &local_kernel, &local_comm) {
+
+                if let Err(e) = self.apply_cycle(
+                    0,
+                    &coarse_rhs,
+                    &mut coarse_correction,
+                    &mut temp_workspace,
+                    &local_kernel,
+                    &local_comm,
+                ) {
                     return Err(e);
                 }
-                
-                // Interpolate back 
-                let _ = utils::parallel_mat_vec_sparse(&self.levels[0].interpolation, &coarse_correction, 
-                                &mut local_workspace.fine_correction[..r.len()]);
-                
+
+                // Interpolate back
+                utils::parallel_mat_vec_sparse(
+                    &self.levels[0].interpolation,
+                    &coarse_correction,
+                    &mut local_workspace.fine_correction[..r.len()],
+                )?;
+
                 // Add correction
                 for i in 0..r.len() {
                     z[i] += local_workspace.fine_correction[i];
                 }
             }
-            
+
             // Post-smooth
-            Self::smooth_jacobi_parallel(&self.matrix, &diag_inv, r, z, self.nu_post);
+            self.smooth_jacobi_parallel(&self.matrix, &diag_inv, r, z, self.nu_post)?;
         }
-        
+
         // Validate output for numerical safety
         for (i, &val) in z.iter().enumerate() {
             if val.is_nan() || val.is_infinite() {
                 return Err(KError::SolveError(format!(
-                    "Invalid value {} generated in output vector at position {}", val, i
+                    "Invalid value {} generated in output vector at position {}",
+                    val, i
                 )));
             }
         }
-        
+
         Ok(())
     }
     /// AMG is constructed with new(), so setup is a no-op.
@@ -1613,10 +1897,12 @@ fn smooth_interpolation(interpolation: &mut Mat<f64>, matrix: &Mat<f64>, weight:
         let updates: Vec<(usize, usize, f64)> = (0..row_count)
             .into_par_iter()
             .flat_map(|i| {
-                (0..col_count).into_par_iter().map(move |j| (i, j, weight * matrix[(i, j)]))
+                (0..col_count)
+                    .into_par_iter()
+                    .map(move |j| (i, j, weight * matrix[(i, j)]))
             })
             .collect();
-        
+
         // Apply updates sequentially (still faster than mutex per element)
         for (i, j, update) in updates {
             interpolation[(i, j)] -= update;
@@ -1638,33 +1924,39 @@ fn minimize_energy(interpolation: &mut Mat<f64>, _matrix: &Mat<f64>) {
     let rows = interpolation.nrows();
     let cols = interpolation.ncols();
     #[cfg(feature = "rayon")]
-    let normalized_rows: Vec<Vec<f64>> = (0..rows).into_par_iter().map(|i| {
-        let mut row_vec: Vec<f64> = (0..cols).map(|j| interpolation[(i, j)]).collect();
-        let row_sum: f64 = row_vec.iter().map(|&val| val * val).sum();
-        let norm_factor = if row_sum.abs() > 1e-14 {
-            row_sum.sqrt()
-        } else {
-            1.0
-        };
-        for val in row_vec.iter_mut() {
-            *val /= norm_factor;
-        }
-        row_vec
-    }).collect();
+    let normalized_rows: Vec<Vec<f64>> = (0..rows)
+        .into_par_iter()
+        .map(|i| {
+            let mut row_vec: Vec<f64> = (0..cols).map(|j| interpolation[(i, j)]).collect();
+            let row_sum: f64 = row_vec.iter().map(|&val| val * val).sum();
+            let norm_factor = if row_sum.abs() > 1e-14 {
+                row_sum.sqrt()
+            } else {
+                1.0
+            };
+            for val in row_vec.iter_mut() {
+                *val /= norm_factor;
+            }
+            row_vec
+        })
+        .collect();
     #[cfg(not(feature = "rayon"))]
-    let normalized_rows: Vec<Vec<f64>> = (0..rows).into_iter().map(|i| {
-        let mut row_vec: Vec<f64> = (0..cols).map(|j| interpolation[(i, j)]).collect();
-        let row_sum: f64 = row_vec.iter().map(|&val| val * val).sum();
-        let norm_factor = if row_sum.abs() > 1e-14 {
-            row_sum.sqrt()
-        } else {
-            1.0
-        };
-        for val in row_vec.iter_mut() {
-            *val /= norm_factor;
-        }
-        row_vec
-    }).collect();
+    let normalized_rows: Vec<Vec<f64>> = (0..rows)
+        .into_iter()
+        .map(|i| {
+            let mut row_vec: Vec<f64> = (0..cols).map(|j| interpolation[(i, j)]).collect();
+            let row_sum: f64 = row_vec.iter().map(|&val| val * val).sum();
+            let norm_factor = if row_sum.abs() > 1e-14 {
+                row_sum.sqrt()
+            } else {
+                1.0
+            };
+            for val in row_vec.iter_mut() {
+                *val /= norm_factor;
+            }
+            row_vec
+        })
+        .collect();
     for i in 0..rows {
         for j in 0..cols {
             interpolation[(i, j)] = normalized_rows[i][j];
@@ -1673,24 +1965,28 @@ fn minimize_energy(interpolation: &mut Mat<f64>, _matrix: &Mat<f64>) {
 }
 
 /// Parallel mat-vec multiplication for sparse matrices using rayon or serial fallback.
-fn parallel_mat_vec_sparse(mat: &CsrMatrix<f64>, vec: &[f64], result: &mut [f64]) -> Result<(), KError> {
+fn parallel_mat_vec_sparse(
+    mat: &CsrMatrix<f64>,
+    vec: &[f64],
+    result: &mut [f64],
+) -> Result<(), KError> {
     let (rows, cols) = (mat.nrows(), mat.ncols());
     let (vlen, rlen) = (vec.len(), result.len());
-    
+
     if cols != vlen {
         return Err(KError::InvalidInput(format!(
             "Dimension mismatch in parallel_mat_vec_sparse: Matrix is {}x{}, but input vector length is {}",
             rows, cols, vlen
         )));
     }
-    
+
     if rows != rlen {
         return Err(KError::InvalidInput(format!(
             "Dimension mismatch in parallel_mat_vec_sparse: Matrix is {}x{}, but result length is {}",
             rows, cols, rlen
         )));
     }
-    
+
     // Use the sparse spmv method
     mat.spmv_scaled(1.0, vec, 0.0, result)
 }
@@ -1699,44 +1995,34 @@ fn parallel_mat_vec_sparse(mat: &CsrMatrix<f64>, vec: &[f64], result: &mut [f64]
 fn parallel_mat_vec(mat: &Mat<f64>, vec: &[f64], result: &mut [f64]) -> Result<(), KError> {
     let (rows, cols) = (mat.nrows(), mat.ncols());
     let (vlen, rlen) = (vec.len(), result.len());
-    
+
     if cols != vlen {
         return Err(KError::InvalidInput(format!(
             "Dimension mismatch in parallel_mat_vec: Matrix is {}x{}, but input vector length is {}",
             rows, cols, vlen
         )));
     }
-    
+
     if rows != rlen {
         return Err(KError::InvalidInput(format!(
             "Dimension mismatch in parallel_mat_vec: Matrix is {}x{}, but result length is {}",
             rows, cols, rlen
         )));
     }
-    
+
     #[cfg(feature = "rayon")]
     {
-        result
-            .par_iter_mut()
-            .enumerate()
-            .for_each(|(i, res)| {
-                *res = (0..cols)
-                    .map(|j| mat[(i, j)] * vec[j])
-                    .sum();
-            });
+        result.par_iter_mut().enumerate().for_each(|(i, res)| {
+            *res = (0..cols).map(|j| mat[(i, j)] * vec[j]).sum();
+        });
     }
     #[cfg(not(feature = "rayon"))]
     {
-        result
-            .iter_mut()
-            .enumerate()
-            .for_each(|(i, res)| {
-                *res = (0..cols)
-                    .map(|j| mat[(i, j)] * vec[j])
-                    .sum();
-            });
+        result.iter_mut().enumerate().for_each(|(i, res)| {
+            *res = (0..cols).map(|j| mat[(i, j)] * vec[j]).sum();
+        });
     }
-    
+
     Ok(())
 }
 
@@ -1822,7 +2108,7 @@ fn greedy_aggregation(s: &Mat<f64>) -> Vec<usize> {
     let mut aggregate_sizes = Vec::new();
     let mut next_agg_id = 0;
     let max_aggregate_size = 4; // Better balance - smaller aggregates
-    
+
     // Sort nodes by connectivity strength (most connected first for better seeds)
     let mut node_strengths: Vec<(f64, usize)> = (0..n)
         .map(|i| {
@@ -1830,45 +2116,45 @@ fn greedy_aggregation(s: &Mat<f64>) -> Vec<usize> {
             (total_strength, i)
         })
         .collect();
-    
+
     // Sort by descending strength for better seed selection
     node_strengths.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-    
+
     for &(_strength, seed) in &node_strengths {
         if aggregates[seed] != usize::MAX {
             continue; // Already assigned
         }
-        
+
         // Start new aggregate with better balance control
         let mut current_aggregate = vec![seed];
         aggregates[seed] = next_agg_id;
-        
+
         // Collect potential neighbors sorted by connection strength
         let mut candidates: Vec<(f64, usize)> = (0..n)
             .filter(|&j| j != seed && aggregates[j] == usize::MAX)
             .map(|j| (s[(seed, j)], j))
             .collect();
-        
+
         // Sort by descending strength
         candidates.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap_or(std::cmp::Ordering::Equal));
-        
+
         // Add strongly connected neighbors up to max size
         for &(strength, neighbor) in &candidates {
             if current_aggregate.len() >= max_aggregate_size {
                 break;
             }
-            
+
             // Only add if strongly connected (threshold-based)
             if strength > 0.1 && aggregates[neighbor] == usize::MAX {
                 current_aggregate.push(neighbor);
                 aggregates[neighbor] = next_agg_id;
             }
         }
-        
+
         aggregate_sizes.push(current_aggregate.len());
         next_agg_id += 1;
     }
-    
+
     aggregates
 }
 
@@ -1967,12 +2253,10 @@ fn construct_prolongation(a: &Mat<f64>, aggregates: &[usize]) -> Mat<f64> {
     #[cfg(feature = "rayon")]
     {
         let mut p = Mat::<f64>::zeros(n, coarse_n);
-        // Collect updates in parallel, then apply sequentially  
-        let updates: Vec<(usize, usize)> = (0..n)
-            .into_par_iter()
-            .map(|i| (i, aggregates[i]))
-            .collect();
-        
+        // Collect updates in parallel, then apply sequentially
+        let updates: Vec<(usize, usize)> =
+            (0..n).into_par_iter().map(|i| (i, aggregates[i])).collect();
+
         // Apply updates sequentially - much faster than per-element mutex
         for (i, agg_id) in updates {
             p[(i, agg_id)] = 1.0;
@@ -1996,11 +2280,7 @@ mod tests {
 
     #[test]
     fn test_amg_preconditioner_simple() {
-        let matrix = mat![
-            [4.0, 1.0, 0.0],
-            [1.0, 3.0, 1.0],
-            [0.0, 1.0, 2.0]
-        ];
+        let matrix = mat![[4.0, 1.0, 0.0], [1.0, 3.0, 1.0], [0.0, 1.0, 2.0]];
         let r = vec![5.0, 5.0, 3.0];
         let mut z = vec![0.0; 3];
 
@@ -2008,7 +2288,9 @@ mod tests {
         let coarsening_threshold = 9.0; // Use large threshold to prevent coarsening for small matrices
         let amg_preconditioner = AMG::new(&matrix, max_levels, coarsening_threshold);
 
-        amg_preconditioner.apply(crate::preconditioner::PcSide::Left, &r, &mut z).unwrap();
+        amg_preconditioner
+            .apply(crate::preconditioner::PcSide::Left, &r, &mut z)
+            .unwrap();
 
         let mut residual = vec![0.0; 3];
         MatVecOp::matvec(&matrix, &z, &mut residual).unwrap();
@@ -2016,7 +2298,11 @@ mod tests {
             residual[i] = r[i] - residual[i];
         }
         let residual_norm = residual.iter().map(|&x| x * x).sum::<f64>().sqrt();
-        assert!(residual_norm < 100.0, "Residual norm too high: {}", residual_norm);
+        assert!(
+            residual_norm < 100.0,
+            "Residual norm too high: {}",
+            residual_norm
+        );
     }
 
     #[test]
@@ -2034,7 +2320,9 @@ mod tests {
         let coarsening_threshold = 9.0; // Use large threshold to prevent coarsening for small matrices
         let amg_preconditioner = AMG::new(&matrix, max_levels, coarsening_threshold);
 
-        amg_preconditioner.apply(crate::preconditioner::PcSide::Left, &r, &mut z).unwrap();
+        amg_preconditioner
+            .apply(crate::preconditioner::PcSide::Left, &r, &mut z)
+            .unwrap();
 
         let mut residual = vec![0.0; 4];
         MatVecOp::matvec(&matrix, &z, &mut residual).unwrap();
@@ -2042,33 +2330,25 @@ mod tests {
             residual[i] = r[i] - residual[i];
         }
         let residual_norm = residual.iter().map(|&x| x * x).sum::<f64>().sqrt();
-        assert!(residual_norm < 100.0, "Residual norm too high: {}", residual_norm);
+        assert!(
+            residual_norm < 100.0,
+            "Residual norm too high: {}",
+            residual_norm
+        );
     }
 
     #[test]
     fn test_smooth_interpolation_basic() {
         // Input matrices
-        let mut interpolation = mat![
-            [1.0, 2.0, 3.0],
-            [4.0, 5.0, 6.0],
-            [7.0, 8.0, 9.0]
-        ];
-        let matrix = mat![
-            [0.5, 0.5, 0.5],
-            [1.0, 1.0, 1.0],
-            [1.5, 1.5, 1.5]
-        ];
+        let mut interpolation = mat![[1.0, 2.0, 3.0], [4.0, 5.0, 6.0], [7.0, 8.0, 9.0]];
+        let matrix = mat![[0.5, 0.5, 0.5], [1.0, 1.0, 1.0], [1.5, 1.5, 1.5]];
         let weight = 0.5;
 
         // Apply the function
         smooth_interpolation(&mut interpolation, &matrix, weight);
 
         // Expected result
-        let expected = mat![
-            [0.75, 1.75, 2.75],
-            [3.5, 4.5, 5.5],
-            [6.25, 7.25, 8.25]
-        ];
+        let expected = mat![[0.75, 1.75, 2.75], [3.5, 4.5, 5.5], [6.25, 7.25, 8.25]];
 
         // Assertions
         assert_eq!(interpolation, expected);
@@ -2082,11 +2362,7 @@ mod tests {
             [5.0, 6.0, 7.0, 8.0],
             [9.0, 10.0, 11.0, 12.0]
         ];
-        let matrix = mat![
-            [0.5, 0.5],
-            [1.0, 1.0],
-            [1.5, 1.5]
-        ];
+        let matrix = mat![[0.5, 0.5], [1.0, 1.0], [1.5, 1.5]];
         let weight = 1.0;
 
         // Apply the function
@@ -2108,24 +2384,26 @@ mod tests {
         // Test sparse matrix multiplication with simple matrices
         // A = [[2, 1], [0, 3]], B = [[1, 0], [1, 2]]
         // Expected: A*B = [[3, 2], [3, 6]]
-        
+
         let a = CsrMatrix::from_csr(
-            2, 2,
-            vec![0, 2, 3],     // row_ptr
-            vec![0, 1, 1],     // col_indices  
-            vec![2.0, 1.0, 3.0] // values
+            2,
+            2,
+            vec![0, 2, 3],       // row_ptr
+            vec![0, 1, 1],       // col_indices
+            vec![2.0, 1.0, 3.0], // values
         );
-        
+
         let b = CsrMatrix::from_csr(
-            2, 2,
-            vec![0, 1, 3],     // row_ptr
-            vec![0, 0, 1],     // col_indices
-            vec![1.0, 1.0, 2.0] // values
+            2,
+            2,
+            vec![0, 1, 3],       // row_ptr
+            vec![0, 0, 1],       // col_indices
+            vec![1.0, 1.0, 2.0], // values
         );
-        
+
         let result = utils::sparse_matrix_multiply(&a, &b).unwrap();
         let result_dense = result.to_dense();
-        
+
         // Check expected values
         assert!((result_dense[(0, 0)] - 3.0).abs() < 1e-12);
         assert!((result_dense[(0, 1)] - 2.0).abs() < 1e-12);
@@ -2136,41 +2414,31 @@ mod tests {
     #[test]
     fn test_sparse_galerkin_vs_dense() {
         // Compare sparse vs dense Galerkin products
-        let matrix = faer::mat![
-            [4.0, 1.0, 0.0],
-            [1.0, 3.0, 1.0],
-            [0.0, 1.0, 2.0]
-        ];
-        
+        let matrix = faer::mat![[4.0, 1.0, 0.0], [1.0, 3.0, 1.0], [0.0, 1.0, 2.0]];
+
         // Simple operators for testing
-        let interpolation = faer::mat![
-            [1.0, 0.0],
-            [0.5, 0.5],
-            [0.0, 1.0]
-        ];
-        
-        let restriction = faer::mat![
-            [1.0, 0.5, 0.0],
-            [0.0, 0.5, 1.0]
-        ];
-        
+        let interpolation = faer::mat![[1.0, 0.0], [0.5, 0.5], [0.0, 1.0]];
+
+        let restriction = faer::mat![[1.0, 0.5, 0.0], [0.0, 0.5, 1.0]];
+
         // Dense computation
         let temp = &restriction * &matrix;
         let dense_result = &temp * &interpolation;
-        
+
         // Sparse computation
         let sparse_matrix = CsrMatrix::from_dense(&matrix, 1e-15);
         let sparse_interpolation = CsrMatrix::from_dense(&interpolation, 1e-15);
         let sparse_restriction = CsrMatrix::from_dense(&restriction, 1e-15);
-        
+
         let sparse_result = utils::sparse_galerkin_product(
             &sparse_restriction,
             &sparse_matrix,
-            &sparse_interpolation
-        ).unwrap();
-        
+            &sparse_interpolation,
+        )
+        .unwrap();
+
         let sparse_result_dense = sparse_result.to_dense();
-        
+
         println!("Dense result:");
         for i in 0..dense_result.nrows() {
             for j in 0..dense_result.ncols() {
@@ -2178,7 +2446,7 @@ mod tests {
             }
             println!();
         }
-        
+
         println!("Sparse result:");
         for i in 0..sparse_result_dense.nrows() {
             for j in 0..sparse_result_dense.ncols() {
@@ -2186,35 +2454,38 @@ mod tests {
             }
             println!();
         }
-        
+
         // Check if results match within tolerance
         for i in 0..dense_result.nrows() {
             for j in 0..dense_result.ncols() {
                 let diff = (dense_result[(i, j)] - sparse_result_dense[(i, j)]).abs();
-                assert!(diff < 1e-10, "Mismatch at ({}, {}): dense={}, sparse={}, diff={}", 
-                       i, j, dense_result[(i, j)], sparse_result_dense[(i, j)], diff);
+                assert!(
+                    diff < 1e-10,
+                    "Mismatch at ({}, {}): dense={}, sparse={}, diff={}",
+                    i,
+                    j,
+                    dense_result[(i, j)],
+                    sparse_result_dense[(i, j)],
+                    diff
+                );
             }
         }
     }
 
-    #[test]  
+    #[test]
     fn test_high_threshold_debug() {
         // Test with high threshold that should prevent coarsening
-        let matrix = mat![
-            [4.0, 1.0, 0.0],
-            [1.0, 3.0, 1.0],
-            [0.0, 1.0, 2.0]
-        ];
-        
+        let matrix = mat![[4.0, 1.0, 0.0], [1.0, 3.0, 1.0], [0.0, 1.0, 2.0]];
+
         let max_levels = 2;
         let coarsening_threshold = 9.0; // High threshold - should prevent coarsening
         let amg = AMG::new(&matrix, max_levels, coarsening_threshold);
-        
+
         println!("Matrix size: {}", matrix.nrows());
         println!("Coarsening threshold: {}", coarsening_threshold);
         println!("AMG levels created: {}", amg.levels.len());
         println!("Levels is empty: {}", amg.levels.is_empty());
-        
+
         if amg.levels.is_empty() {
             println!("SUCCESS: No multilevel hierarchy created - will use simple smoothing");
         } else {


### PR DESCRIPTION
## Summary
- expose `jacobi_omega` and `chebyshev_degree` in `AMGConfig` with builder support and validation
- rewrite Jacobi smoothers as methods using the evolving iterate with damping
- thread new API through AMG cycles and MPI paths, propagating errors instead of panicking

## Testing
- `cargo test --quiet` *(fails: Could not find MPI library for various reasons)*

------
https://chatgpt.com/codex/tasks/task_e_68a563aa7df883298e88931d36298441