### PR TITLE
feat: add LinOp abstraction and shell

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -588,6 +588,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "gemm"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -744,7 +750,19 @@ checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -879,7 +897,7 @@ dependencies = [
 
 [[package]]
 name = "kryst"
-version = "1.0.4"
+version = "1.2.1"
 dependencies = [
  "approx",
  "bitflags 2.9.1",
@@ -894,6 +912,7 @@ dependencies = [
  "rayon",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror 1.0.69",
 ]
 
@@ -955,6 +974,12 @@ name = "linux-raw-sys"
 version = "0.4.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
 
 [[package]]
 name = "log"
@@ -1401,6 +1426,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "rand"
 version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,7 +1458,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -1534,7 +1565,20 @@ dependencies = [
  "bitflags 2.9.1",
  "errno",
  "libc",
- "linux-raw-sys",
+ "linux-raw-sys 0.4.15",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11181fbabf243db407ef8df94a6ce0b2f9a733bd8be4ad02b4eda9602296cac8"
+dependencies = [
+ "bitflags 2.9.1",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
  "windows-sys 0.59.0",
 ]
 
@@ -1688,6 +1732,19 @@ dependencies = [
  "libc",
  "thiserror 1.0.69",
  "walkdir",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15b61f8f20e3a6f7e0649d825294eaf317edce30f82cf6026e7e4cb9222a7d1e"
+dependencies = [
+ "fastrand",
+ "getrandom 0.3.3",
+ "once_cell",
+ "rustix 1.0.8",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1857,6 +1914,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
+dependencies = [
+ "wit-bindgen-rt",
+]
+
+[[package]]
 name = "wasm-bindgen"
 version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1933,7 +1999,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -2207,6 +2273,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen-rt"
+version = "0.39.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.9.1",
+]
 
 [[package]]
 name = "zerocopy"

--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -23,6 +23,7 @@
 
 use std::str::FromStr;
 use faer::Mat;
+use crate::matrix::op::LinOp;
 use crate::solver::{LinearSolver, CgSolver, GmresSolver, FgmresSolver, BiCgStabSolver, MinresSolver, 
                    TfqmrSolver, CgnrSolver, CgsSolver, QmrSolver, LuSolver, PcgSolver};
 use crate::preconditioner::Preconditioner;
@@ -66,6 +67,8 @@ pub struct Workspace {
     /// Current restart parameter (for validation)
     pub restart: usize,
 }
+
+// Adapter to view a Mat-based preconditioner as operating on a LinOp.
 
 /// All supported Krylov solver types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -125,8 +128,8 @@ impl FromStr for SolverType {
 /// 1. `setup()` - Prepare preconditioner and allocate workspaces
 /// 2. `solve()` - Solve linear systems efficiently using cached data
 pub struct KspContext {
-    solver: Option<Box<dyn LinearSolver<Mat<f64>, Vec<f64>, Scalar = f64, Error = KError>>>,
-    pc: Option<Box<dyn Preconditioner<Mat<f64>, Vec<f64>>>>,
+    solver: Option<Box<dyn LinearSolver<dyn LinOp<S = f64>, Vec<f64>, Scalar = f64, Error = KError>>>,
+    pc: Option<Box<dyn Preconditioner<dyn LinOp<S = f64>, Vec<f64>>>>,
     /// Deferred preconditioner construction info (for matrix-dependent PCs)
     deferred_pc: Option<DeferredPcInfo>,
     /// Current solver type (for PREONLY handling)
@@ -254,7 +257,7 @@ impl KspContext {
             },
             _ => {
                 // Create the appropriate Krylov solver
-                let solver: Box<dyn LinearSolver<Mat<f64>, Vec<f64>, Scalar = f64, Error = KError>> = match solver_type {
+                let solver: Box<dyn LinearSolver<dyn LinOp<S = f64>, Vec<f64>, Scalar = f64, Error = KError>> = match solver_type {
                     SolverType::Cg => {
                         let cg = CgSolver::new(self.rtol, self.maxits);
                         Box::new(cg)
@@ -574,7 +577,7 @@ impl KspContext {
     /// ksp.solve(&A, &b1, &mut x1)?;  // Fast solve
     /// ksp.solve(&A, &b2, &mut x2)?;  // Reuses workspace
     /// ```
-    pub fn setup(&mut self, a: &Mat<f64>, n: usize) -> Result<(), KError> {
+    pub fn setup(&mut self, a: &dyn LinOp<S = f64>, n: usize) -> Result<(), KError> {
         // Use default communicator (no parallelism) if none specified
         #[cfg(not(any(feature="mpi", feature="rayon")))]
         let default_comm = crate::parallel::UniverseComm::Serial;
@@ -599,15 +602,21 @@ impl KspContext {
     /// # Returns
     /// * `Ok(())` on success
     /// * `Err(KError)` if setup fails
-    pub fn setup_with_comm(&mut self, a: &Mat<f64>, n: usize, comm: crate::parallel::UniverseComm) -> Result<(), KError> {
+    pub fn setup_with_comm(&mut self, a: &dyn LinOp<S = f64>, n: usize, comm: crate::parallel::UniverseComm) -> Result<(), KError> {
         let _setup_stage = StageGuard::new("KSPSetupWithComm");
-        
+
         #[cfg(feature = "logging")]
         trace!("Setting up KSP context with {} unknowns", n);
-        
+
         // Store the communicator
         self.comm = Some(comm);
-        
+
+        // Currently, setup requires access to the underlying faer::Mat for preprocessing
+        let a_mat = a
+            .as_any()
+            .downcast_ref::<Mat<f64>>()
+            .ok_or_else(|| KError::InvalidInput("KSP setup requires faer::Mat<f64>".to_string()))?;
+
         // Apply matrix preprocessing (reordering + scaling) if specified
         let processed_matrix = if let Some(ref pc_opts) = self.pc_options {
             let reorder_method = match pc_opts.reorder.as_deref() {
@@ -635,16 +644,16 @@ impl KspContext {
                 #[cfg(feature = "logging")]
                 trace!("Applying matrix preprocessing: reorder={:?}, scaling={:?}", reorder_method, scaling_method);
                 
-                let (processed, preprocessing_info) = preprocess_matrix(a, reorder_method, scaling_method)?;
+                let (processed, preprocessing_info) = preprocess_matrix(a_mat, reorder_method, scaling_method)?;
                 self.preprocessing = Some(preprocessing_info);
                 processed
             } else {
                 self.preprocessing = Some(MatrixPreprocessing::identity(n));
-                a.clone()
+                a_mat.clone()
             }
         } else {
             self.preprocessing = Some(MatrixPreprocessing::identity(n));
-            a.clone()
+            a_mat.clone()
         };
         
         // Check for PC-chaining before deferred PC construction
@@ -762,7 +771,7 @@ impl KspContext {
     /// // Subsequent solves reuse workspace  
     /// let stats2 = ksp.solve(&A, &b2, &mut x2)?;
     /// ```
-    pub fn solve(&mut self, a: &Mat<f64>, b: &Vec<f64>, x: &mut Vec<f64>) -> Result<SolveStats<f64>, KError> {
+    pub fn solve(&mut self, a: &dyn LinOp<S = f64>, b: &Vec<f64>, x: &mut Vec<f64>) -> Result<SolveStats<f64>, KError> {
         let _solve_stage = StageGuard::new("KSPSolve");
         
         #[cfg(feature = "logging")]
@@ -827,11 +836,12 @@ impl KspContext {
             // Use the unified solve method with workspace and optional monitors
             let solver = self.solver.as_mut().unwrap(); // Safe because we checked above
             let comm = self.comm.as_ref().unwrap_or(&crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm));
+
             let stats = solver.solve(
-                a, 
-                self.pc.as_deref(), 
-                b, 
-                x, 
+                a,
+                self.pc.as_deref(),
+                b,
+                x,
                 comm,
                 monitors_slice,
                 Some(self.work.as_mut().unwrap()) // Always use workspace
@@ -861,13 +871,18 @@ impl KspContext {
     /// 
     /// This method handles the direct solve by using the stored pc_type to
     /// determine which direct solver to use and calling it appropriately.
-    fn apply_direct_solve(&mut self, a: &Mat<f64>, b: &Vec<f64>, x: &mut Vec<f64>) -> Result<SolveStats<f64>, KError> {
+    fn apply_direct_solve(&mut self, a: &dyn LinOp<S = f64>, b: &Vec<f64>, x: &mut Vec<f64>) -> Result<SolveStats<f64>, KError> {
+        let a_mat = a
+            .as_any()
+            .downcast_ref::<Mat<f64>>()
+            .ok_or_else(|| KError::InvalidInput("PREONLY direct solve requires faer::Mat<f64>".to_string()))?;
+
         match self.pc_type {
             Some(PcType::Lu) => {
                 // For LU, use the LuSolver directly with the new API
                 let mut lu_solver = LuSolver::new();
                 let comm = self.comm.as_ref().unwrap_or(&crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm));
-                lu_solver.solve(a, None, b, x, comm, None, self.work.as_mut())?;
+                lu_solver.solve(a_mat, None, b, x, comm, None, self.work.as_mut())?;
                 Ok(SolveStats {
                     iterations: 1,
                     final_residual: 0.0,
@@ -878,7 +893,7 @@ impl KspContext {
                 // For QR, use the QrSolver directly with the new API
                 let mut qr_solver = crate::solver::direct_lu::QrSolver::new();
                 let comm = self.comm.as_ref().unwrap_or(&crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm));
-                qr_solver.solve(a, None, b, x, comm, None, self.work.as_mut())?;
+                qr_solver.solve(a_mat, None, b, x, comm, None, self.work.as_mut())?;
                 Ok(SolveStats {
                     iterations: 1,
                     final_residual: 0.0,

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -22,9 +22,10 @@
 use std::str::FromStr;
 use faer::Mat;
 use crate::preconditioner::{Preconditioner, PcSide};
-use crate::solver::{LuSolver, direct_lu::QrSolver, LinearSolver}; 
+use crate::solver::{LuSolver, direct_lu::QrSolver, LinearSolver};
 use crate::config::options::PcOptions;
 use crate::error::KError;
+use crate::matrix::op::LinOp;
 
 /// All supported preconditioner types for runtime selection.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -113,6 +114,29 @@ impl Preconditioner<Mat<f64>, Vec<f64>> for NoOpPreconditioner {
     fn apply(&self, _side: PcSide, r: &Vec<f64>, z: &mut Vec<f64>) -> Result<(), KError> {
         z.clone_from(r);
         Ok(())
+    }
+}
+
+// Wrapper that adapts Mat-based preconditioners to LinOp interface.
+struct MatOpPreconditioner {
+    inner: Box<dyn Preconditioner<Mat<f64>, Vec<f64>>>,
+}
+
+impl MatOpPreconditioner {
+    fn new(inner: Box<dyn Preconditioner<Mat<f64>, Vec<f64>>>) -> Self { Self { inner } }
+}
+
+impl Preconditioner<dyn LinOp<S = f64>, Vec<f64>> for MatOpPreconditioner {
+    fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        let mat = a
+            .as_any()
+            .downcast_ref::<Mat<f64>>()
+            .ok_or_else(|| KError::InvalidInput("expected faer::Mat".to_string()))?;
+        self.inner.setup(mat)
+    }
+
+    fn apply(&self, side: PcSide, x: &Vec<f64>, y: &mut Vec<f64>) -> Result<(), KError> {
+        self.inner.apply(side, x, y)
     }
 }
 
@@ -310,25 +334,25 @@ impl PcFactory {
     pub fn create_preconditioner(
         pc_type: PcType, 
         options: Option<&PcOptions>
-    ) -> Result<Box<dyn Preconditioner<Mat<f64>, Vec<f64>>>, KError> {
+    ) -> Result<Box<dyn Preconditioner<dyn LinOp<S = f64>, Vec<f64>>>, KError> {
         use crate::preconditioner::{Jacobi, Ilu0, Ilutp};
         
         match pc_type {
             // Matrix-independent preconditioners - construct immediately
             PcType::Jacobi => {
-                Ok(Box::new(Jacobi::new()))
+                Ok(Box::new(MatOpPreconditioner::new(Box::new(Jacobi::new()))))
             },
             PcType::Ilu0 => {
-                Ok(Box::new(Ilu0::new()))
+                Ok(Box::new(MatOpPreconditioner::new(Box::new(Ilu0::new()))))
             },
             PcType::None => {
-                Ok(Box::new(NoOpPreconditioner))
+                Ok(Box::new(MatOpPreconditioner::new(Box::new(NoOpPreconditioner))))
             },
             PcType::Lu => {
-                Ok(Box::new(LuPreconditioner::new()))
+                Ok(Box::new(MatOpPreconditioner::new(Box::new(LuPreconditioner::new()))))
             },
             PcType::Qr => {
-                Ok(Box::new(QrPreconditioner::new()))
+                Ok(Box::new(MatOpPreconditioner::new(Box::new(QrPreconditioner::new()))))
             },
             PcType::SuperLuDist => {
                 // Create SuperLU_DIST preconditioner with options if available
@@ -428,9 +452,9 @@ impl PcFactory {
                         preconditioner.set_preallocation_strategy(strategy_enum);
                     }
                     
-                    Ok(Box::new(preconditioner))
+                    Ok(Box::new(MatOpPreconditioner::new(Box::new(preconditioner))))
                 } else {
-                    Ok(Box::new(SuperLuDistPreconditioner::new()))
+                    Ok(Box::new(MatOpPreconditioner::new(Box::new(SuperLuDistPreconditioner::new()))))
                 }
             },
             PcType::Ilutp => {
@@ -443,7 +467,7 @@ impl PcFactory {
                 } else {
                     Ilutp::new()
                 };
-                Ok(Box::new(ilutp))
+                Ok(Box::new(MatOpPreconditioner::new(Box::new(ilutp))))
             },
             
             // Matrix-dependent preconditioners cannot be constructed without a matrix
@@ -494,7 +518,7 @@ impl PcFactory {
     pub fn construct_deferred_preconditioner(
         deferred_info: DeferredPcInfo,
         matrix: &Mat<f64>
-    ) -> Result<Box<dyn Preconditioner<Mat<f64>, Vec<f64>>>, KError> {
+    ) -> Result<Box<dyn Preconditioner<dyn LinOp<S = f64>, Vec<f64>>>, KError> {
         #[cfg(feature = "logging")]
         log::trace!("Constructing deferred preconditioner: {:?}", deferred_info.pc_type);
         
@@ -523,9 +547,9 @@ impl PcFactory {
                 #[cfg(feature = "logging")]
                 log::trace!("Creating Chebyshev preconditioner: degree={}, λ_min={:.6e}, λ_max={:.6e}", degree, lambda_min, lambda_max);
                 
-                Ok(Box::new(crate::preconditioner::chebyshev::ChebyshevPre::new(
+                Ok(Box::new(MatOpPreconditioner::new(Box::new(crate::preconditioner::chebyshev::ChebyshevPre::new(
                     matrix.clone(), degree, lambda_min, lambda_max
-                )))
+                )))))
             },
             PcType::Amg => {
                 // Create AMG preconditioner with matrix
@@ -539,7 +563,7 @@ impl PcFactory {
                 log::trace!("Creating AMG preconditioner: max_levels={}, threshold={:.6e}, nu_pre={}, nu_post={}", 
                        max_levels, threshold, nu_pre, nu_post);
                 
-                Ok(Box::new(crate::preconditioner::amg::AMG::with_smoothing(matrix, max_levels, threshold, nu_pre, nu_post)))
+                Ok(Box::new(MatOpPreconditioner::new(Box::new(crate::preconditioner::amg::AMG::with_smoothing(matrix, max_levels, threshold, nu_pre, nu_post)))))
             },
             _ => {
                 Err(KError::UnrecognizedPcType(format!("Unexpected deferred PC type: {:?}", deferred_info.pc_type)))
@@ -561,7 +585,7 @@ impl PcFactory {
         chain_str: &str,
         matrix: &Mat<f64>,
         options: Option<&PcOptions>
-    ) -> Result<Box<dyn Preconditioner<Mat<f64>, Vec<f64>>>, KError> {
+    ) -> Result<Box<dyn Preconditioner<dyn LinOp<S = f64>, Vec<f64>>>, KError> {
         #[cfg(feature = "logging")]
         log::trace!("Constructing PC chain: {}", chain_str);
         
@@ -628,7 +652,7 @@ impl PcFactory {
         
         #[cfg(feature = "logging")]
         log::trace!("Successfully created PC chain with {} preconditioners", pc_chain.len());
-        Ok(Box::new(pc_chain))
+        Ok(Box::new(MatOpPreconditioner::new(Box::new(pc_chain))))
     }
 }
 

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -12,6 +12,30 @@ pub trait MatTransVec<V> {
     fn mattransvec(&self, x: &V, y: &mut V);
 }
 
+// Blanket implementations of MatVec/MatTransVec for LinOp types using Vec storage.
+use crate::matrix::op::LinOp;
+use faer::traits::ComplexField;
+
+impl<T, L> MatVec<Vec<T>> for L
+where
+    L: LinOp<S = T> + ?Sized,
+    T: ComplexField,
+{
+    fn matvec(&self, x: &Vec<T>, y: &mut Vec<T>) {
+        LinOp::matvec(self, &x[..], &mut y[..]);
+    }
+}
+
+impl<T, L> MatTransVec<Vec<T>> for L
+where
+    L: LinOp<S = T> + ?Sized,
+    T: ComplexField,
+{
+    fn mattransvec(&self, x: &Vec<T>, y: &mut Vec<T>) {
+        LinOp::matvec_t(self, &x[..], &mut y[..]);
+    }
+}
+
 /// Inner products & norms.
 pub trait InnerProduct<V> {
     /// Associated scalar type.

--- a/src/core/wrappers.rs
+++ b/src/core/wrappers.rs
@@ -21,22 +21,6 @@ use crate::core::traits::{Indexing, InnerProduct, MatTransVec, MatVec};
 use faer::{Mat, MatRef};
 use num_traits::Float;
 
-/// Implements matrix-vector multiplication for `faer::Mat`.
-///
-/// Computes `y = A * x` where `A` is a dense matrix, `x` and `y` are vectors.
-impl<T: Float> MatVec<Vec<T>> for Mat<T> {
-    fn matvec(&self, x: &Vec<T>, y: &mut Vec<T>) {
-        assert_eq!(self.nrows(), y.len(), "Output vector y has incorrect length");
-        assert_eq!(self.ncols(), x.len(), "Input vector x has incorrect length");
-        for i in 0..self.nrows() {
-            y[i] = T::zero();
-            for j in 0..self.ncols() {
-                y[i] = y[i] + self[(i, j)] * x[j];
-            }
-        }
-    }
-}
-
 /// Implements matrix-vector multiplication for a matrix reference (`faer::MatRef`).
 impl<'a, T: Float> MatVec<Vec<T>> for MatRef<'a, T> {
     fn matvec(&self, x: &Vec<T>, y: &mut Vec<T>) {
@@ -46,22 +30,6 @@ impl<'a, T: Float> MatVec<Vec<T>> for MatRef<'a, T> {
             y[i] = T::zero();
             for j in 0..self.ncols() {
                 y[i] = y[i] + self[(i, j)] * x[j];
-            }
-        }
-    }
-}
-
-/// Implements matrix-transpose-vector multiplication for `faer::Mat`.
-///
-/// Computes `y = A^T * x` where `A` is a dense matrix, `x` and `y` are vectors.
-impl<T: Float> MatTransVec<Vec<T>> for Mat<T> {
-    fn mattransvec(&self, x: &Vec<T>, y: &mut Vec<T>) {
-        assert_eq!(self.ncols(), y.len(), "Output vector y has incorrect length");
-        assert_eq!(self.nrows(), x.len(), "Input vector x has incorrect length");
-        for j in 0..self.ncols() {
-            y[j] = T::zero();
-            for i in 0..self.nrows() {
-                y[j] = y[j] + self[(i, j)] * x[i];
             }
         }
     }

--- a/src/matrix/dense.rs
+++ b/src/matrix/dense.rs
@@ -18,8 +18,8 @@ pub trait DenseMatrix<T>: MatVec<Vec<T>> + Indexing {
     fn from_raw(nrows: usize, ncols: usize, data: Vec<T>) -> Self;
 }
 
-impl<T: Copy + num_traits::Float> DenseMatrix<T> for Mat<T> {
-    fn from_raw(nrows: usize, ncols: usize, data: Vec<T>) -> Self {
+impl DenseMatrix<f64> for Mat<f64> {
+    fn from_raw(nrows: usize, ncols: usize, data: Vec<f64>) -> Self {
         Mat::from_fn(nrows, ncols, |i, j| data[j * nrows + i])
     }
 }

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -4,3 +4,8 @@ pub mod dense;
 pub use dense::DenseMatrix;
 pub mod sparse;
 pub mod utils;
+pub mod op;
+pub mod op_shell;
+
+pub use op::LinOp;
+pub use op_shell::MatShell;

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -1,0 +1,60 @@
+use std::any::Any;
+use faer::traits::ComplexField;
+
+/// Format-agnostic linear operator.
+pub trait LinOp: Send + Sync {
+    /// Scalar type.
+    type S: ComplexField;
+
+    /// Dimensions (rows, cols).
+    fn dims(&self) -> (usize, usize);
+
+    /// Compute y = A x.
+    fn matvec(&self, x: &[Self::S], y: &mut [Self::S]);
+
+    /// Optional transpose/adjoint matvec. Default panics.
+    fn matvec_t(&self, _x: &[Self::S], _y: &mut [Self::S]) {
+        unimplemented!("transpose/adjoint not provided for this operator");
+    }
+
+    /// Lightweight identifiers for structure/value changes.
+    fn structure_id(&self) -> u64 { 0 }
+    fn values_id(&self) -> u64 { 0 }
+
+    /// Downcast hook for specialized solvers/preconditioners.
+    fn as_any(&self) -> &dyn Any;
+}
+
+// --- Dense adapter -------------------------------------------------------
+use faer::Mat;
+impl LinOp for Mat<f64> {
+    type S = f64;
+
+    fn dims(&self) -> (usize, usize) { (self.nrows(), self.ncols()) }
+
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        assert_eq!(x.len(), self.ncols());
+        assert_eq!(y.len(), self.nrows());
+        for i in 0..self.nrows() {
+            let mut sum = 0.0;
+            for j in 0..self.ncols() {
+                sum += self[(i, j)] * x[j];
+            }
+            y[i] = sum;
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any { self }
+}
+
+// --- CSR adapter ---------------------------------------------------------
+use crate::matrix::sparse::{CsrMatrix, SparseMatrix};
+impl LinOp for CsrMatrix<f64> {
+    type S = f64;
+
+    fn dims(&self) -> (usize, usize) { (self.nrows(), self.ncols()) }
+
+    fn matvec(&self, x: &[f64], y: &mut [f64]) { self.spmv(x, y); }
+
+    fn as_any(&self) -> &dyn Any { self }
+}

--- a/src/matrix/op_shell.rs
+++ b/src/matrix/op_shell.rs
@@ -1,0 +1,67 @@
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use super::op::LinOp;
+
+/// Matrix-free "shell" operator.
+pub struct MatShell<S> {
+    m: usize,
+    n: usize,
+    mv: Arc<dyn Fn(&[S], &mut [S]) + Send + Sync>,
+    mvt: Option<Arc<dyn Fn(&[S], &mut [S]) + Send + Sync>>, 
+    sid: AtomicU64,
+    vid: AtomicU64,
+}
+
+impl MatShell<f64> {
+    pub fn new(
+        m: usize,
+        n: usize,
+        mv: impl Fn(&[f64], &mut [f64]) + Send + Sync + 'static,
+    ) -> Self {
+        Self {
+            m,
+            n,
+            mv: Arc::new(mv),
+            mvt: None,
+            sid: AtomicU64::new(1),
+            vid: AtomicU64::new(1),
+        }
+    }
+
+    pub fn with_transpose(
+        mut self,
+        mvt: impl Fn(&[f64], &mut [f64]) + Send + Sync + 'static,
+    ) -> Self {
+        self.mvt = Some(Arc::new(mvt));
+        self
+    }
+
+    pub fn bump_values(&self) {
+        self.vid.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn bump_structure(&self) {
+        self.sid.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+impl LinOp for MatShell<f64> {
+    type S = f64;
+
+    fn dims(&self) -> (usize, usize) { (self.m, self.n) }
+
+    fn matvec(&self, x: &[f64], y: &mut [f64]) { (self.mv)(x, y) }
+
+    fn matvec_t(&self, x: &[f64], y: &mut [f64]) {
+        if let Some(f) = &self.mvt {
+            f(x, y);
+        } else {
+            LinOp::matvec_t(self, x, y);
+        }
+    }
+
+    fn structure_id(&self) -> u64 { self.sid.load(Ordering::Relaxed) }
+    fn values_id(&self) -> u64 { self.vid.load(Ordering::Relaxed) }
+    fn as_any(&self) -> &dyn std::any::Any { self }
+}

--- a/src/matrix/sparse.rs
+++ b/src/matrix/sparse.rs
@@ -244,14 +244,7 @@ impl<T: ComplexField + Copy + num_traits::One + num_traits::Zero> SparseMatrix<T
 }
 
 // Implement MatVec trait for CsrMatrix to work with Kryst solvers
-use crate::core::traits::{MatVec, Indexing};
-
-impl<T: ComplexField + Copy + num_traits::One + num_traits::Zero + std::ops::Add<Output = T> + std::ops::Mul<Output = T> + PartialOrd> MatVec<Vec<T>> for CsrMatrix<T> {
-    fn matvec(&self, x: &Vec<T>, y: &mut Vec<T>) {
-        // Use our 4-parameter spmv_scaled method
-        let _ = self.spmv_scaled(T::one(), x.as_slice(), T::zero(), y.as_mut_slice());
-    }
-}
+use crate::core::traits::Indexing;
 
 // Implement Indexing trait for CsrMatrix to work with preconditioners
 impl<T: ComplexField + Copy + num_traits::One + num_traits::Zero> Indexing for CsrMatrix<T> {

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -41,7 +41,7 @@ impl Default for PcSide {
 }
 
 /// A preconditioner M ≈ A⁻¹.
-pub trait Preconditioner<M, V> {
+pub trait Preconditioner<M: ?Sized, V> {
     /// Build any factorization/hierarchy once from the system matrix.
     ///
     /// # Arguments
@@ -66,7 +66,7 @@ pub trait Preconditioner<M, V> {
 }
 
 /// A preconditioner whose action M⁻¹ may change at every iteration.
-pub trait FlexiblePreconditioner<M, V> {
+pub trait FlexiblePreconditioner<M: ?Sized, V> {
     /// Given the current residual `r`, produce `z ≈ Mₖ⁻¹ r`.
     fn apply(&mut self, r: &V, z: &mut V) -> Result<(), crate::error::KError>;
 }

--- a/src/solver/bicgstab.rs
+++ b/src/solver/bicgstab.rs
@@ -50,7 +50,7 @@ impl<T: num_traits::Float + From<f64> + std::ops::Mul<Output = T> + Send + Sync>
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for BiCgStabSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for BiCgStabSolver<T>
 where
     M: MatVec<V>,
     (): InnerProduct<V, Scalar = T>,

--- a/src/solver/cg.rs
+++ b/src/solver/cg.rs
@@ -111,7 +111,7 @@ impl<T: Copy + num_traits::Float + From<f64> + std::ops::Mul<Output = T>> CgSolv
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for CgSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for CgSolver<T>
 where
     M: MatVec<V>,
     (): InnerProduct<V, Scalar = T>,

--- a/src/solver/cgnr.rs
+++ b/src/solver/cgnr.rs
@@ -61,7 +61,7 @@ impl<T: num_traits::Float + From<f64>> CgneSolver<T> {
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for CgnrSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for CgnrSolver<T>
 where
     M: MatVec<V>,
     (): InnerProduct<V, Scalar = T>,

--- a/src/solver/cgs.rs
+++ b/src/solver/cgs.rs
@@ -49,7 +49,7 @@ where T: num_traits::Float + Clone + Send + Sync + std::fmt::Debug + std::fmt::L
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for CgsSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for CgsSolver<T>
 where
     M: MatVec<V>,
     (): InnerProduct<V, Scalar = T>,

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -147,7 +147,7 @@ where
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for FgmresSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for FgmresSolver<T>
 where
     M: MatVec<V>,
     (): InnerProduct<V, Scalar = T>,

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -195,7 +195,7 @@ impl<T: Copy + Float + From<f64> + std::ops::Mul<Output = T>> GmresSolver<T> {
     // --- Arnoldi process with double orthogonalization and happy breakdown ---
     /// Perform one step of the Arnoldi process (no preconditioning).
     /// Returns true if happy breakdown is detected.
-    fn arnoldi<M, V>(
+    fn arnoldi<M: ?Sized, V>(
         a: &M,
         ip: &(),
         v_basis: &mut Vec<V>,
@@ -269,7 +269,7 @@ impl<T: Copy + Float + From<f64> + std::ops::Mul<Output = T>> GmresSolver<T> {
     }
     #[allow(dead_code)]
     /// Arnoldi process with preconditioning (for advanced use)
-    fn arnoldi_with_pc<M, V>(
+    fn arnoldi_with_pc<M: ?Sized, V>(
         a: &M,
         pc: &dyn crate::preconditioner::Preconditioner<M, V>,
         ip: &(),
@@ -357,7 +357,7 @@ impl<T: Copy + Float + From<f64> + std::ops::Mul<Output = T>> GmresSolver<T> {
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for GmresSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for GmresSolver<T>
 where
     M: MatVec<V>,
     (): InnerProduct<V, Scalar = T>,

--- a/src/solver/minres.rs
+++ b/src/solver/minres.rs
@@ -73,7 +73,7 @@ impl<T: Float> MinresSolver<T> {
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for MinresSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for MinresSolver<T>
 where
     M: MatVec<V>,
     (): InnerProduct<V, Scalar = T>,

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -27,7 +27,7 @@ use crate::preconditioner::Preconditioner;
 /// * `M` - Matrix type
 /// * `V` - Vector type
 ///
-pub trait LinearSolver<M, V> {
+pub trait LinearSolver<M: ?Sized, V> {
     type Error;
     
     /// Scalar type used by the solver (e.g., f32, f64)
@@ -77,7 +77,10 @@ pub trait LinearSolver<M, V> {
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,
-    ) -> Result<SolveStats<Self::Scalar>, Self::Error> {
+    ) -> Result<SolveStats<Self::Scalar>, Self::Error>
+    where
+        Self: Sized,
+    {
         self.solve(a, pc, b, x, comm, None, None)
     }
     
@@ -90,7 +93,10 @@ pub trait LinearSolver<M, V> {
         x: &mut V,
         comm: &crate::parallel::UniverseComm,
         monitors: &[Box<dyn Fn(usize, Self::Scalar) + Send + Sync>],
-    ) -> Result<SolveStats<Self::Scalar>, Self::Error> {
+    ) -> Result<SolveStats<Self::Scalar>, Self::Error>
+    where
+        Self: Sized,
+    {
         self.solve(a, pc, b, x, comm, Some(monitors), None)
     }
     
@@ -103,7 +109,10 @@ pub trait LinearSolver<M, V> {
         x: &mut V,
         comm: &crate::parallel::UniverseComm,
         work: &mut crate::context::ksp_context::Workspace,
-    ) -> Result<SolveStats<Self::Scalar>, Self::Error> {
+    ) -> Result<SolveStats<Self::Scalar>, Self::Error>
+    where
+        Self: Sized,
+    {
         self.solve(a, pc, b, x, comm, None, Some(work))
     }
 }

--- a/src/solver/pca_gmres.rs
+++ b/src/solver/pca_gmres.rs
@@ -138,7 +138,7 @@ impl<T: num_traits::Float + Send + Sync + From<f64> + std::ops::SubAssign + std:
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for PcaGmresSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for PcaGmresSolver<T>
 where
     M: MatVec<V> + Sync,
     (): InnerProduct<V, Scalar = T>,

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -74,7 +74,7 @@ impl<T: Copy + num_traits::Float> PcgSolver<T> {
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for PcgSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for PcgSolver<T>
 where
     M: MatVec<V>,
     (): InnerProduct<V, Scalar = T>,

--- a/src/solver/qmr.rs
+++ b/src/solver/qmr.rs
@@ -74,9 +74,9 @@ impl<T: Float> QmrSolver<T> {
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for QmrSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for QmrSolver<T>
 where
-    M: 'static + MatVec<V> + MatTransVec<V> + std::fmt::Debug + Send + Sync,
+    M: 'static + MatVec<V> + MatTransVec<V> + Send + Sync,
     (): InnerProduct<V, Scalar = T>,
     V: From<Vec<T>> + AsRef<[T]> + AsMut<[T]> + Clone + Send + Sync,
     T: Float + From<f64> + std::fmt::Debug + Sum + Send + Sync + std::fmt::LowerExp,

--- a/src/solver/tfqmr.rs
+++ b/src/solver/tfqmr.rs
@@ -53,7 +53,7 @@ impl<T: Float + num_traits::FromPrimitive> TfqmrSolver<T> {
     }
 }
 
-impl<M, V, T> LinearSolver<M, V> for TfqmrSolver<T>
+impl<M: ?Sized, V, T> LinearSolver<M, V> for TfqmrSolver<T>
 where
     M: MatVec<V> + Send + Sync,
     (): InnerProduct<V, Scalar = T>,


### PR DESCRIPTION
## Summary
- introduce LinOp trait and blanket MatVec/MatTransVec implementations
- support dense, CSR, and matrix-free shell operators via adapters
- begin wiring contexts and solvers toward format-agnostic operators

## Testing
- `cargo test --no-default-features` *(fails: borrowed data escapes outside method in ksp_context.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68a57056b3808329a3f48a7673c94320