### PR TITLE
Relax lifetime ties between solvers and preconditioners

### DIFF
--- a/src/solver/bicgstab.rs
+++ b/src/solver/bicgstab.rs
@@ -78,7 +78,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/cg.rs
+++ b/src/solver/cg.rs
@@ -139,7 +139,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/cgnr.rs
+++ b/src/solver/cgnr.rs
@@ -86,7 +86,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,
@@ -286,7 +286,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/cgs.rs
+++ b/src/solver/cgs.rs
@@ -74,7 +74,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/direct_lu.rs
+++ b/src/solver/direct_lu.rs
@@ -78,7 +78,7 @@ where
     fn solve(
         &mut self,
         a: &Mat<T>,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<Mat<T>, Vec<T>>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<Mat<T>, Vec<T>> + '_)>,
         b: &Vec<T>,
         x: &mut Vec<T>,
         _comm: &crate::parallel::UniverseComm,
@@ -167,7 +167,7 @@ impl<T: ComplexField + RealField + Copy + PartialOrd + From<f64>> LinearSolver<M
     fn solve(
         &mut self,
         a: &Mat<T>,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<Mat<T>, Vec<T>>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<Mat<T>, Vec<T>> + '_)>,
         b: &Vec<T>,
         x: &mut Vec<T>,
         _comm: &crate::parallel::UniverseComm,

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -160,7 +160,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        _pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        _pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,
@@ -532,7 +532,7 @@ where
     fn cycle<M, V>(
         &mut self,
         a: &M,
-        mut pc: Option<&mut dyn FlexiblePreconditioner<M, V>>,
+        mut pc: Option<&mut (dyn FlexiblePreconditioner<M, V> + '_)>,
         b: &V,
         #[allow(unused_variables)] _x: &mut V,
         v_basis: &mut [V],

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -271,7 +271,7 @@ impl<T: Copy + Float + From<f64> + std::ops::Mul<Output = T>> GmresSolver<T> {
     /// Arnoldi process with preconditioning (for advanced use)
     fn arnoldi_with_pc<M: ?Sized, V>(
         a: &M,
-        pc: &dyn crate::preconditioner::Preconditioner<M, V>,
+        pc: &(dyn crate::preconditioner::Preconditioner<M, V> + '_),
         ip: &(),
         v_basis: &mut Vec<V>,
         h: &mut [Vec<T>],
@@ -384,7 +384,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/minres.rs
+++ b/src/solver/minres.rs
@@ -100,7 +100,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -55,7 +55,7 @@ pub trait LinearSolver<M: ?Sized, V> {
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn Preconditioner<M, V>>,
+        pc: Option<&(dyn Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,
@@ -73,7 +73,7 @@ pub trait LinearSolver<M: ?Sized, V> {
     fn solve_simple(
         &mut self,
         a: &M,
-        pc: Option<&dyn Preconditioner<M, V>>,
+        pc: Option<&(dyn Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,
@@ -88,7 +88,7 @@ pub trait LinearSolver<M: ?Sized, V> {
     fn solve_with_monitors(
         &mut self,
         a: &M,
-        pc: Option<&dyn Preconditioner<M, V>>,
+        pc: Option<&(dyn Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,
@@ -104,7 +104,7 @@ pub trait LinearSolver<M: ?Sized, V> {
     fn solve_with_workspace(
         &mut self,
         a: &M,
-        pc: Option<&dyn Preconditioner<M, V>>,
+        pc: Option<&(dyn Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/pca_gmres.rs
+++ b/src/solver/pca_gmres.rs
@@ -165,7 +165,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -104,7 +104,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/qmr.rs
+++ b/src/solver/qmr.rs
@@ -104,7 +104,7 @@ where
     fn solve(
         &mut self,
         a: &M,
-        _pc: Option<&dyn crate::preconditioner::Preconditioner<M, V>>,
+        _pc: Option<&(dyn crate::preconditioner::Preconditioner<M, V> + '_)>,
         b: &V,
         x: &mut V,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/superlu_dist.rs
+++ b/src/solver/superlu_dist.rs
@@ -3897,7 +3897,7 @@ impl LinearSolver<CsrMatrix<f64>, Vec<f64>> for SuperLuDistSolver {
     fn solve(
         &mut self,
         a: &CsrMatrix<f64>,
-        pc: Option<&dyn crate::preconditioner::Preconditioner<CsrMatrix<f64>, Vec<f64>>>,
+        pc: Option<&(dyn crate::preconditioner::Preconditioner<CsrMatrix<f64>, Vec<f64>> + '_)>,
         b: &Vec<f64>,
         x: &mut Vec<f64>,
         comm: &crate::parallel::UniverseComm,

--- a/src/solver/tfqmr.rs
+++ b/src/solver/tfqmr.rs
@@ -79,7 +79,7 @@ where
     /// * `Err(KError)` on error
     fn solve(&mut self,
              a: &M,
-             _pc: Option<&dyn Preconditioner<M, V>>,
+            _pc: Option<&(dyn Preconditioner<M, V> + '_)>,
              b: &V,
              x: &mut V,
              comm: &crate::parallel::UniverseComm,


### PR DESCRIPTION
## Summary
- allow solver trait methods to accept preconditioners with late-bound lifetimes
- update all solver implementations to match the relaxed signature

## Testing
- `cargo test --no-default-features` *(fails: borrowed data escapes outside of method)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a54d06808329b9de89057092fceb