### PR TITLE
feat: adapt legacy preconditioners

### DIFF
--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -1,6 +1,18 @@
 use crate::config::options::PcOptions;
 use crate::error::KError;
-use crate::preconditioner::{Preconditioner, PreconditionerMat, PcSide, jacobi::Jacobi};
+use crate::preconditioner::{
+    Preconditioner,
+    PreconditionerMat,
+    PcSide,
+    jacobi::Jacobi,
+    LegacyOpPreconditioner,
+    Ilut,
+    Ilutp,
+    Ilup,
+    Sor,
+    MatSorType,
+    ChebyshevPre,
+};
 use crate::matrix::op::LinOp;
 use faer::Mat;
 
@@ -76,6 +88,26 @@ impl PcFactory {
     ) -> Result<Box<dyn Preconditioner>, KError> {
         match pc_type {
             PcType::Jacobi => Ok(Box::new(MatOpPreconditioner::new(Box::new(Jacobi::new())))),
+            PcType::Ilut => {
+                let ilut = Ilut::new(0, 0.0);
+                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilut))))
+            }
+            PcType::Ilutp => {
+                let ilutp = Ilutp::new();
+                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilutp))))
+            }
+            PcType::Ilup => {
+                let ilup = Ilup::new(0);
+                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilup))))
+            }
+            PcType::Sor => {
+                let sor = Sor::<Mat<f64>, Vec<f64>, f64>::new(1.0, 1, 0, MatSorType::APPLY_LOWER, 0.0);
+                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(sor))))
+            }
+            PcType::Chebyshev => {
+                let pre = ChebyshevPre::new(Mat::zeros(0, 0), 0, 1.0, 1.0);
+                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(pre))))
+            }
             PcType::None => Ok(Box::new(NoOpPreconditioner)),
             _ => Err(KError::UnrecognizedPcType(format!("{:?} not implemented", pc_type))),
         }

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -5,6 +5,7 @@
 use crate::error::KError;
 use faer::Mat;
 use std::str::FromStr;
+use crate::matrix::op::LinOp;
 
 /// Which side to apply M⁻¹ on in preconditioning.
 ///
@@ -77,6 +78,38 @@ pub mod legacy {
     pub trait FlexiblePreconditioner<M: ?Sized, V> {
         fn setup(&mut self, a: &M) -> Result<(), KError>;
         fn apply(&mut self, r: &V, z: &mut V) -> Result<(), KError>;
+    }
+}
+
+/// Adapter that wraps a legacy matrix-based preconditioner and exposes the new
+/// object-safe [`Preconditioner`] interface.
+pub struct LegacyOpPreconditioner {
+    /// Inner legacy preconditioner operating on dense matrices and vectors.
+    inner: Box<dyn legacy::Preconditioner<Mat<f64>, Vec<f64>> + Send + Sync>,
+}
+
+impl LegacyOpPreconditioner {
+    /// Create a new adapter from a boxed legacy preconditioner.
+    pub fn new(inner: Box<dyn legacy::Preconditioner<Mat<f64>, Vec<f64>> + Send + Sync>) -> Self {
+        Self { inner }
+    }
+}
+
+impl Preconditioner for LegacyOpPreconditioner {
+    fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        let m = a
+            .as_any()
+            .downcast_ref::<Mat<f64>>()
+            .ok_or_else(|| KError::InvalidInput("expected faer::Mat<f64>".into()))?;
+        self.inner.setup(m)
+    }
+
+    fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        let x_vec = x.to_vec();
+        let mut y_vec = vec![0.0; y.len()];
+        self.inner.apply(side, &x_vec, &mut y_vec)?;
+        y.copy_from_slice(&y_vec);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- add adapter bridging legacy matrix preconditioners to new object-safe trait
- allow factory to construct Ilut, Ilutp, Ilup, Sor, and Chebyshev preconditioners via the new interface

## Testing
- `cargo test --lib`


------
https://chatgpt.com/codex/tasks/task_e_68a7c695dc00832988e83e1e07eb5f2f