### PR TITLE
Add monitor API and update integration tests

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -50,6 +50,7 @@ pub struct KspContext {
     pmat: Option<Arc<dyn LinOp<S = f64>>>,
     work: Option<Workspace>,
     setup_called: bool,
+    monitors: Vec<Box<dyn Fn(usize, f64) + Send + Sync>>,
     pub rtol: f64,
     pub atol: f64,
     pub dtol: f64,
@@ -67,6 +68,7 @@ impl KspContext {
             pmat: None,
             work: None,
             setup_called: false,
+            monitors: Vec::new(),
             rtol: 1e-6,
             atol: 1e-12,
             dtol: 1e3,
@@ -163,18 +165,75 @@ impl KspContext {
             .solver
             .as_mut()
             .ok_or_else(|| KError::SolveError("No solver".into()))?;
+        let monitors = if self.monitors.is_empty() {
+            None
+        } else {
+            Some(self.monitors.as_slice())
+        };
         solver.solve(
             amat.as_ref(),
             self.pc.as_deref(),
             b,
             x,
             &UniverseComm::NoComm(crate::parallel::NoComm),
-            None,
+            monitors,
             self.work.as_mut(),
         )
     }
 
     fn invalidate_setup(&mut self) {
         self.setup_called = false;
+    }
+
+    /// Add an iteration monitor callback.
+    pub fn add_monitor<F>(&mut self, f: F)
+    where
+        F: Fn(usize, f64) + Send + Sync + 'static,
+    {
+        self.monitors.push(Box::new(f));
+    }
+
+    /// Return the number of registered monitors.
+    pub fn num_monitors(&self) -> usize {
+        self.monitors.len()
+    }
+
+    /// Clear all registered monitors.
+    pub fn clear_monitors(&mut self) {
+        self.monitors.clear();
+    }
+
+    /// Invoke all monitors with the provided iteration and residual.
+    pub fn invoke_monitors(&self, iter: usize, residual: f64) {
+        for m in &self.monitors {
+            m(iter, residual);
+        }
+    }
+
+    /// Set solver tolerances and maximum iterations.
+    pub fn set_tolerances(
+        &mut self,
+        rtol: f64,
+        atol: f64,
+        dtol: f64,
+        maxits: usize,
+    ) -> &mut Self {
+        self.rtol = rtol;
+        self.atol = atol;
+        self.dtol = dtol;
+        self.maxits = maxits;
+        self.invalidate_setup();
+        self
+    }
+
+    /// Query whether setup has been performed.
+    pub fn is_setup(&self) -> bool {
+        self.setup_called
+    }
+
+    /// Set the GMRES restart parameter.
+    pub fn set_restart(&mut self, restart: usize) {
+        self.restart = restart;
+        self.invalidate_setup();
     }
 }

--- a/tests/monitor_integration.rs
+++ b/tests/monitor_integration.rs
@@ -65,7 +65,7 @@ fn test_monitor_with_solver() -> Result<(), KError> {
     // Track residuals seen by monitor
     let residuals = Arc::new(Mutex::new(Vec::new()));
     let residuals_clone = Arc::clone(&residuals);
-    
+
     let mut ksp = KspContext::new();
     
     // Register a monitor to collect residuals
@@ -74,10 +74,14 @@ fn test_monitor_with_solver() -> Result<(), KError> {
         res_vec.push((iter, residual));
     });
     
-    ksp.set_type(SolverType::Preonly)?
-        .set_pc_type(PcType::Lu)?;
-    
-    let _stats = ksp.solve(&a, &b, &mut x)?;
+    ksp.set_type(SolverType::Cg)?
+        .set_pc_type(PcType::None, None)?;
+
+    use kryst::matrix::op::LinOp;
+    let amat: Arc<dyn LinOp<S = f64>> = Arc::new(a);
+    ksp.set_operators(amat, None);
+
+    let _stats = ksp.solve(&b, &mut x)?;
     
     // For PREONLY, monitors might not be called since it's a direct solver
     // This is expected behavior

--- a/tests/preconditioner_integration.rs
+++ b/tests/preconditioner_integration.rs
@@ -5,8 +5,10 @@
 //! solution accuracy, and correct preconditioner application. These tests ensure that the
 //! preconditioner and solver interfaces are compatible and robust for a variety of matrix types.
 
-use kryst::preconditioner::{Preconditioner, Jacobi, Ilu0};
-use kryst::solver::{PcgSolver, GmresSolver, LinearSolver};
+use kryst::preconditioner::{Jacobi, Ilu0, PcSide};
+use kryst::preconditioner::legacy::Preconditioner;
+use kryst::solver::{CgSolver, GmresSolver};
+use kryst::solver::legacy::LinearSolver;
 use kryst::solver::gmres::Preconditioning;
 use faer::Mat;
 
@@ -83,13 +85,13 @@ fn cg_with_jacobi() {
     let comm = kryst::parallel::UniverseComm::NoComm(kryst::parallel::NoComm);
     let (a, b) = ill_cond(5, 1e6);
     let mut pc = Jacobi::new();
-    <Jacobi<f64> as Preconditioner<Mat<f64>, Vec<f64>>>::setup(&mut pc, &a).unwrap();
-    let mut solver = PcgSolver::new(1e-6, 1000);
+    pc.setup(&a).unwrap();
+    let mut solver = CgSolver::new(1e-6, 1000);
     let mut x = vec![0.0; 5];
     // wrap A and pc into a PCG solver if you have one, else manually:
     let r_in = b.clone();
     let mut r_out = vec![0.0; b.len()];
-    <Jacobi<f64> as Preconditioner<Mat<f64>, Vec<f64>>>::apply(&pc, kryst::preconditioner::PcSide::Left, &r_in, &mut r_out).unwrap();
+    pc.apply(PcSide::Left, &r_in, &mut r_out).unwrap();
     let stats = solver.solve(&a, None, &b, &mut x, &comm, None, None).unwrap();
     assert!(matches!(stats.reason, kryst::utils::convergence::ConvergedReason::ConvergedRtol | kryst::utils::convergence::ConvergedReason::ConvergedAtol));
     // No stats to check; just ensure it runs without panic
@@ -102,7 +104,7 @@ fn gmres_with_ilu0() {
     let comm = kryst::parallel::UniverseComm::NoComm(kryst::parallel::NoComm);
     let (a, b) = ill_cond(5, 1e4);
     let mut pc = Ilu0::new();
-    <Ilu0<f64> as Preconditioner<Mat<f64>, Vec<f64>>>::setup(&mut pc, &a).unwrap();
+    pc.setup(&a).unwrap();
     let mut solver = GmresSolver::new(4, 1e-6, 1000);
     let mut x = vec![0.0; 5];
     let stats = solver.solve(&a, None, &b, &mut x, &comm, None, None).unwrap();
@@ -117,8 +119,8 @@ fn pcg_with_jacobi() {
     let comm = kryst::parallel::UniverseComm::NoComm(kryst::parallel::NoComm);
     let (a, b) = ill_cond(5, 1e6);
     let mut pc = Jacobi::new();
-    <Jacobi<f64> as Preconditioner<Mat<f64>, Vec<f64>>>::setup(&mut pc, &a).unwrap();
-    let mut solver = kryst::solver::PcgSolver::new(1e-6, 1000);
+    pc.setup(&a).unwrap();
+    let mut solver = CgSolver::new(1e-6, 1000);
     let mut x = vec![0.0; 5];
     let stats = solver.solve(&a, Some(&pc), &b, &mut x, &comm, None, None).unwrap();
     assert!(matches!(stats.reason, kryst::utils::convergence::ConvergedReason::ConvergedRtol | kryst::utils::convergence::ConvergedReason::ConvergedAtol));
@@ -133,7 +135,7 @@ fn spd_jacobi_pcg_converges() {
     let (a, b, x_true) = spd_matrix(n);
     let mut pc = Jacobi::new();
     pc.setup(&a).unwrap();
-    let mut solver = PcgSolver::new(1e-12, n);
+    let mut solver = CgSolver::new(1e-12, n);
     let mut x = vec![0.0; n];
     let stats = solver.solve(&a, Some(&pc), &b, &mut x, &comm, None, None).unwrap();
     assert!(matches!(stats.reason, kryst::utils::convergence::ConvergedReason::ConvergedRtol | kryst::utils::convergence::ConvergedReason::ConvergedAtol));
@@ -148,7 +150,7 @@ fn spd_no_pc_cg_converges() {
     let comm = kryst::parallel::UniverseComm::NoComm(kryst::parallel::NoComm);
     let n = 10;
     let (a, b, x_true) = spd_matrix(n);
-    let mut solver = PcgSolver::new(1e-12, n);
+    let mut solver = CgSolver::new(1e-12, n);
     let mut x = vec![0.0; n];
     let stats = solver.solve(&a, None, &b, &mut x, &comm, None, None).unwrap();
     assert!(matches!(stats.reason, kryst::utils::convergence::ConvergedReason::ConvergedRtol | kryst::utils::convergence::ConvergedReason::ConvergedAtol));


### PR DESCRIPTION
## Summary
- add basic monitor management and solver tolerance helpers to `KspContext`
- update monitor and preconditioner integration tests to the current API

## Testing
- `cargo test --test monitor_integration -- --nocapture`
- `cargo test --test preconditioner_integration -- --nocapture`


------
https://chatgpt.com/codex/tasks/task_e_68a7e3e686088329ba6dd3ebfe56c348