### PR TITLE
Integrate runtime KSP/PC options into new API

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -1,12 +1,13 @@
-use crate::config::options::PcOptions;
+use crate::config::options::{KspOptions, PcOptions};
 use crate::context::pc_context::{PcFactory, PcType};
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::parallel::UniverseComm;
 use crate::preconditioner::{PcSide, Preconditioner};
-use crate::solver::{CgSolver, GmresSolver, LinearSolver, MatSolverAdapter};
+use crate::solver::{BiCgStabSolver, CgSolver, GmresSolver, LinearSolver, MatSolverAdapter};
 use crate::utils::convergence::SolveStats;
 use std::sync::Arc;
+use std::str::FromStr;
 
 /// Workspace placeholder reused by solvers.
 #[derive(Debug)]
@@ -39,7 +40,22 @@ impl Workspace {
 pub enum SolverType {
     Cg,
     Gmres,
+    BiCgStab,
     Preonly,
+}
+
+impl FromStr for SolverType {
+    type Err = KError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "cg" => Ok(SolverType::Cg),
+            "gmres" => Ok(SolverType::Gmres),
+            "bicgstab" => Ok(SolverType::BiCgStab),
+            "preonly" => Ok(SolverType::Preonly),
+            other => Err(KError::UnrecognizedSolverType(other.to_string())),
+        }
+    }
 }
 
 /// Minimal KSP context holding solver, preconditioner, and operators.
@@ -88,6 +104,9 @@ impl KspContext {
                 self.rtol,
                 self.maxits,
             ))),
+            SolverType::BiCgStab => {
+                Box::new(MatSolverAdapter::new(BiCgStabSolver::new(self.rtol, self.maxits)))
+            }
             SolverType::Preonly => {
                 return Err(KError::SolveError("Preonly solver not available".into()))
             }
@@ -104,6 +123,51 @@ impl KspContext {
     ) -> Result<&mut Self, KError> {
         self.pc = Some(PcFactory::create_preconditioner(pc_type, opts)?);
         self.invalidate_setup();
+        Ok(self)
+    }
+
+    /// Configure the KSP context using parsed KSP options.
+    pub fn set_from_options(&mut self, opts: &KspOptions) -> Result<&mut Self, KError> {
+        if let Some(ref t) = opts.ksp_type {
+            let st = SolverType::from_str(t)?;
+            self.set_type(st)?;
+        }
+        if let Some(rtol) = opts.rtol {
+            self.rtol = rtol;
+        }
+        if let Some(atol) = opts.atol {
+            self.atol = atol;
+        }
+        if let Some(dtol) = opts.dtol {
+            self.dtol = dtol;
+        }
+        if let Some(maxits) = opts.maxits {
+            self.maxits = maxits;
+        }
+        if let Some(restart) = opts.restart {
+            self.restart = restart;
+        }
+        if let Some(ref side) = opts.pc_side {
+            self.pc_side = PcSide::from_str(side)?;
+        }
+        self.invalidate_setup();
+        Ok(self)
+    }
+
+    /// Configure both KSP and PC from their respective option sets.
+    pub fn set_from_all_options(
+        &mut self,
+        ksp_opts: &KspOptions,
+        pc_opts: &PcOptions,
+    ) -> Result<&mut Self, KError> {
+        self.set_from_options(ksp_opts)?;
+        if let Some(ref pct) = pc_opts.pc_type {
+            let pct = PcType::from_str(pct)?;
+            self.set_pc_type(pct, Some(pc_opts))?;
+        }
+        if let Some(ref side) = ksp_opts.pc_side {
+            self.pc_side = PcSide::from_str(side)?;
+        }
         Ok(self)
     }
 

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -15,6 +15,7 @@ use crate::preconditioner::{
 };
 use crate::matrix::op::LinOp;
 use faer::Mat;
+use std::str::FromStr;
 
 /// Supported preconditioner types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -35,6 +36,32 @@ pub enum PcType {
     Lu,
     Qr,
     SuperLuDist,
+}
+
+impl FromStr for PcType {
+    type Err = KError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_lowercase().as_str() {
+            "jacobi" => Ok(PcType::Jacobi),
+            "ilu0" => Ok(PcType::Ilu0),
+            "none" => Ok(PcType::None),
+            "ilu" => Ok(PcType::Ilu),
+            "ilut" => Ok(PcType::Ilut),
+            "ilutp" => Ok(PcType::Ilutp),
+            "ilup" => Ok(PcType::Ilup),
+            "block_jacobi" => Ok(PcType::BlockJacobi),
+            "sor" => Ok(PcType::Sor),
+            "asm" => Ok(PcType::Asm),
+            "chebyshev" => Ok(PcType::Chebyshev),
+            "amg" => Ok(PcType::Amg),
+            "approxinv" | "approxinverse" => Ok(PcType::ApproxInverse),
+            "lu" => Ok(PcType::Lu),
+            "qr" => Ok(PcType::Qr),
+            "superludist" => Ok(PcType::SuperLuDist),
+            other => Err(KError::UnrecognizedPcType(other.to_string())),
+        }
+    }
 }
 
 /// Placeholder for deferred preconditioner construction info.

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -162,6 +162,8 @@ pub use cg::CgSolver;
 
 pub mod gmres;
 pub use gmres::GmresSolver;
+pub mod bicgstab;
+pub use bicgstab::BiCgStabSolver;
 pub mod direct_lu;
 pub use direct_lu::{LuSolver, QrSolver};
 


### PR DESCRIPTION
## Summary
- add `set_from_options` and `set_from_all_options` to `KspContext`
- implement case-insensitive parsing for solver and preconditioner types
- expose BiCGStab solver in API

## Testing
- `cargo test` *(fails: method argument mismatch and missing APIs in existing tests)*

------
https://chatgpt.com/codex/tasks/task_e_68a7ed8bae5883298726ffc052a38ede