### PR TITLE
Add operator change tracking and preconditioner reuse

### DIFF
--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -106,6 +106,7 @@ pub struct PcOptions {
     pub superlu_workspace_memory_limit: Option<usize>,
     pub superlu_aggressive_memory_reuse: Option<bool>,
     pub superlu_preallocation_strategy: Option<String>,
+    pub reuse_policy: Option<String>,
 }
 
 /// Side enum kept as-is.
@@ -248,6 +249,7 @@ impl Sink for PcOptions {
             "pc_superlu_max_concurrent_panels" => set_opt!(&mut self.superlu_max_concurrent_panels, parse_as::<usize>(v, spec)?),
             "pc_superlu_workspace_memory_limit" => set_opt!(&mut self.superlu_workspace_memory_limit, parse_as::<usize>(v, spec)?),
             "pc_superlu_preallocation_strategy" => set_opt!(&mut self.superlu_preallocation_strategy, v.to_lowercase()),
+            "pc_reuse_policy" => set_opt!(&mut self.reuse_policy, v.to_string()),
             "options_file" => Ok(()), // consumed earlier
             _ => Err(KError::SolveError(format!("Unknown PC key: {}", spec.key))),
         }

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -58,6 +58,7 @@ pub static SPECS: &[Spec] = &[
     Spec { flag: "-pc_amg_ieee_checks",      key: "pc_amg_ieee_checks",      arity: Arity::Zero, kind: ValueKind::Bool, doc: "enable IEEE checks" },
     Spec { flag: "-pc_amg_optimize_workspace", key: "pc_amg_optimize_workspace", arity: Arity::Zero, kind: ValueKind::Bool, doc: "optimize workspace" },
     Spec { flag: "-pc_chain",                key: "pc_chain",                arity: Arity::One, kind: ValueKind::Str,   doc: "comma-separated chain" },
+    Spec { flag: "-pc_reuse_policy",        key: "pc_reuse_policy",        arity: Arity::One, kind: ValueKind::Str,   doc: "never|reuse_numeric|auto" },
 
     // ILU block
     Spec { flag: "-pc_ilu_type",             key: "pc_ilu_type",             arity: Arity::One, kind: ValueKind::Str,   doc: "ilu0|iluk|ilut|..." },

--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -1,9 +1,9 @@
 use crate::config::options::{KspOptions, PcOptions};
 use crate::context::pc_context::{PcFactory, PcType};
 use crate::error::KError;
-use crate::matrix::op::LinOp;
+use crate::matrix::op::{LinOp, StructureId, ValuesId};
 use crate::parallel::UniverseComm;
-use crate::preconditioner::{PcSide, Preconditioner};
+use crate::preconditioner::{PcSide, Preconditioner, PcReusePolicy};
 use crate::solver::{BiCgStabSolver, CgSolver, GmresSolver, LinearSolver, MatSolverAdapter};
 use crate::utils::convergence::SolveStats;
 use std::sync::Arc;
@@ -73,6 +73,9 @@ pub struct KspContext {
     pub maxits: usize,
     pub restart: usize,
     pub pc_side: PcSide,
+    pc_reuse: PcReusePolicy,
+    last_pc_sid: Option<StructureId>,
+    last_pc_vid: Option<ValuesId>,
 }
 
 impl KspContext {
@@ -91,6 +94,9 @@ impl KspContext {
             maxits: 1000,
             restart: 30,
             pc_side: PcSide::Left,
+            pc_reuse: PcReusePolicy::Auto,
+            last_pc_sid: None,
+            last_pc_vid: None,
         }
     }
 
@@ -165,6 +171,14 @@ impl KspContext {
             let pct = PcType::from_str(pct)?;
             self.set_pc_type(pct, Some(pc_opts))?;
         }
+        if let Some(ref pol) = pc_opts.reuse_policy {
+            let pol = match pol.as_str() {
+                "never" => PcReusePolicy::Never,
+                "reuse_numeric" => PcReusePolicy::ReuseNumeric,
+                _ => PcReusePolicy::Auto,
+            };
+            self.set_pc_reuse_policy(pol);
+        }
         if let Some(ref side) = ksp_opts.pc_side {
             self.pc_side = PcSide::from_str(side)?;
         }
@@ -183,19 +197,71 @@ impl KspContext {
         self
     }
 
+    pub fn set_pc_reuse_policy(&mut self, policy: PcReusePolicy) -> &mut Self {
+        self.pc_reuse = policy;
+        self
+    }
+
+    fn reset_pc_ids(&mut self) {
+        self.last_pc_sid = None;
+        self.last_pc_vid = None;
+    }
+
+    pub fn last_pc_sid(&self) -> Option<StructureId> { self.last_pc_sid }
+    pub fn last_pc_vid(&self) -> Option<ValuesId> { self.last_pc_vid }
+
     /// Prepare preconditioner and workspace.
     pub fn setup(&mut self) -> Result<(), KError> {
-        let amat = self
-            .amat
-            .as_ref()
-            .ok_or_else(|| KError::InvalidInput("Amat not set".into()))?;
         let pmat = self
             .pmat
             .as_ref()
             .ok_or_else(|| KError::InvalidInput("Pmat not set".into()))?;
+        let amat = self
+            .amat
+            .as_ref()
+            .ok_or_else(|| KError::InvalidInput("Amat not set".into()))?;
+
+        let sid = {
+            let id = pmat.structure_id();
+            if id.0 != 0 {
+                id
+            } else {
+                StructureId(Arc::as_ptr(pmat) as *const () as usize as u64)
+            }
+        };
+        let vid = pmat.values_id();
+
+        if self.pc.is_none() {
+            // no factory hook here; assume pc set elsewhere
+            self.last_pc_sid = None;
+            self.last_pc_vid = None;
+        }
 
         if let Some(pc) = self.pc.as_mut() {
-            pc.setup(pmat.as_ref())?;
+            match self.last_pc_sid {
+                None => {
+                    pc.setup(pmat.as_ref())?;
+                    self.last_pc_sid = Some(sid);
+                    self.last_pc_vid = Some(vid);
+                }
+                Some(old_sid) if old_sid != sid => {
+                    pc.setup(pmat.as_ref())?;
+                    self.last_pc_sid = Some(sid);
+                    self.last_pc_vid = Some(vid);
+                }
+                Some(_old_sid) => {
+                    if self.last_pc_vid != Some(vid)
+                        && self.pc_reuse.allow_numeric()
+                        && pc.supports_numeric_update()
+                    {
+                        pc.update_values(pmat.as_ref())?;
+                        self.last_pc_vid = Some(vid);
+                    } else if self.last_pc_vid != Some(vid) {
+                        pc.setup(pmat.as_ref())?;
+                        self.last_pc_vid = Some(vid);
+                    }
+                }
+            }
         }
 
         let (m, _) = amat.dims();
@@ -247,6 +313,7 @@ impl KspContext {
 
     fn invalidate_setup(&mut self) {
         self.setup_called = false;
+        self.reset_pc_ids();
     }
 
     /// Add an iteration monitor callback.

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -114,7 +114,7 @@ impl PcFactory {
         _options: Option<&PcOptions>,
     ) -> Result<Box<dyn Preconditioner>, KError> {
         match pc_type {
-            PcType::Jacobi => Ok(Box::new(MatOpPreconditioner::new(Box::new(Jacobi::new())))),
+            PcType::Jacobi => Ok(Box::new(Jacobi::new())),
             PcType::Ilut => {
                 let ilut = Ilut::new(0, 0.0);
                 Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilut))))

--- a/src/matrix/format_impls.rs
+++ b/src/matrix/format_impls.rs
@@ -21,7 +21,7 @@ impl AsFormat for CsrMatrix<f64> {
 impl AsFormat for Mat<f64> {
     fn to_csr_cached(&self, drop_tol: f64) -> Arc<CsrMatrix<f64>> {
         let base_ptr = self as *const Mat<f64> as usize;
-        let structure_id = LinOp::structure_id(self);
+        let structure_id = LinOp::structure_id(self).0;
         let key = key_from_ptr(base_ptr, structure_id, drop_tol);
         if let Some(existing) = {
             let cache = CSR_CACHE.lock().unwrap();

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -10,6 +10,6 @@ pub mod format;
 mod format_impls;
 pub mod convert;
 
-pub use op::LinOp;
+pub use op::{LinOp, StructureId, ValuesId, ChangeIds, DenseOp, CsrOp};
 pub use op_shell::MatShell;
 pub use convert::{try_as_csr, to_csr_cached};

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -1,9 +1,15 @@
-use std::{any::Any, hash::{Hash, Hasher}};
+use std::any::Any;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 use faer::traits::ComplexField;
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct StructureId(pub u64);
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ValuesId(pub u64);
+
 /// Format-agnostic linear operator.
-pub trait LinOp: Send + Sync {
-    /// Scalar type.
+pub trait LinOp: Send + Sync + Any {
     type S: ComplexField;
 
     /// Dimensions (rows, cols).
@@ -17,21 +23,100 @@ pub trait LinOp: Send + Sync {
         unimplemented!("transpose/adjoint not provided for this operator");
     }
 
-    /// Lightweight identifiers for structure/value changes.
-    fn structure_id(&self) -> u64 { 0 }
-    fn values_id(&self) -> u64 { 0 }
-
     /// Downcast hook for specialized solvers/preconditioners.
     fn as_any(&self) -> &dyn Any;
+
+    /// Changes when the nonzero pattern / shape changes.
+    /// Default 0 -> unknown; higher layers may fall back to pointer identity.
+    fn structure_id(&self) -> StructureId { StructureId(0) }
+
+    /// Changes when only numerical values change.
+    /// Default 0 -> unknown.
+    fn values_id(&self) -> ValuesId { ValuesId(0) }
 }
 
-// --- Dense adapter -------------------------------------------------------
+/// Simple bumpable counters for LinOp implementors/wrappers.
+#[derive(Default)]
+pub struct ChangeIds {
+    pub sid: AtomicU64,
+    pub vid: AtomicU64,
+}
+impl ChangeIds {
+    pub fn structure_id(&self) -> StructureId {
+        StructureId(self.sid.load(Ordering::Relaxed))
+    }
+    pub fn values_id(&self) -> ValuesId {
+        ValuesId(self.vid.load(Ordering::Relaxed))
+    }
+    pub fn bump_structure(&self) {
+        self.sid.fetch_add(1, Ordering::Relaxed);
+    }
+    pub fn bump_values(&self) {
+        self.vid.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+// --- Optional wrappers for dense and CSR matrices -------------------------
 use faer::Mat;
+use crate::matrix::sparse::CsrMatrix;
+
+pub struct DenseOp {
+    mat: Arc<Mat<f64>>,
+    ids: ChangeIds,
+}
+impl DenseOp {
+    pub fn new(mat: Arc<Mat<f64>>) -> Self {
+        let ids = ChangeIds::default();
+        ids.bump_structure();
+        ids.bump_values();
+        Self { mat, ids }
+    }
+    pub fn mark_structure_changed(&self) { self.ids.bump_structure(); }
+    pub fn mark_values_changed(&self) { self.ids.bump_values(); }
+    pub fn inner(&self) -> &Mat<f64> { &self.mat }
+}
+impl LinOp for DenseOp {
+    type S = f64;
+    fn dims(&self) -> (usize, usize) { (self.mat.nrows(), self.mat.ncols()) }
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        let _ = crate::matrix::utils::parallel_mat_vec(&self.mat, x, y);
+    }
+    fn as_any(&self) -> &dyn Any { &*self.mat }
+    fn structure_id(&self) -> StructureId { self.ids.structure_id() }
+    fn values_id(&self) -> ValuesId { self.ids.values_id() }
+}
+
+pub struct CsrOp {
+    csr: Arc<CsrMatrix<f64>>,
+    ids: ChangeIds,
+}
+impl CsrOp {
+    pub fn new(csr: Arc<CsrMatrix<f64>>) -> Self {
+        let ids = ChangeIds::default();
+        ids.bump_structure();
+        ids.bump_values();
+        Self { csr, ids }
+    }
+    pub fn mark_structure_changed(&self) { self.ids.bump_structure(); }
+    pub fn mark_values_changed(&self) { self.ids.bump_values(); }
+    pub fn inner(&self) -> &CsrMatrix<f64> { &self.csr }
+}
+impl LinOp for CsrOp {
+    type S = f64;
+    fn dims(&self) -> (usize, usize) { (self.csr.nrows(), self.csr.ncols()) }
+    fn matvec(&self, x: &[f64], y: &mut [f64]) { self.csr.spmv(x, y); }
+    fn as_any(&self) -> &dyn Any { &*self.csr }
+    fn structure_id(&self) -> StructureId { self.ids.structure_id() }
+    fn values_id(&self) -> ValuesId { self.ids.values_id() }
+}
+
+// --- Direct adapters ------------------------------------------------------
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+
 impl LinOp for Mat<f64> {
     type S = f64;
-
     fn dims(&self) -> (usize, usize) { (self.nrows(), self.ncols()) }
-
     fn matvec(&self, x: &[f64], y: &mut [f64]) {
         assert_eq!(x.len(), self.ncols());
         assert_eq!(y.len(), self.nrows());
@@ -43,32 +128,39 @@ impl LinOp for Mat<f64> {
             y[i] = sum;
         }
     }
-
-    fn structure_id(&self) -> u64 {
-        let mut h = std::collections::hash_map::DefaultHasher::new();
+    fn matvec_t(&self, x: &[f64], y: &mut [f64]) {
+        // simple dense transpose matvec
+        assert_eq!(x.len(), self.nrows());
+        assert_eq!(y.len(), self.ncols());
+        for j in 0..self.ncols() {
+            let mut sum = 0.0;
+            for i in 0..self.nrows() {
+                sum += self[(i, j)] * x[i];
+            }
+            y[j] = sum;
+        }
+    }
+    fn as_any(&self) -> &dyn Any { self }
+    fn structure_id(&self) -> StructureId {
+        let mut h = DefaultHasher::new();
         self.nrows().hash(&mut h);
         self.ncols().hash(&mut h);
-        h.finish()
+        StructureId(h.finish())
     }
-
-    fn as_any(&self) -> &dyn Any { self }
+    fn values_id(&self) -> ValuesId { ValuesId(0) }
 }
 
-// --- CSR adapter ---------------------------------------------------------
-use crate::matrix::sparse::{CsrMatrix, SparseMatrix};
+use crate::matrix::sparse::SparseMatrix;
 impl LinOp for CsrMatrix<f64> {
     type S = f64;
-
     fn dims(&self) -> (usize, usize) { (self.nrows(), self.ncols()) }
-
     fn matvec(&self, x: &[f64], y: &mut [f64]) { self.spmv(x, y); }
-
-    fn structure_id(&self) -> u64 {
-        let mut h = std::collections::hash_map::DefaultHasher::new();
+    fn as_any(&self) -> &dyn Any { self }
+    fn structure_id(&self) -> StructureId {
+        let mut h = DefaultHasher::new();
         self.row_ptr().hash(&mut h);
         self.col_idx().hash(&mut h);
-        h.finish()
+        StructureId(h.finish())
     }
-
-    fn as_any(&self) -> &dyn Any { self }
+    fn values_id(&self) -> ValuesId { ValuesId(0) }
 }

--- a/src/matrix/op_shell.rs
+++ b/src/matrix/op_shell.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::op::LinOp;
+use super::op::{LinOp, StructureId, ValuesId};
 
 /// Matrix-free "shell" operator.
 pub struct MatShell<S> {
@@ -61,7 +61,7 @@ impl LinOp for MatShell<f64> {
         }
     }
 
-    fn structure_id(&self) -> u64 { self.sid.load(Ordering::Relaxed) }
-    fn values_id(&self) -> u64 { self.vid.load(Ordering::Relaxed) }
+    fn structure_id(&self) -> StructureId { StructureId(self.sid.load(Ordering::Relaxed)) }
+    fn values_id(&self) -> ValuesId { ValuesId(self.vid.load(Ordering::Relaxed)) }
     fn as_any(&self) -> &dyn std::any::Any { self }
 }

--- a/src/matrix/sparse.rs
+++ b/src/matrix/sparse.rs
@@ -185,6 +185,12 @@ impl<
     pub fn values(&self) -> &[T] {
         self.inner.val()
     }
+
+    /// Mutably borrow the CSR value array (length = nnz).
+    #[inline]
+    pub fn values_mut(&mut self) -> &mut [T] {
+        self.inner.val_mut()
+    }
 }
 
 impl<T: ComplexField + Copy + num_traits::One + num_traits::Zero> SparseMatrix<T> for CsrMatrix<T> {

--- a/src/preconditioner/jacobi.rs
+++ b/src/preconditioner/jacobi.rs
@@ -1,57 +1,71 @@
-//! Jacobi preconditioner implementation.
-//!
-//! This monomorphic version operates on `f64` values and dense [`faer::Mat`] matrices.
-
 use crate::error::KError;
-use crate::preconditioner::{PcSide, PreconditionerMat};
+use crate::matrix::op::LinOp;
+use crate::matrix::sparse::CsrMatrix;
+use crate::preconditioner::{Preconditioner, PcSide};
 use faer::Mat;
 
-/// Jacobi preconditioner: stores the inverse of the diagonal of the matrix.
 pub struct Jacobi {
-    /// Inverse diagonal entries.
     pub(crate) diag_inv: Vec<f64>,
+    n: usize,
 }
-
 impl Jacobi {
-    /// Create an empty Jacobi preconditioner. Call [`setup_mat`] before use.
-    pub fn new() -> Self {
-        Self { diag_inv: Vec::new() }
-    }
+    pub fn new() -> Self { Self { diag_inv: Vec::new(), n: 0 } }
 
-    fn build_from_dense(&mut self, a: &Mat<f64>) -> Result<(), KError> {
-        let n = a.nrows();
-        self.diag_inv.resize(n, 0.0);
-        for i in 0..n {
-            let val = a[(i, i)];
-            self.diag_inv[i] = if val != 0.0 { 1.0 / val } else { 0.0 };
+    fn recompute(&mut self, pmat: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        if let Some(csr) = pmat.as_any().downcast_ref::<CsrMatrix<f64>>() {
+            let n = csr.nrows().min(csr.ncols());
+            self.diag_inv.resize(n, 0.0);
+            for i in 0..n {
+                let rs = csr.row_ptr()[i];
+                let re = csr.row_ptr()[i + 1];
+                let mut aii = 0.0;
+                for p in rs..re {
+                    if csr.col_idx()[p] == i {
+                        aii = csr.values()[p];
+                        break;
+                    }
+                }
+                self.diag_inv[i] = if aii.abs() > 1e-14 { 1.0 / aii } else { 0.0 };
+            }
+            self.n = n;
+            return Ok(());
+        }
+        if let Some(d) = pmat.as_any().downcast_ref::<Mat<f64>>() {
+            let n = d.nrows().min(d.ncols());
+            self.diag_inv.resize(n, 0.0);
+            for i in 0..n {
+                let aii = d[(i, i)];
+                self.diag_inv[i] = if aii.abs() > 1e-14 { 1.0 / aii } else { 0.0 };
+            }
+            self.n = n;
+            return Ok(());
+        }
+        Err(KError::InvalidInput("Jacobi needs Dense or CSR".into()))
+    }
+}
+impl Preconditioner for Jacobi {
+    fn setup(&mut self, pmat: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        self.recompute(pmat)
+    }
+    fn update_values(&mut self, pmat: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        self.recompute(pmat)
+    }
+    fn supports_numeric_update(&self) -> bool { true }
+    fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
+        assert_eq!(r.len(), self.n);
+        assert_eq!(z.len(), self.n);
+        for i in 0..self.n {
+            z[i] = self.diag_inv[i] * r[i];
         }
         Ok(())
     }
 }
 
-impl PreconditionerMat for Jacobi {
-    fn setup_mat(&mut self, a: &Mat<f64>) -> Result<(), KError> {
-        self.build_from_dense(a)
-    }
-
-    fn apply_vec(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
-        assert_eq!(r.len(), z.len());
-        for ((zi, di), ri) in z.iter_mut().zip(self.diag_inv.iter()).zip(r.iter()) {
-            *zi = di * ri;
-        }
-        Ok(())
-    }
-}
-
-// Provide legacy trait implementation for components still using the generic
-// preconditioner interface.
 impl crate::preconditioner::legacy::Preconditioner<Mat<f64>, Vec<f64>> for Jacobi {
     fn setup(&mut self, a: &Mat<f64>) -> Result<(), KError> {
-        self.setup_mat(a)
+        self.recompute(a)
     }
-
     fn apply(&self, side: PcSide, r: &Vec<f64>, z: &mut Vec<f64>) -> Result<(), KError> {
-        self.apply_vec(side, r.as_slice(), z.as_mut_slice())
+        crate::preconditioner::Preconditioner::apply(self, side, r.as_slice(), z.as_mut_slice())
     }
 }
-

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -42,13 +42,28 @@ impl Default for PcSide {
     }
 }
 
+#[derive(Clone, Copy, Debug)]
+pub enum PcReusePolicy {
+    Never,
+    ReuseNumeric,
+    Auto,
+}
+impl PcReusePolicy {
+    pub fn allow_numeric(self) -> bool {
+        matches!(self, PcReusePolicy::ReuseNumeric | PcReusePolicy::Auto)
+    }
+}
+
 /// Object-safe preconditioner operating on `f64` slices and [`LinOp`] matrices.
 pub trait Preconditioner: Send + Sync {
     /// Build any factorization/hierarchy once from the system matrix.
-    fn setup(
-        &mut self,
-        a: &dyn crate::matrix::op::LinOp<S = f64>,
-    ) -> Result<(), KError>;
+    fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError>;
+
+    fn update_values(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        self.setup(a)
+    }
+
+    fn supports_numeric_update(&self) -> bool { false }
 
     /// Apply M⁻¹ to input vector, writing result to output slice.
     fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError>;

--- a/tests/reuse_tests.rs
+++ b/tests/reuse_tests.rs
@@ -1,0 +1,48 @@
+use std::sync::Arc;
+use kryst::matrix::{CsrOp};
+use kryst::matrix::sparse::CsrMatrix;
+use kryst::context::ksp_context::{KspContext, SolverType};
+use kryst::preconditioner::{PcReusePolicy};
+use kryst::context::pc_context::PcType;
+
+#[test]
+fn pc_rebuilds_on_structure_change() {
+    let a1 = Arc::new(CsrMatrix::from_csr(2,2, vec![0,1,2], vec![0,1], vec![1.0,2.0]));
+    let op1 = Arc::new(CsrOp::new(a1));
+    let a2 = Arc::new(CsrMatrix::from_csr(2,2, vec![0,1,2], vec![0,1], vec![3.0,4.0]));
+    let op2 = Arc::new(CsrOp::new(a2));
+
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Gmres).unwrap();
+    ksp.set_pc_type(PcType::Jacobi, None).unwrap();
+    ksp.set_operators(op1.clone(), None);
+
+    ksp.setup().unwrap();
+    let sid1 = ksp.last_pc_sid();
+
+    ksp.set_operators(op2.clone(), None);
+    op2.mark_structure_changed();
+    ksp.setup().unwrap();
+    assert_ne!(sid1, ksp.last_pc_sid());
+}
+
+#[test]
+fn jacobi_numeric_update_without_rebuild() {
+    let a = Arc::new(CsrMatrix::from_csr(2,2, vec![0,1,2], vec![0,1], vec![1.0,2.0]));
+    let op = Arc::new(CsrOp::new(a));
+
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Gmres).unwrap();
+    ksp.set_pc_type(PcType::Jacobi, None).unwrap();
+    ksp.set_pc_reuse_policy(PcReusePolicy::ReuseNumeric);
+    ksp.set_operators(op.clone(), None);
+
+    ksp.setup().unwrap();
+    let sid0 = ksp.last_pc_sid();
+    let vid0 = ksp.last_pc_vid();
+
+    op.mark_values_changed();
+    ksp.setup().unwrap();
+    assert_eq!(sid0, ksp.last_pc_sid());
+    assert_ne!(vid0, ksp.last_pc_vid());
+}


### PR DESCRIPTION
## Summary
- track structural and numeric changes via `StructureId`/`ValuesId` on `LinOp`
- allow preconditioners to refresh values without rebuilding and add `PcReusePolicy`
- add tests for matrix/operator reuse behavior

## Testing
- `cargo test --lib --tests`

------
https://chatgpt.com/codex/tasks/task_e_68a7f4f2e2bc83299d26c713da859642