### PR TITLE
feat: add direct solve hook to Preconditioner trait

### DIFF
--- a/src/preconditioner/direct.rs
+++ b/src/preconditioner/direct.rs
@@ -1,0 +1,61 @@
+use crate::error::KError;
+use crate::matrix::op::LinOp;
+use crate::preconditioner::{PcSide, Preconditioner};
+use crate::solver::legacy::LinearSolver;
+use crate::solver::LuSolver;
+use faer::Mat;
+
+/// Minimal LU-based preconditioner that supports [`Preconditioner::direct_solve`].
+pub struct LuPc {
+    ready: bool,
+}
+
+impl LuPc {
+    pub fn new() -> Self {
+        Self { ready: false }
+    }
+}
+
+impl Preconditioner for LuPc {
+    fn setup(&mut self, pmat: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        let _m: &Mat<f64> = pmat
+            .as_any()
+            .downcast_ref::<Mat<f64>>()
+            .ok_or_else(|| KError::InvalidInput("LU PC requires faer::Mat<f64>".into()))?;
+        self.ready = true;
+        Ok(())
+    }
+
+    fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
+        z.copy_from_slice(r);
+        Ok(())
+    }
+
+    fn direct_solve(
+        &mut self,
+        op: &dyn LinOp<S = f64>,
+        b: &[f64],
+        x: &mut [f64],
+    ) -> Result<bool, KError> {
+        let m: &Mat<f64> = op.as_any().downcast_ref::<Mat<f64>>().ok_or_else(|| {
+            KError::InvalidInput("LU direct_solve requires faer::Mat<f64>".into())
+        })?;
+
+        let mut lu = LuSolver::new();
+        let b_vec = b.to_vec();
+        let mut x_vec = vec![0.0; x.len()];
+        lu.solve(
+            m,
+            None,
+            &b_vec,
+            &mut x_vec,
+            &crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm),
+            None,
+            None,
+        )?;
+        x.copy_from_slice(&x_vec);
+        Ok(true)
+    }
+}
+
+

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -55,18 +55,42 @@ impl PcReusePolicy {
 }
 
 /// Object-safe preconditioner operating on `f64` slices and [`LinOp`] matrices.
+///
+/// Preconditioners may optionally implement [`direct_solve`], allowing the
+/// preconditioner to act as a stand-alone direct solver (e.g. LU, QR). Only
+/// implementations that are true direct methods should override it.
+///
+/// Contract for [`direct_solve`]:
+/// * return `Ok(true)` and fill `x` when the system is solved successfully,
+/// * return `Ok(false)` if no direct solve is supported, and
+/// * return `Err(..)` if an attempted direct solve fails.
+///
+/// The `op` passed will typically be the same matrix that [`setup`] was called
+/// with. `&mut self` is taken to permit use of cached factors or workspace. The
+/// default implementation simply returns `Ok(false)` so existing preconditioners
+/// remain unaffected.
 pub trait Preconditioner: Send + Sync {
     /// Build any factorization/hierarchy once from the system matrix.
     fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError>;
+
+    /// Apply M⁻¹ to input vector, writing result to output slice.
+    fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError>;
+
+    /// Try to solve `op * x = b` completely.
+    fn direct_solve(
+        &mut self,
+        _op: &dyn LinOp<S = f64>,
+        _b: &[f64],
+        _x: &mut [f64],
+    ) -> Result<bool, KError> {
+        Ok(false)
+    }
 
     fn update_values(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
         self.setup(a)
     }
 
     fn supports_numeric_update(&self) -> bool { false }
-
-    /// Apply M⁻¹ to input vector, writing result to output slice.
-    fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError>;
 }
 
 /// Internal trait for preconditioners that operate directly on dense matrices.
@@ -142,6 +166,7 @@ pub mod ilup;
 pub mod chebyshev;
 pub mod approxinv;
 pub mod chain;
+pub mod direct;
 
 // Re-exports for convenience
 pub use jacobi::Jacobi;
@@ -155,7 +180,33 @@ pub use ilup::Ilup;
 pub use chebyshev::{Chebyshev, ChebyshevPre};
 pub use approxinv::ApproxInv;
 pub use chain::PcChain;
+pub use direct::LuPc;
 pub use self::sor::MatSorType;
 
 /// Unified preconditioner enum for all supported types.
 pub use crate::context::pc_context::{PC, SparsityPattern};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use faer::Mat;
+
+    struct Dummy;
+
+    impl Preconditioner for Dummy {
+        fn setup(&mut self, _pmat: &dyn LinOp<S = f64>) -> Result<(), KError> { Ok(()) }
+
+        fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
+            z.copy_from_slice(r);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn default_direct_solve_is_false() {
+        let mut pc = Dummy;
+        let a = Mat::<f64>::zeros(1, 1);
+        let mut x = [0.0];
+        assert_eq!(pc.direct_solve(&a, &[1.0], &mut x).unwrap(), false);
+    }
+}


### PR DESCRIPTION
## Summary
- add optional `direct_solve` method to `Preconditioner`
- provide example LU preconditioner implementing direct solve
- include unit test verifying default returns false

## Testing
- `cargo test --lib`

------
https://chatgpt.com/codex/tasks/task_e_68a802d4b6bc8329a62155f572669ae0