### PR TITLE
Add direct LU/QR/SuperLU_DIST preconditioners and PREONLY solver

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -5,7 +5,7 @@ use crate::matrix::op::{LinOp, StructureId, ValuesId};
 use crate::parallel::UniverseComm;
 use crate::preconditioner::{PcSide, Preconditioner, PcReusePolicy};
 use crate::solver::{BiCgStabSolver, CgSolver, GmresSolver, LinearSolver, MatSolverAdapter};
-use crate::utils::convergence::SolveStats;
+use crate::utils::convergence::{SolveStats, ConvergedReason};
 use std::sync::Arc;
 use std::str::FromStr;
 
@@ -67,6 +67,7 @@ pub struct KspContext {
     work: Option<Workspace>,
     setup_called: bool,
     monitors: Vec<Box<dyn Fn(usize, f64) + Send + Sync>>,
+    solver_type: SolverType,
     pub rtol: f64,
     pub atol: f64,
     pub dtol: f64,
@@ -88,6 +89,7 @@ impl KspContext {
             work: None,
             setup_called: false,
             monitors: Vec::new(),
+            solver_type: SolverType::Gmres,
             rtol: 1e-6,
             atol: 1e-12,
             dtol: 1e3,
@@ -101,25 +103,29 @@ impl KspContext {
     }
 
     pub fn set_type(&mut self, solver_type: SolverType) -> Result<&mut Self, KError> {
-        let solver: Box<dyn LinearSolver<Error = KError>> = match solver_type {
-            SolverType::Cg => {
-                Box::new(MatSolverAdapter::new(CgSolver::new(self.rtol, self.maxits)))
-            }
-            SolverType::Gmres => Box::new(MatSolverAdapter::new(GmresSolver::new(
+        self.solver_type = solver_type;
+        self.solver = match solver_type {
+            SolverType::Cg => Some(Box::new(MatSolverAdapter::new(CgSolver::new(
+                self.rtol,
+                self.maxits,
+            )))),
+            SolverType::Gmres => Some(Box::new(MatSolverAdapter::new(GmresSolver::new(
                 self.restart,
                 self.rtol,
                 self.maxits,
+            )))),
+            SolverType::BiCgStab => Some(Box::new(MatSolverAdapter::new(
+                BiCgStabSolver::new(self.rtol, self.maxits),
             ))),
-            SolverType::BiCgStab => {
-                Box::new(MatSolverAdapter::new(BiCgStabSolver::new(self.rtol, self.maxits)))
-            }
-            SolverType::Preonly => {
-                return Err(KError::SolveError("Preonly solver not available".into()))
-            }
+            SolverType::Preonly => None,
         };
-        self.solver = Some(solver);
         self.invalidate_setup();
         Ok(self)
+    }
+
+    pub fn set_type_from_str(&mut self, solver_type: &str) -> Result<&mut Self, KError> {
+        let st = SolverType::from_str(solver_type)?;
+        self.set_type(st)
     }
 
     pub fn set_pc_type(
@@ -130,6 +136,14 @@ impl KspContext {
         self.pc = Some(PcFactory::create_preconditioner(pc_type, opts)?);
         self.invalidate_setup();
         Ok(self)
+    }
+
+    pub fn set_pc_type_from_str(
+        &mut self,
+        pc_type: &str,
+    ) -> Result<&mut Self, KError> {
+        let pct = PcType::from_str(pc_type)?;
+        self.set_pc_type(pct, None)
     }
 
     /// Configure the KSP context using parsed KSP options.
@@ -291,6 +305,33 @@ impl KspContext {
             .amat
             .as_ref()
             .ok_or_else(|| KError::InvalidInput("Amat not set".into()))?;
+
+        if self.solver_type == SolverType::Preonly {
+            let pmat = self
+                .pmat
+                .as_ref()
+                .ok_or_else(|| KError::InvalidInput("Pmat not set".into()))?;
+            let pc = self
+                .pc
+                .as_mut()
+                .ok_or_else(|| {
+                    KError::SolveError(
+                        "PREONLY requires a direct PC (LU/QR/SuperLU_DIST)".into(),
+                    )
+                })?;
+            return match pc.direct_solve(pmat.as_ref(), b, x)? {
+                true => Ok(SolveStats {
+                    iterations: 1,
+                    final_residual: 0.0,
+                    reason: ConvergedReason::ConvergedAtol,
+                }),
+                false => Err(KError::SolveError(
+                    "Selected PC does not implement direct_solve; choose LU/QR/SuperLU_DIST"
+                        .into(),
+                )),
+            };
+        }
+
         let solver = self
             .solver
             .as_mut()

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -12,6 +12,9 @@ use crate::preconditioner::{
     Sor,
     MatSorType,
     ChebyshevPre,
+    LuPc,
+    QrPc,
+    SuperLuDistPc,
 };
 use crate::matrix::op::LinOp;
 use faer::Mat;
@@ -136,6 +139,9 @@ impl PcFactory {
                 Ok(Box::new(LegacyOpPreconditioner::new(Box::new(pre))))
             }
             PcType::None => Ok(Box::new(NoOpPreconditioner)),
+            PcType::Lu => Ok(Box::new(LuPc::new())),
+            PcType::Qr => Ok(Box::new(QrPc::new())),
+            PcType::SuperLuDist => Ok(Box::new(SuperLuDistPc::new())),
             _ => Err(KError::UnrecognizedPcType(format!("{:?} not implemented", pc_type))),
         }
     }

--- a/src/preconditioner/direct.rs
+++ b/src/preconditioner/direct.rs
@@ -2,8 +2,11 @@ use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::legacy::LinearSolver;
-use crate::solver::LuSolver;
+use crate::solver::{LuSolver, QrSolver};
+#[cfg(feature = "superlu_dist")]
+use crate::solver::superlu_dist::SuperLuDistSolver;
 use faer::Mat;
+use crate::matrix::sparse::CsrMatrix;
 
 /// Minimal LU-based preconditioner that supports [`Preconditioner::direct_solve`].
 pub struct LuPc {
@@ -55,6 +58,115 @@ impl Preconditioner for LuPc {
         )?;
         x.copy_from_slice(&x_vec);
         Ok(true)
+    }
+}
+
+/// Minimal QR-based preconditioner wrapper.
+pub struct QrPc;
+
+impl QrPc {
+    pub fn new() -> Self { Self }
+}
+
+impl Preconditioner for QrPc {
+    fn setup(&mut self, pmat: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        let _m: &Mat<f64> = pmat
+            .as_any()
+            .downcast_ref::<Mat<f64>>()
+            .ok_or_else(|| KError::InvalidInput("QR PC requires faer::Mat<f64>".into()))?;
+        Ok(())
+    }
+
+    fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
+        z.copy_from_slice(r);
+        Ok(())
+    }
+
+    fn direct_solve(
+        &mut self,
+        op: &dyn LinOp<S = f64>,
+        b: &[f64],
+        x: &mut [f64],
+    ) -> Result<bool, KError> {
+        let m: &Mat<f64> = op.as_any().downcast_ref::<Mat<f64>>().ok_or_else(|| {
+            KError::InvalidInput("QR direct_solve requires faer::Mat<f64>".into())
+        })?;
+
+        let mut qr = QrSolver::new();
+        let b_vec = b.to_vec();
+        let mut x_vec = vec![0.0; x.len()];
+        qr.solve(
+            m,
+            None,
+            &b_vec,
+            &mut x_vec,
+            &crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm),
+            None,
+            None,
+        )?;
+        x.copy_from_slice(&x_vec);
+        Ok(true)
+    }
+}
+
+/// Minimal SuperLU_DIST-based preconditioner wrapper operating on CSR matrices.
+#[cfg_attr(not(feature = "superlu_dist"), allow(dead_code))]
+pub struct SuperLuDistPc;
+
+impl SuperLuDistPc {
+    pub fn new() -> Self { Self }
+}
+
+impl Preconditioner for SuperLuDistPc {
+    fn setup(&mut self, pmat: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        let _a: &CsrMatrix<f64> = pmat
+            .as_any()
+            .downcast_ref::<CsrMatrix<f64>>()
+            .ok_or_else(|| {
+                KError::InvalidInput("SuperLU_DIST PC requires CSR matrix".into())
+            })?;
+        Ok(())
+    }
+
+    fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
+        z.copy_from_slice(r);
+        Ok(())
+    }
+
+    fn direct_solve(
+        &mut self,
+        op: &dyn LinOp<S = f64>,
+        b: &[f64],
+        x: &mut [f64],
+    ) -> Result<bool, KError> {
+        #[cfg(not(feature = "superlu_dist"))]
+        {
+            return Err(KError::SolveError(
+                "superlu_dist feature not enabled".into(),
+            ));
+        }
+
+        #[cfg(feature = "superlu_dist")]
+        {
+            let a: &CsrMatrix<f64> = op.as_any().downcast_ref::<CsrMatrix<f64>>().ok_or_else(|| {
+                KError::InvalidInput("SuperLU_DIST expects CSR".into())
+            })?;
+
+            let mut slu = SuperLuDistSolver::new();
+            let b_vec = b.to_vec();
+            let mut x_vec = vec![0.0; x.len()];
+            slu.solve(
+                a,
+                None,
+                &b_vec,
+                &mut x_vec,
+                &crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm),
+                None,
+                None,
+            )?;
+            x.copy_from_slice(&x_vec);
+            Ok(true)
+        }
     }
 }
 

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -180,7 +180,7 @@ pub use ilup::Ilup;
 pub use chebyshev::{Chebyshev, ChebyshevPre};
 pub use approxinv::ApproxInv;
 pub use chain::PcChain;
-pub use direct::LuPc;
+pub use direct::{LuPc, QrPc, SuperLuDistPc};
 pub use self::sor::MatSorType;
 
 /// Unified preconditioner enum for all supported types.

--- a/tests/direct_pc.rs
+++ b/tests/direct_pc.rs
@@ -1,0 +1,44 @@
+use kryst::context::ksp_context::{KspContext, SolverType};
+use kryst::context::pc_context::PcType;
+use faer::Mat;
+use std::sync::Arc;
+
+#[test]
+fn lu_preonly_succeeds() {
+    let mut a = Mat::<f64>::zeros(2, 2);
+    a[(0, 0)] = 2.0;
+    a[(1, 1)] = 3.0;
+    let amat = Arc::new(a) as Arc<dyn kryst::matrix::op::LinOp<S = f64>>;
+
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Preonly).unwrap();
+    ksp.set_pc_type(PcType::Lu, None).unwrap();
+    ksp.set_operators(amat.clone(), None);
+
+    let b = [2.0, 6.0];
+    let mut x = [0.0, 0.0];
+    let stats = ksp.solve(&b, &mut x).unwrap();
+
+    assert_eq!(x, [1.0, 2.0]);
+    assert_eq!(stats.iterations, 1);
+}
+
+#[test]
+fn qr_preonly_succeeds() {
+    let mut a = Mat::<f64>::zeros(2, 2);
+    a[(0, 0)] = 4.0;
+    a[(1, 1)] = 5.0;
+    let amat = Arc::new(a) as Arc<dyn kryst::matrix::op::LinOp<S = f64>>;
+
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Preonly).unwrap();
+    ksp.set_pc_type(PcType::Qr, None).unwrap();
+    ksp.set_operators(amat.clone(), None);
+
+    let b = [4.0, 10.0];
+    let mut x = [0.0, 0.0];
+    let stats = ksp.solve(&b, &mut x).unwrap();
+
+    assert_eq!(x, [1.0, 2.0]);
+    assert_eq!(stats.iterations, 1);
+}

--- a/tests/options_integration.rs
+++ b/tests/options_integration.rs
@@ -190,9 +190,8 @@ fn test_preonly_configuration() {
 
     let mut ksp = KspContext::new();
 
-    // Configure PREONLY with LU preconditioner and expect failure
-    assert!(ksp.set_type(SolverType::Preonly).is_err());
-    // Preonly solver is not available, so we don't attempt further configuration
+    // PREONLY should now be accepted
+    ksp.set_type(SolverType::Preonly).unwrap();
 }
 
 #[test]
@@ -203,7 +202,8 @@ fn test_preonly_options_integration() {
     let args = vec!["-ksp_type", "preonly", "-pc_type", "lu"];
     let ksp_opts = KspOptions::from_args(&args).unwrap();
     let pc_opts = PcOptions::from_args(&args).unwrap();
-    
+
     let mut ksp = KspContext::new();
-    assert!(ksp.set_from_all_options(&ksp_opts, &pc_opts).is_err());
+    // PREONLY with LU should configure successfully
+    ksp.set_from_all_options(&ksp_opts, &pc_opts).unwrap();
 }


### PR DESCRIPTION
## Summary
- add QrPc and SuperLuDistPc wrappers alongside existing LuPc
- wire lu/qr/superludist into PcFactory and re-enable PREONLY to call direct solver
- test direct preconditioners and updated options parsing

## Testing
- `cargo test --lib --tests`

------
https://chatgpt.com/codex/tasks/task_e_68a8072de5088329ac8bc7c9a2addbb0