### PR TITLE
Add direct solve path for PREONLY

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -61,13 +61,13 @@ impl FromStr for SolverType {
 /// Minimal KSP context holding solver, preconditioner, and operators.
 pub struct KspContext {
     solver: Option<Box<dyn LinearSolver<Error = KError>>>,
+    solver_type: Option<SolverType>,
     pc: Option<Box<dyn Preconditioner>>,
     amat: Option<Arc<dyn LinOp<S = f64>>>,
     pmat: Option<Arc<dyn LinOp<S = f64>>>,
     work: Option<Workspace>,
     setup_called: bool,
     monitors: Vec<Box<dyn Fn(usize, f64) + Send + Sync>>,
-    solver_type: SolverType,
     pub rtol: f64,
     pub atol: f64,
     pub dtol: f64,
@@ -83,13 +83,13 @@ impl KspContext {
     pub fn new() -> Self {
         Self {
             solver: None,
+            solver_type: None,
             pc: None,
             amat: None,
             pmat: None,
             work: None,
             setup_called: false,
             monitors: Vec::new(),
-            solver_type: SolverType::Gmres,
             rtol: 1e-6,
             atol: 1e-12,
             dtol: 1e3,
@@ -103,7 +103,7 @@ impl KspContext {
     }
 
     pub fn set_type(&mut self, solver_type: SolverType) -> Result<&mut Self, KError> {
-        self.solver_type = solver_type;
+        self.solver_type = Some(solver_type);
         self.solver = match solver_type {
             SolverType::Cg => Some(Box::new(MatSolverAdapter::new(CgSolver::new(
                 self.rtol,
@@ -301,12 +301,7 @@ impl KspContext {
         if !self.setup_called {
             self.setup()?;
         }
-        let amat = self
-            .amat
-            .as_ref()
-            .ok_or_else(|| KError::InvalidInput("Amat not set".into()))?;
-
-        if self.solver_type == SolverType::Preonly {
+        if matches!(self.solver_type, Some(SolverType::Preonly)) {
             let pmat = self
                 .pmat
                 .as_ref()
@@ -316,21 +311,26 @@ impl KspContext {
                 .as_mut()
                 .ok_or_else(|| {
                     KError::SolveError(
-                        "PREONLY requires a direct PC (LU/QR/SuperLU_DIST)".into(),
+                        "PREONLY requires a direct preconditioner: use -pc_type {lu|qr|superludist}".into(),
                     )
                 })?;
-            return match pc.direct_solve(pmat.as_ref(), b, x)? {
-                true => Ok(SolveStats {
-                    iterations: 1,
-                    final_residual: 0.0,
-                    reason: ConvergedReason::ConvergedAtol,
-                }),
-                false => Err(KError::SolveError(
-                    "Selected PC does not implement direct_solve; choose LU/QR/SuperLU_DIST"
-                        .into(),
-                )),
-            };
+            pc.direct_solve(
+                pmat.as_ref(),
+                b,
+                x,
+                &UniverseComm::NoComm(crate::parallel::NoComm),
+            )?;
+            return Ok(SolveStats {
+                iterations: 1,
+                final_residual: 0.0,
+                reason: ConvergedReason::ConvergedAtol,
+            });
         }
+
+        let amat = self
+            .amat
+            .as_ref()
+            .ok_or_else(|| KError::InvalidInput("Amat not set".into()))?;
 
         let solver = self
             .solver

--- a/src/preconditioner/direct.rs
+++ b/src/preconditioner/direct.rs
@@ -1,5 +1,6 @@
 use crate::error::KError;
 use crate::matrix::op::LinOp;
+use crate::parallel::UniverseComm;
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::legacy::LinearSolver;
 use crate::solver::{LuSolver, QrSolver};
@@ -39,7 +40,8 @@ impl Preconditioner for LuPc {
         op: &dyn LinOp<S = f64>,
         b: &[f64],
         x: &mut [f64],
-    ) -> Result<bool, KError> {
+        comm: &UniverseComm,
+    ) -> Result<(), KError> {
         let m: &Mat<f64> = op.as_any().downcast_ref::<Mat<f64>>().ok_or_else(|| {
             KError::InvalidInput("LU direct_solve requires faer::Mat<f64>".into())
         })?;
@@ -47,17 +49,9 @@ impl Preconditioner for LuPc {
         let mut lu = LuSolver::new();
         let b_vec = b.to_vec();
         let mut x_vec = vec![0.0; x.len()];
-        lu.solve(
-            m,
-            None,
-            &b_vec,
-            &mut x_vec,
-            &crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm),
-            None,
-            None,
-        )?;
+        lu.solve(m, None, &b_vec, &mut x_vec, comm, None, None)?;
         x.copy_from_slice(&x_vec);
-        Ok(true)
+        Ok(())
     }
 }
 
@@ -87,7 +81,8 @@ impl Preconditioner for QrPc {
         op: &dyn LinOp<S = f64>,
         b: &[f64],
         x: &mut [f64],
-    ) -> Result<bool, KError> {
+        comm: &UniverseComm,
+    ) -> Result<(), KError> {
         let m: &Mat<f64> = op.as_any().downcast_ref::<Mat<f64>>().ok_or_else(|| {
             KError::InvalidInput("QR direct_solve requires faer::Mat<f64>".into())
         })?;
@@ -95,17 +90,9 @@ impl Preconditioner for QrPc {
         let mut qr = QrSolver::new();
         let b_vec = b.to_vec();
         let mut x_vec = vec![0.0; x.len()];
-        qr.solve(
-            m,
-            None,
-            &b_vec,
-            &mut x_vec,
-            &crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm),
-            None,
-            None,
-        )?;
+        qr.solve(m, None, &b_vec, &mut x_vec, comm, None, None)?;
         x.copy_from_slice(&x_vec);
-        Ok(true)
+        Ok(())
     }
 }
 
@@ -138,7 +125,8 @@ impl Preconditioner for SuperLuDistPc {
         op: &dyn LinOp<S = f64>,
         b: &[f64],
         x: &mut [f64],
-    ) -> Result<bool, KError> {
+        comm: &UniverseComm,
+    ) -> Result<(), KError> {
         #[cfg(not(feature = "superlu_dist"))]
         {
             return Err(KError::SolveError(
@@ -155,17 +143,9 @@ impl Preconditioner for SuperLuDistPc {
             let mut slu = SuperLuDistSolver::new();
             let b_vec = b.to_vec();
             let mut x_vec = vec![0.0; x.len()];
-            slu.solve(
-                a,
-                None,
-                &b_vec,
-                &mut x_vec,
-                &crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm),
-                None,
-                None,
-            )?;
+            slu.solve(a, None, &b_vec, &mut x_vec, comm, None, None)?;
             x.copy_from_slice(&x_vec);
-            Ok(true)
+            Ok(())
         }
     }
 }

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -3,9 +3,10 @@
 //! This module defines the Preconditioner trait and includes implementations such as Jacobi, ILU, SOR, AMG, Additive Schwarz, and more.
 
 use crate::error::KError;
+use crate::matrix::op::LinOp;
+use crate::parallel::UniverseComm;
 use faer::Mat;
 use std::str::FromStr;
-use crate::matrix::op::LinOp;
 
 /// Which side to apply M⁻¹ on in preconditioning.
 ///
@@ -58,17 +59,8 @@ impl PcReusePolicy {
 ///
 /// Preconditioners may optionally implement [`direct_solve`], allowing the
 /// preconditioner to act as a stand-alone direct solver (e.g. LU, QR). Only
-/// implementations that are true direct methods should override it.
-///
-/// Contract for [`direct_solve`]:
-/// * return `Ok(true)` and fill `x` when the system is solved successfully,
-/// * return `Ok(false)` if no direct solve is supported, and
-/// * return `Err(..)` if an attempted direct solve fails.
-///
-/// The `op` passed will typically be the same matrix that [`setup`] was called
-/// with. `&mut self` is taken to permit use of cached factors or workspace. The
-/// default implementation simply returns `Ok(false)` so existing preconditioners
-/// remain unaffected.
+/// implementations that are true direct methods should override it. The default
+/// implementation returns an error indicating direct solves are unsupported.
 pub trait Preconditioner: Send + Sync {
     /// Build any factorization/hierarchy once from the system matrix.
     fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError>;
@@ -76,14 +68,17 @@ pub trait Preconditioner: Send + Sync {
     /// Apply M⁻¹ to input vector, writing result to output slice.
     fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError>;
 
-    /// Try to solve `op * x = b` completely.
+    /// Solve `op * x = b` directly when supported.
     fn direct_solve(
         &mut self,
         _op: &dyn LinOp<S = f64>,
         _b: &[f64],
         _x: &mut [f64],
-    ) -> Result<bool, KError> {
-        Ok(false)
+        _comm: &UniverseComm,
+    ) -> Result<(), KError> {
+        Err(KError::SolveError(
+            "direct_solve not supported by this preconditioner".into(),
+        ))
     }
 
     fn update_values(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
@@ -203,10 +198,11 @@ mod tests {
     }
 
     #[test]
-    fn default_direct_solve_is_false() {
+    fn default_direct_solve_errors() {
         let mut pc = Dummy;
         let a = Mat::<f64>::zeros(1, 1);
         let mut x = [0.0];
-        assert_eq!(pc.direct_solve(&a, &[1.0], &mut x).unwrap(), false);
+        let comm = UniverseComm::NoComm(crate::parallel::NoComm);
+        assert!(pc.direct_solve(&a, &[1.0], &mut x, &comm).is_err());
     }
 }

--- a/tests/ksp_preonly.rs
+++ b/tests/ksp_preonly.rs
@@ -1,0 +1,24 @@
+use kryst::context::ksp_context::{KspContext, SolverType};
+use kryst::context::pc_context::PcType;
+use faer::Mat;
+use std::sync::Arc;
+
+#[test]
+fn preonly_runs_with_lu_pc() {
+    let mut a = Mat::<f64>::zeros(2, 2);
+    a[(0, 0)] = 4.0;
+    a[(1, 1)] = 3.0;
+    let amat = Arc::new(a.clone()) as Arc<dyn kryst::matrix::op::LinOp<S = f64>>;
+    let pmat = Arc::new(a) as Arc<dyn kryst::matrix::op::LinOp<S = f64>>;
+
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Preonly).unwrap();
+    ksp.set_pc_type(PcType::Lu, None).unwrap();
+    ksp.set_operators(amat, Some(pmat));
+
+    let b = [1.0, 2.0];
+    let mut x = [0.0, 0.0];
+    let stats = ksp.solve(&b, &mut x).unwrap();
+
+    assert_eq!(stats.iterations, 1);
+}


### PR DESCRIPTION
## Summary
- add object-safe `direct_solve` hook to `Preconditioner`
- track solver type in `KspContext` and call preconditioner directly for `PREONLY`
- implement `direct_solve` for LU/QR/SuperLU_DIST preconditioners and add tiny PREONLY test

## Testing
- `cargo test --tests`

------
https://chatgpt.com/codex/tasks/task_e_68a80b435c98832983b92a0bcd34ae10