### PR TITLE
Enable PREONLY direct solve through preconditioners

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -67,7 +67,7 @@ pub struct KspContext {
     work: Option<Workspace>,
     setup_called: bool,
     monitors: Vec<Box<dyn Fn(usize, f64) + Send + Sync>>,
-    solver_type: SolverType,
+    solver_type: Option<SolverType>,
     pub rtol: f64,
     pub atol: f64,
     pub dtol: f64,
@@ -89,7 +89,7 @@ impl KspContext {
             work: None,
             setup_called: false,
             monitors: Vec::new(),
-            solver_type: SolverType::Gmres,
+            solver_type: None,
             rtol: 1e-6,
             atol: 1e-12,
             dtol: 1e3,
@@ -103,7 +103,7 @@ impl KspContext {
     }
 
     pub fn set_type(&mut self, solver_type: SolverType) -> Result<&mut Self, KError> {
-        self.solver_type = solver_type;
+        self.solver_type = Some(solver_type);
         self.solver = match solver_type {
             SolverType::Cg => Some(Box::new(MatSolverAdapter::new(CgSolver::new(
                 self.rtol,
@@ -306,7 +306,7 @@ impl KspContext {
             .as_ref()
             .ok_or_else(|| KError::InvalidInput("Amat not set".into()))?;
 
-        if self.solver_type == SolverType::Preonly {
+        if matches!(self.solver_type, Some(SolverType::Preonly)) {
             let pmat = self
                 .pmat
                 .as_ref()
@@ -319,17 +319,17 @@ impl KspContext {
                         "PREONLY requires a direct PC (LU/QR/SuperLU_DIST)".into(),
                     )
                 })?;
-            return match pc.direct_solve(pmat.as_ref(), b, x)? {
-                true => Ok(SolveStats {
-                    iterations: 1,
-                    final_residual: 0.0,
-                    reason: ConvergedReason::ConvergedAtol,
-                }),
-                false => Err(KError::SolveError(
-                    "Selected PC does not implement direct_solve; choose LU/QR/SuperLU_DIST"
-                        .into(),
-                )),
-            };
+            pc.direct_solve(
+                pmat.as_ref(),
+                b,
+                x,
+                &UniverseComm::NoComm(crate::parallel::NoComm),
+            )?;
+            return Ok(SolveStats {
+                iterations: 1,
+                final_residual: 0.0,
+                reason: ConvergedReason::ConvergedAtol,
+            });
         }
 
         let solver = self

--- a/src/preconditioner/direct/lu_pc.rs
+++ b/src/preconditioner/direct/lu_pc.rs
@@ -1,6 +1,7 @@
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};
+use crate::parallel::UniverseComm;
 use faer::Mat;
 
 pub struct LuPc;
@@ -23,5 +24,19 @@ impl Preconditioner for LuPc {
         // minimal: identity; later, cache factors and solve M z = r
         z.copy_from_slice(r);
         Ok(())
+    }
+
+    fn direct_solve(
+        &mut self,
+        pmat: &dyn LinOp<S = f64>,
+        b: &[f64],
+        x: &mut [f64],
+        _comm: &UniverseComm,
+    ) -> Result<(), KError> {
+        let a = pmat
+            .as_any()
+            .downcast_ref::<Mat<f64>>()
+            .ok_or_else(|| KError::InvalidInput("LU PC requires faer::Mat<f64>".into()))?;
+        crate::solver::dense_lu::solve(a, b, x)
     }
 }

--- a/src/preconditioner/direct/qr_pc.rs
+++ b/src/preconditioner/direct/qr_pc.rs
@@ -1,6 +1,7 @@
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};
+use crate::parallel::UniverseComm;
 use faer::Mat;
 
 pub struct QrPc;
@@ -22,5 +23,19 @@ impl Preconditioner for QrPc {
     fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
         z.copy_from_slice(r);
         Ok(())
+    }
+
+    fn direct_solve(
+        &mut self,
+        pmat: &dyn LinOp<S = f64>,
+        b: &[f64],
+        x: &mut [f64],
+        _comm: &UniverseComm,
+    ) -> Result<(), KError> {
+        let a = pmat
+            .as_any()
+            .downcast_ref::<Mat<f64>>()
+            .ok_or_else(|| KError::InvalidInput("QR PC requires faer::Mat<f64>".into()))?;
+        crate::solver::dense_qr::solve(a, b, x)
     }
 }

--- a/src/preconditioner/direct/superlu_dist_pc.rs
+++ b/src/preconditioner/direct/superlu_dist_pc.rs
@@ -1,6 +1,7 @@
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};
+use crate::parallel::UniverseComm;
 
 #[cfg(feature = "superlu_dist")]
 use crate::matrix::sparse::CsrMatrix;
@@ -37,5 +38,27 @@ impl Preconditioner for SuperLuDistPc {
     fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
         z.copy_from_slice(r);
         Ok(())
+    }
+
+    fn direct_solve(
+        &mut self,
+        pmat: &dyn LinOp<S = f64>,
+        b: &[f64],
+        x: &mut [f64],
+        comm: &UniverseComm,
+    ) -> Result<(), KError> {
+        #[cfg(feature = "superlu_dist")]
+        {
+            let a = pmat
+                .as_any()
+                .downcast_ref::<CsrMatrix<f64>>()
+                .ok_or_else(|| KError::InvalidInput("SuperLU_DIST PC requires CSR matrix".into()))?;
+            crate::solver::superlu_dist::solve(a, b, x, comm)
+        }
+        #[cfg(not(feature = "superlu_dist"))]
+        {
+            let _ = (pmat, b, x, comm);
+            Err(KError::SolveError("superlu_dist feature not enabled".into()))
+        }
     }
 }

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -3,9 +3,10 @@
 //! This module defines the Preconditioner trait and includes implementations such as Jacobi, ILU, SOR, AMG, Additive Schwarz, and more.
 
 use crate::error::KError;
+use crate::matrix::op::LinOp;
+use crate::parallel::UniverseComm;
 use faer::Mat;
 use std::str::FromStr;
-use crate::matrix::op::LinOp;
 
 /// Which side to apply M⁻¹ on in preconditioning.
 ///
@@ -58,17 +59,9 @@ impl PcReusePolicy {
 ///
 /// Preconditioners may optionally implement [`direct_solve`], allowing the
 /// preconditioner to act as a stand-alone direct solver (e.g. LU, QR). Only
-/// implementations that are true direct methods should override it.
-///
-/// Contract for [`direct_solve`]:
-/// * return `Ok(true)` and fill `x` when the system is solved successfully,
-/// * return `Ok(false)` if no direct solve is supported, and
-/// * return `Err(..)` if an attempted direct solve fails.
-///
-/// The `op` passed will typically be the same matrix that [`setup`] was called
-/// with. `&mut self` is taken to permit use of cached factors or workspace. The
-/// default implementation simply returns `Ok(false)` so existing preconditioners
-/// remain unaffected.
+/// implementations that are true direct methods should override it. The default
+/// implementation returns a clear [`KError`], so existing preconditioners
+/// continue to work unchanged.
 pub trait Preconditioner: Send + Sync {
     /// Build any factorization/hierarchy once from the system matrix.
     fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError>;
@@ -76,14 +69,20 @@ pub trait Preconditioner: Send + Sync {
     /// Apply M⁻¹ to input vector, writing result to output slice.
     fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError>;
 
-    /// Try to solve `op * x = b` completely.
+    /// Attempt to solve `op * x = b` directly using the preconditioner.
+    ///
+    /// The default implementation returns [`KError::SolveError`] indicating
+    /// that direct solves are not supported by this preconditioner.
     fn direct_solve(
         &mut self,
         _op: &dyn LinOp<S = f64>,
         _b: &[f64],
         _x: &mut [f64],
-    ) -> Result<bool, KError> {
-        Ok(false)
+        _comm: &UniverseComm,
+    ) -> Result<(), KError> {
+        Err(KError::SolveError(
+            "direct_solve not supported by this preconditioner".into(),
+        ))
     }
 
     fn update_values(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
@@ -203,10 +202,14 @@ mod tests {
     }
 
     #[test]
-    fn default_direct_solve_is_false() {
+    fn default_direct_solve_errors() {
         let mut pc = Dummy;
         let a = Mat::<f64>::zeros(1, 1);
         let mut x = [0.0];
-        assert_eq!(pc.direct_solve(&a, &[1.0], &mut x).unwrap(), false);
+        let err = pc.direct_solve(&a, &[1.0], &mut x, &UniverseComm::NoComm(crate::parallel::NoComm)).unwrap_err();
+        match err {
+            KError::SolveError(msg) => assert!(msg.contains("direct_solve not supported")),
+            _ => panic!("unexpected error variant"),
+        }
     }
 }

--- a/src/solver/dense_lu.rs
+++ b/src/solver/dense_lu.rs
@@ -1,0 +1,23 @@
+use crate::error::KError;
+use faer::linalg::solvers::{FullPivLu, SolveCore};
+use faer::{Mat, MatMut, Conj};
+
+/// Solve a dense system using LU factorization.
+pub fn solve(a: &Mat<f64>, b: &[f64], x: &mut [f64]) -> Result<(), KError> {
+    if a.nrows() != a.ncols() {
+        return Err(KError::InvalidInput(
+            "dense_lu::solve requires a square matrix".into(),
+        ));
+    }
+    if b.len() != a.nrows() || x.len() != a.ncols() {
+        return Err(KError::InvalidInput(
+            "dimension mismatch in dense_lu::solve".into(),
+        ));
+    }
+    let lu = FullPivLu::new(a.as_ref());
+    x.clone_from_slice(b);
+    let m = b.len();
+    let x_mat = MatMut::from_column_major_slice_mut(x, m, 1);
+    lu.solve_in_place_with_conj(Conj::No, x_mat);
+    Ok(())
+}

--- a/src/solver/dense_qr.rs
+++ b/src/solver/dense_qr.rs
@@ -1,0 +1,18 @@
+use crate::error::KError;
+use faer::linalg::solvers::{Qr, SolveCore};
+use faer::{Mat, MatMut, Conj};
+
+/// Solve a dense system using QR factorization.
+pub fn solve(a: &Mat<f64>, b: &[f64], x: &mut [f64]) -> Result<(), KError> {
+    if b.len() != a.nrows() || x.len() != a.ncols() {
+        return Err(KError::InvalidInput(
+            "dimension mismatch in dense_qr::solve".into(),
+        ));
+    }
+    let qr = Qr::new(a.as_ref());
+    x.clone_from_slice(b);
+    let m = b.len();
+    let x_mat = MatMut::from_column_major_slice_mut(x, m, 1);
+    qr.solve_in_place_with_conj(Conj::No, x_mat);
+    Ok(())
+}

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -166,4 +166,8 @@ pub mod bicgstab;
 pub use bicgstab::BiCgStabSolver;
 pub mod direct_lu;
 pub use direct_lu::{LuSolver, QrSolver};
+pub mod dense_lu;
+pub mod dense_qr;
+pub mod superlu_dist;
+pub use superlu_dist::SuperLuDistSolver;
 

--- a/src/solver/superlu_dist.rs
+++ b/src/solver/superlu_dist.rs
@@ -4080,6 +4080,32 @@ impl LinearSolver<CsrMatrix<f64>, Vec<f64>> for SuperLuDistSolver {
     }
 }
 
+/// Convenience wrapper to perform a direct SuperLU_DIST solve.
+#[cfg(feature = "superlu_dist")]
+pub fn solve(
+    a: &CsrMatrix<f64>,
+    b: &[f64],
+    x: &mut [f64],
+    comm: &UniverseComm,
+) -> Result<(), KError> {
+    let mut solver = SuperLuDistSolver::new();
+    let mut x_vec = x.to_vec();
+    let b_vec = b.to_vec();
+    solver.solve(a, None, &b_vec, &mut x_vec, comm, None, None)?;
+    x.copy_from_slice(&x_vec);
+    Ok(())
+}
+
+#[cfg(not(feature = "superlu_dist"))]
+pub fn solve(
+    _a: &crate::matrix::sparse::CsrMatrix<f64>,
+    _b: &[f64],
+    _x: &mut [f64],
+    _comm: &UniverseComm,
+) -> Result<(), KError> {
+    Err(KError::SolveError("superlu_dist feature not enabled".into()))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/tests/preonly_integration.rs
+++ b/tests/preonly_integration.rs
@@ -1,0 +1,29 @@
+use kryst::context::ksp_context::{KspContext, SolverType};
+use kryst::context::pc_context::PcType;
+use faer::Mat;
+use std::sync::Arc;
+use kryst::matrix::op::LinOp;
+
+#[test]
+fn preonly_runs_with_lu_pc() {
+    let mut a = Mat::<f64>::zeros(2, 2);
+    a[(0, 0)] = 4.0;
+    a[(0, 1)] = 1.0;
+    a[(1, 0)] = 1.0;
+    a[(1, 1)] = 3.0;
+    let amat: Arc<dyn LinOp<S = f64>> = Arc::new(a.clone());
+    let pmat: Arc<dyn LinOp<S = f64>> = Arc::new(a);
+
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Preonly).unwrap();
+    ksp.set_pc_type(PcType::Lu, None).unwrap();
+    ksp.set_operators(amat, Some(pmat));
+
+    let b = [1.0, 2.0];
+    let mut x = [0.0, 0.0];
+    let stats = ksp.solve(&b, &mut x).unwrap();
+
+    assert_eq!(stats.iterations, 1);
+    assert!((x[0] - 0.0909090909).abs() < 1e-8);
+    assert!((x[1] - 0.6363636363).abs() < 1e-8);
+}


### PR DESCRIPTION
## Summary
- extend `Preconditioner` trait with an object-safe `direct_solve`
- track solver type in `KspContext` and bypass iterative solver when using `PREONLY`
- implement direct solves for LU, QR, and SuperLU_DIST and add dense helpers

## Testing
- `cargo test --lib --tests`

------
https://chatgpt.com/codex/tasks/task_e_68a8113bced083299e4c64097ad9352b