### PR TITLE
Add MINRES solver type to solver context

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -3,11 +3,13 @@ use crate::context::pc_context::{PcFactory, PcType};
 use crate::error::KError;
 use crate::matrix::op::{LinOp, StructureId, ValuesId};
 use crate::parallel::UniverseComm;
-use crate::preconditioner::{PcSide, Preconditioner, PcReusePolicy};
-use crate::solver::{BiCgStabSolver, CgSolver, GmresSolver, LinearSolver, MatSolverAdapter, PcgSolver};
-use crate::utils::convergence::{SolveStats, ConvergedReason};
-use std::sync::Arc;
+use crate::preconditioner::{PcReusePolicy, PcSide, Preconditioner};
+use crate::solver::{
+    BiCgStabSolver, CgSolver, GmresSolver, LinearSolver, MatSolverAdapter, MinresSolver, PcgSolver,
+};
+use crate::utils::convergence::{ConvergedReason, SolveStats};
 use std::str::FromStr;
+use std::sync::Arc;
 
 /// Workspace placeholder reused by solvers.
 #[derive(Debug)]
@@ -42,6 +44,7 @@ pub enum SolverType {
     Gmres,
     BiCgStab,
     Pcg,
+    Minres,
     Preonly,
 }
 
@@ -54,6 +57,7 @@ impl FromStr for SolverType {
             "gmres" => Ok(SolverType::Gmres),
             "bicgstab" => Ok(SolverType::BiCgStab),
             "pcg" => Ok(SolverType::Pcg),
+            "minres" => Ok(SolverType::Minres),
             "preonly" => Ok(SolverType::Preonly),
             other => Err(KError::UnrecognizedSolverType(other.to_string())),
         }
@@ -116,10 +120,15 @@ impl KspContext {
                 self.rtol,
                 self.maxits,
             )))),
-            SolverType::BiCgStab => Some(Box::new(MatSolverAdapter::new(
-                BiCgStabSolver::new(self.rtol, self.maxits),
-            ))),
+            SolverType::BiCgStab => Some(Box::new(MatSolverAdapter::new(BiCgStabSolver::new(
+                self.rtol,
+                self.maxits,
+            )))),
             SolverType::Pcg => Some(Box::new(PcgSolver::new(self.rtol, self.maxits))),
+            SolverType::Minres => Some(Box::new(MatSolverAdapter::new(MinresSolver::new(
+                self.rtol,
+                self.maxits,
+            )))),
             SolverType::Preonly => None,
         };
         self.invalidate_setup();
@@ -141,10 +150,7 @@ impl KspContext {
         Ok(self)
     }
 
-    pub fn set_pc_type_from_str(
-        &mut self,
-        pc_type: &str,
-    ) -> Result<&mut Self, KError> {
+    pub fn set_pc_type_from_str(&mut self, pc_type: &str) -> Result<&mut Self, KError> {
         let pct = PcType::from_str(pc_type)?;
         self.set_pc_type(pct, None)
     }
@@ -224,8 +230,12 @@ impl KspContext {
         self.last_pc_vid = None;
     }
 
-    pub fn last_pc_sid(&self) -> Option<StructureId> { self.last_pc_sid }
-    pub fn last_pc_vid(&self) -> Option<ValuesId> { self.last_pc_vid }
+    pub fn last_pc_sid(&self) -> Option<StructureId> {
+        self.last_pc_sid
+    }
+    pub fn last_pc_vid(&self) -> Option<ValuesId> {
+        self.last_pc_vid
+    }
 
     /// Prepare preconditioner and workspace.
     pub fn setup(&mut self) -> Result<(), KError> {
@@ -314,14 +324,9 @@ impl KspContext {
                 .pmat
                 .as_ref()
                 .ok_or_else(|| KError::InvalidInput("Pmat not set".into()))?;
-            let pc = self
-                .pc
-                .as_mut()
-                .ok_or_else(|| {
-                    KError::SolveError(
-                        "PREONLY requires a direct PC (LU/QR/SuperLU_DIST)".into(),
-                    )
-                })?;
+            let pc = self.pc.as_mut().ok_or_else(|| {
+                KError::SolveError("PREONLY requires a direct PC (LU/QR/SuperLU_DIST)".into())
+            })?;
             pc.direct_solve(
                 pmat.as_ref(),
                 b,
@@ -386,13 +391,7 @@ impl KspContext {
     }
 
     /// Set solver tolerances and maximum iterations.
-    pub fn set_tolerances(
-        &mut self,
-        rtol: f64,
-        atol: f64,
-        dtol: f64,
-        maxits: usize,
-    ) -> &mut Self {
+    pub fn set_tolerances(&mut self, rtol: f64, atol: f64, dtol: f64, maxits: usize) -> &mut Self {
         self.rtol = rtol;
         self.atol = atol;
         self.dtol = dtol;

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -1,11 +1,11 @@
 //! Solver traits and adapters.
 
-use crate::matrix::op::LinOp;
-use crate::preconditioner::{Preconditioner, PcSide};
-use crate::utils::convergence::SolveStats;
 use crate::context::ksp_context::Workspace;
-use crate::parallel::UniverseComm;
 use crate::error::KError;
+use crate::matrix::op::LinOp;
+use crate::parallel::UniverseComm;
+use crate::preconditioner::{PcSide, Preconditioner};
+use crate::utils::convergence::SolveStats;
 
 /// Object-safe linear solver operating on `f64` slices and [`LinOp`] operators.
 pub trait LinearSolver: Send {
@@ -111,8 +111,12 @@ struct MatPcAdapter<'a> {
     inner: &'a dyn Preconditioner,
 }
 
-impl<'a> crate::preconditioner::legacy::Preconditioner<faer::Mat<f64>, Vec<f64>> for MatPcAdapter<'a> {
-    fn setup(&mut self, _a: &faer::Mat<f64>) -> Result<(), KError> { Ok(()) }
+impl<'a> crate::preconditioner::legacy::Preconditioner<faer::Mat<f64>, Vec<f64>>
+    for MatPcAdapter<'a>
+{
+    fn setup(&mut self, _a: &faer::Mat<f64>) -> Result<(), KError> {
+        Ok(())
+    }
     fn apply(&self, side: PcSide, r: &Vec<f64>, z: &mut Vec<f64>) -> Result<(), KError> {
         self.inner.apply(side, r.as_slice(), z.as_mut_slice())
     }
@@ -145,9 +149,9 @@ where
         let mut x_vec = x.to_vec();
         let b_vec = b.to_vec();
         let pc_adapter = pc.map(|p| MatPcAdapter { inner: p });
-        let pc_ref = pc_adapter
-            .as_ref()
-            .map(|p| p as &dyn crate::preconditioner::legacy::Preconditioner<faer::Mat<f64>, Vec<f64>>);
+        let pc_ref = pc_adapter.as_ref().map(|p| {
+            p as &dyn crate::preconditioner::legacy::Preconditioner<faer::Mat<f64>, Vec<f64>>
+        });
         let stats = self
             .inner
             .solve(mat, pc_ref, &b_vec, &mut x_vec, comm, monitors, work)?;
@@ -166,10 +170,11 @@ pub mod bicgstab;
 pub use bicgstab::BiCgStabSolver;
 pub mod pcg;
 pub use pcg::PcgSolver;
+pub mod minres;
+pub use minres::MinresSolver;
 pub mod direct_lu;
 pub use direct_lu::{LuSolver, QrSolver};
 pub mod dense_lu;
 pub mod dense_qr;
 pub mod superlu_dist;
 pub use superlu_dist::SuperLuDistSolver;
-


### PR DESCRIPTION
## Summary
- support selecting MINRES via `SolverType` and KSP context
- expose MINRES solver module in solver exports

## Testing
- `cargo test --tests`


------
https://chatgpt.com/codex/tasks/task_e_68a93c5673348329a1dc1b8a29b49009