### PR TITLE
feat: add native CGS solver

### DIFF
--- a/examples/options_demo.rs
+++ b/examples/options_demo.rs
@@ -26,6 +26,7 @@
 //! ```
 
 use std::env;
+use std::sync::Arc;
 use faer::Mat;
 use kryst::config::options::parse_all_options;
 use kryst::context::ksp_context::KspContext;
@@ -85,7 +86,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!();
     
     // Solve the system
-    ksp.set_operators(a.clone(), None);
+    ksp.set_operators(Arc::new(a.clone()), None);
     match ksp.solve(&b, &mut x) {
         Ok(stats) => {
             println!("Solution Results:");

--- a/examples/phase_i_test.rs
+++ b/examples/phase_i_test.rs
@@ -9,6 +9,7 @@ use kryst::{
     context::ksp_context::{KspContext, SolverType},
     context::pc_context::PcType,
     config::options::PcOptions,
+    matrix::op::LinOp,
 };
 use faer::Mat;
 use std::sync::Arc;
@@ -61,7 +62,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
        .set_pc_type(PcType::Asm, Some(&pc_opts))?;
     
     // Create a small test matrix
-    let a = Arc::new(Mat::from_fn(2, 2, |i, j| {
+    let a: Arc<dyn LinOp<S = f64>> = Arc::new(Mat::from_fn(2, 2, |i, j| {
         match (i, j) {
             (0, 0) => 4.0,
             (0, 1) => 1.0,

--- a/examples/setup_reuse_demo.rs
+++ b/examples/setup_reuse_demo.rs
@@ -15,6 +15,7 @@ use std::sync::Arc;
 use faer::Mat;
 use kryst::context::ksp_context::{KspContext, SolverType};
 use kryst::context::pc_context::PcType;
+use kryst::matrix::op::LinOp;
 
 fn create_test_matrix(n: usize) -> Mat<f64> {
     // Create a symmetric positive definite tridiagonal matrix
@@ -39,7 +40,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let num_solves = 5;  // Number of right-hand sides to solve
 
     // Create the system matrix (represents a discrete Laplacian)
-    let a = Arc::new(create_test_matrix(n));
+    let a: Arc<dyn LinOp<S = f64>> = Arc::new(create_test_matrix(n));
     println!("Created {}×{} tridiagonal system matrix", n, n);
 
     // Create multiple right-hand side vectors

--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -5,8 +5,8 @@ use crate::matrix::op::{LinOp, StructureId, ValuesId};
 use crate::parallel::UniverseComm;
 use crate::preconditioner::{PcReusePolicy, PcSide, Preconditioner};
 use crate::solver::{
-    BiCgStabSolver, CgSolver, CgnrSolver, GmresSolver, LinearSolver, MatSolverAdapter, MinresSolver,
-    PcgSolver,
+    BiCgStabSolver, CgSolver, CgnrSolver, CgsSolver, GmresSolver, LinearSolver, MatSolverAdapter,
+    MinresSolver, PcgSolver,
 };
 use crate::utils::convergence::{ConvergedReason, SolveStats};
 use std::str::FromStr;
@@ -45,6 +45,7 @@ pub enum SolverType {
     Cgnr,
     Gmres,
     BiCgStab,
+    Cgs,
     Pcg,
     Minres,
     Preonly,
@@ -59,6 +60,7 @@ impl FromStr for SolverType {
             "cgnr" => Ok(SolverType::Cgnr),
             "gmres" => Ok(SolverType::Gmres),
             "bicgstab" => Ok(SolverType::BiCgStab),
+            "cgs" => Ok(SolverType::Cgs),
             "pcg" => Ok(SolverType::Pcg),
             "minres" => Ok(SolverType::Minres),
             "preonly" => Ok(SolverType::Preonly),
@@ -128,6 +130,7 @@ impl KspContext {
                 self.rtol,
                 self.maxits,
             ))),
+            SolverType::Cgs => Box::new(CgsSolver::new(self.rtol, self.maxits)),
             SolverType::Pcg => Box::new(PcgSolver::new(self.rtol, self.maxits)),
             SolverType::Minres => Box::new(MatSolverAdapter::new(MinresSolver::new(
                 self.rtol,

--- a/src/solver/cgs.rs
+++ b/src/solver/cgs.rs
@@ -1,312 +1,204 @@
-//! Conjugate Gradient Squared (CGS) Solver
-//!
-//! This module implements the CGS iterative method for solving nonsymmetric linear systems Ax = b.
-//! The CGS algorithm is based on the BiConjugate Gradient (BiCG) method, but squares the residual
-//! polynomials to achieve faster convergence in some cases. It is suitable for large, sparse, nonsymmetric
-//! systems, but may suffer from breakdowns or instability for ill-conditioned problems.
-//!
-//! # References
-//! - Saad, Y. (2003). Iterative Methods for Sparse Linear Systems, 2nd Edition. SIAM. §7.2
-//! - https://en.wikipedia.org/wiki/Conjugate_gradient_squared_method
-
-use crate::core::traits::{InnerProduct, MatVec};
-use crate::solver::legacy::LinearSolver;
-use crate::utils::convergence::{Convergence, SolveStats};
+use crate::context::ksp_context::Workspace;
 use crate::error::KError;
-#[cfg(feature = "logging")]
-use log::trace;
+use crate::matrix::op::LinOp;
+use crate::parallel::UniverseComm;
+use crate::preconditioner::{PcSide, Preconditioner};
+use crate::solver::LinearSolver;
+use crate::utils::convergence::{ConvergedReason, SolveStats};
+
 #[cfg(feature = "logging")]
 use crate::utils::profiling::StageGuard;
+#[cfg(feature = "logging")]
+use log::trace;
 
-/// CGS solver struct, holding convergence parameters.
-///
-/// # Type Parameters
-/// * `T` - Scalar type (e.g., f32, f64)
-pub struct CgsSolver<T> {
-    /// Convergence criteria (multi-threshold, max iterations)
-    pub conv: Convergence<T>,
+pub struct CgsSolver {
+    rtol: f64,
+    atol: f64,
+    dtol: f64,
+    maxits: usize,
 }
 
-impl<T> CgsSolver<T>
-where T: num_traits::Float + Clone + Send + Sync + std::fmt::Debug + std::fmt::LowerExp,
-{
-    /// Create a new CGS solver with given tolerance and maximum iterations.
-    ///
-    /// # Arguments
-    /// * `rtol` - Relative residual tolerance for convergence
-    /// * `max_iters` - Maximum number of iterations
-    pub fn new(rtol: T, max_iters: usize) -> Self {
-        let atol = num_traits::cast::<f64, T>(1e-12).unwrap();
-        let dtol = num_traits::cast::<f64, T>(1e3).unwrap();
-        Self {
-            conv: Convergence {
-                rtol,
-                atol,
-                dtol,
-                max_iters,
-            },
+impl CgsSolver {
+    pub fn new(rtol: f64, maxits: usize) -> Self {
+        Self { rtol, atol: 1e-12, dtol: 1e3, maxits }
+    }
+
+    #[inline] fn dot(x: &[f64], y: &[f64], _comm: &UniverseComm) -> f64 {
+        x.iter().zip(y).map(|(a,b)| a*b).sum()
+    }
+    #[inline] fn nrm2(x: &[f64], comm: &UniverseComm) -> f64 { Self::dot(x,x,comm).sqrt() }
+
+    #[inline]
+    fn take_or_resize(buf: &mut Vec<f64>, n: usize) {
+        if buf.len() != n { buf.resize(n, 0.0); }
+    }
+
+    /// Acquire all CGS work vectors from `Workspace` (no steady-state allocs).
+    /// We use:
+    ///   tmp1 = r, tmp2 = v
+    ///   q[0] = u, q[1] = p, q[2] = q, q[3] = upq, q[4] = w (A*(u+q))
+    fn acquire<'a>(n: usize, work: Option<&'a mut Workspace>)
+      -> (&'a mut [f64], &'a mut [f64], &'a mut [f64], &'a mut [f64], &'a mut [f64],
+          &'a mut [f64], &'a mut [f64]) {
+        if let Some(wk) = work {
+            Self::take_or_resize(&mut wk.tmp1, n); // r
+            Self::take_or_resize(&mut wk.tmp2, n); // v
+            while wk.q.len() < 5 { wk.q.push(Vec::new()); }
+            for k in 0..5 { Self::take_or_resize(&mut wk.q[k], n); }
+            let r = &mut wk.tmp1[..];
+            let v = &mut wk.tmp2[..];
+            let (u, p, q, upq, w) = {
+                let (q0, rest) = wk.q.split_at_mut(1);
+                let (q1, rest) = rest.split_at_mut(1);
+                let (q2, rest) = rest.split_at_mut(1);
+                let (q3, q4) = rest.split_at_mut(1);
+                (
+                    &mut q0[0][..],
+                    &mut q1[0][..],
+                    &mut q2[0][..],
+                    &mut q3[0][..],
+                    &mut q4[0][..],
+                )
+            };
+            (r, v, u, p, q, upq, w)
+        } else {
+            // Fallback for unit tests when no Workspace supplied
+            let mk = |n| -> &'static mut [f64] { Box::leak(vec![0.0; n].into_boxed_slice()) };
+            (mk(n), mk(n), mk(n), mk(n), mk(n), mk(n), mk(n))
         }
     }
 }
 
-impl<M: ?Sized, V, T> LinearSolver<M, V> for CgsSolver<T>
-where
-    M: MatVec<V>,
-    (): InnerProduct<V, Scalar = T>,
-    V: AsMut<[T]> + AsRef<[T]> + From<Vec<T>> + Clone,
-    T: num_traits::Float + Clone + From<f64> + std::fmt::Debug + std::ops::AddAssign + std::ops::SubAssign + Send + Sync + std::fmt::LowerExp,
-{
+impl LinearSolver for CgsSolver {
     type Error = KError;
-    type Scalar = T;
 
-    /// Solve the linear system Ax = b using the CGS algorithm.
-    ///
-    /// # Arguments
-    /// * `a` - System matrix
-    /// * `pc` - Optional preconditioner (currently unused)
-    /// * `b` - Right-hand side vector
-    /// * `x` - Initial guess (input/output)
-    /// * `comm` - Communication object for parallel computation
-    /// * `monitors` - Optional monitor callbacks for iteration progress
-    /// * `work` - Optional workspace for reusable allocations
-    ///
-    /// Returns convergence statistics and the solution vector.
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any { self }
+
+    fn setup_workspace(&mut self, work: &mut Workspace) {
+        if work.q.len() < 5 { work.q.resize(5, Vec::new()); }
+    }
+
     fn solve(
         &mut self,
-        a: &M,
-        pc: Option<&(dyn crate::preconditioner::legacy::Preconditioner<M, V> + '_)>,
-        b: &V,
-        x: &mut V,
-        comm: &crate::parallel::UniverseComm,
-        monitors: Option<&[Box<dyn Fn(usize, Self::Scalar) + Send + Sync>]>,
-        work: Option<&mut crate::context::ksp_context::Workspace>,
-    ) -> Result<SolveStats<T>, KError> {
-        // Check runtime profiling and monitoring flags
-        let use_monitors = monitors.is_some();
-        let _has_workspace = work.is_some();
+        a: &dyn LinOp<S = f64>,
+        pc: Option<&dyn Preconditioner>,
+        b: &[f64],
+        x: &mut [f64],
+        comm: &UniverseComm,
+        monitors: Option<&[Box<dyn Fn(usize, f64) + Send + Sync>]>,
+        work: Option<&mut Workspace>,
+    ) -> Result<SolveStats<f64>, Self::Error> {
+        #[cfg(feature="logging")]
+        let _guard = StageGuard::new("CGS");
 
-        #[cfg(feature = "logging")]
-        let _guard = StageGuard::new("CGSSolve");
-        #[cfg(feature = "logging")]
-        trace!("Starting CGS solve, monitoring: {}, workspace: {}", use_monitors, _has_workspace);
+        let (m, n) = a.dims();
+        if m != n { return Err(KError::InvalidInput("CGS requires a square operator".into())); }
+        if b.len() != n || x.len() != n { return Err(KError::InvalidInput("CGS: vector length mismatch".into())); }
 
-        let _ = pc; // CGS does not use preconditioner (yet)
-        let n = b.as_ref().len();
-        let mut xk = x.as_ref().to_vec();
-        let ip = ();
-        
-        // Compute initial residual r = b - A x
-        let mut r = {
-            #[cfg(feature = "logging")]
-            let _matvec_stage = StageGuard::new("CGSMatVec");
-            let mut tmp = V::from(vec![T::zero(); n]);
-            a.matvec(&V::from(xk.clone()), &mut tmp);
-            let r_vec = b.as_ref().iter().zip(tmp.as_ref()).map(|(&bi, &axi)| bi - axi).collect::<Vec<_>>();
-            V::from(r_vec)
-        };
-        
-        let r_tld = r.clone(); // Shadow residual (fixed for all iterations)
-        let mut p = r.clone(); // Search direction
-        let mut q = V::from(vec![T::zero(); n]); // Auxiliary vector
-        let mut u = V::from(vec![T::zero(); n]); // Auxiliary vector
-        let mut rho = ip.dot(&r_tld, &r, comm); // BiCG-like scalar
-        let mut rho_old = T::zero();
-        let res0 = ip.norm(&r, comm); // Initial residual norm
-        
-        let mut stats = SolveStats {
-            iterations: 0,
-            final_residual: res0,
-            reason: crate::utils::convergence::ConvergedReason::Continued,
-        };
+        let (r, v, u, p, q, upq, w) = Self::acquire(n, work);
+        let mut r_tld = vec![0.0; n]; // shadow residual (fixed)
 
-        // Invoke monitors for iteration 0
-        if use_monitors {
-            for monitor in monitors.unwrap() {
-                monitor(0, res0);
-            }
+        let _ = pc; // unused for now
+
+        // r = b - A x
+        if x.iter().any(|&xi| xi != 0.0) {
+            a.matvec(x, v);
+            for i in 0..n { r[i] = b[i] - v[i]; }
+        } else {
+            r.copy_from_slice(b);
+        }
+        r_tld.copy_from_slice(r);
+
+        // initial values
+        let bnorm = Self::nrm2(b, comm).max(1e-32);
+        let mut rnorm = Self::nrm2(r, comm);
+
+        if let Some(ms) = monitors {
+            for m in ms { m(0, rnorm); }
+        }
+        // quick exit
+        let thr = self.atol.max(self.rtol * bnorm);
+        if rnorm <= thr {
+            return Ok(SolveStats {
+                iterations: 0,
+                final_residual: rnorm,
+                reason: if rnorm <= self.atol { ConvergedReason::ConvergedAtol }
+                        else                  { ConvergedReason::ConvergedRtol },
+            });
         }
 
-        #[cfg(feature = "logging")]
-        trace!("CGS initial residual: {:?}", res0);
+        // CGS parameters
+        let mut rho_old = 0.0f64;
+        let mut rho = Self::dot(&r_tld, r, comm); // (r~, r)
+        if rho.abs() <= f64::EPSILON {
+            return Err(KError::IndefiniteMatrix); // classic breakdown
+        }
 
-        for i in 1..=self.conv.max_iters {
-            #[cfg(feature = "logging")]
-            let _iter_stage = StageGuard::new("CGSIteration");
-            
-            #[cfg(feature = "logging")]
-            trace!("CGS iteration {}", i);
+        // First iter: u = r, p = u
+        u.copy_from_slice(r);
+        p.copy_from_slice(u);
 
-            // Check for breakdown (division by zero)
-            if rho.abs() < T::epsilon() {
-                #[cfg(feature = "logging")]
-                trace!("CGS breakdown detected at iteration {}", i);
-                stats.iterations = i;
-                stats.final_residual = ip.norm(&r, comm);
-                stats.reason = crate::utils::convergence::ConvergedReason::DivergedDtol;
-                return Err(KError::IndefiniteMatrix);
-            }
-            
-            if i == 1 {
-                // First iteration: initialize u and p
-                u = r.clone();
-                p = u.clone();
-            } else {
-                #[cfg(feature = "logging")]
-                let _update_stage = StageGuard::new("CGSUpdate");
-                let beta = rho / rho_old;
-                // Save q and p from previous iteration
-                let q_old = q.clone();
-                let p_old = p.clone();
-                // u = r + beta * q_old
-                for (u_j, (r_j, qj_old)) in u.as_mut().iter_mut().zip(r.as_ref().iter().zip(q_old.as_ref())) {
-                    *u_j = *r_j + beta * *qj_old;
-                }
-                // p = u + beta * (q_old + beta * p_old)
-                for ((p_j, u_j), (qj_old, p_oldj)) in p.as_mut().iter_mut().zip(u.as_ref()).zip(q_old.as_ref().iter().zip(p_old.as_ref())) {
-                    *p_j = *u_j + beta * (*qj_old + beta * *p_oldj);
-                }
-            }
-            
+        let mut iters = 0usize;
+        for k in 1..=self.maxits {
+            iters = k;
+
             // v = A p
-            let v = {
-                #[cfg(feature = "logging")]
-                let _matvec_stage = StageGuard::new("CGSMatVec");
-                let mut v_tmp = V::from(vec![T::zero(); n]);
-                a.matvec(&p, &mut v_tmp);
-                v_tmp
-            };
-            
-            // alpha = rho / (r_tld, v)
-            let alpha = {
-                #[cfg(feature = "logging")]
-                let _dot_stage = StageGuard::new("CGSDotProduct");
-                rho / ip.dot(&r_tld, &v, comm)
-            };
-            
-            // q = u - alpha * v
-            {
-                #[cfg(feature = "logging")]
-                let _axpy_stage = StageGuard::new("CGSAxpy");
-                for (q_j, (u_j, v_j)) in q.as_mut().iter_mut().zip(u.as_ref().iter().zip(v.as_ref())) {
-                    *q_j = *u_j - alpha * *v_j;
-                }
+            a.matvec(p, v);
+
+            let sigma = Self::dot(&r_tld, v, comm); // (r~, v)
+            if sigma.abs() <= f64::EPSILON {
+                return Err(KError::IndefiniteMatrix); // breakdown
             }
-            
-            // x = x + alpha * (u + q)
-            {
-                #[cfg(feature = "logging")]
-                let _axpy_stage = StageGuard::new("CGSAxpy");
-                for (xj, (u_j, q_j)) in xk.iter_mut().zip(u.as_ref().iter().zip(q.as_ref())) {
-                    *xj += alpha * (*u_j + *q_j);
-                }
-            }
-            
-            // r = r - alpha * A(u + q)
-            {
-                #[cfg(feature = "logging")]
-                let _matvec_stage = StageGuard::new("CGSMatVec");
-                let mut upq = u.clone();
-                for (upq_i, q_i) in upq.as_mut().iter_mut().zip(q.as_ref()) {
-                    *upq_i += *q_i;
-                }
-                let mut w = V::from(vec![T::zero(); n]);
-                a.matvec(&upq, &mut w);
-                for (rj, wj) in r.as_mut().iter_mut().zip(w.as_ref()) {
-                    *rj = *rj - alpha * *wj;
-                }
-            }
-            
-            let res_norm = {
-                #[cfg(feature = "logging")]
-                let _norm_stage = StageGuard::new("CGSNorm");
-                ip.norm(&r, comm)
-            };
-            
-            // Invoke monitors for current iteration
-            if use_monitors {
-                for monitor in monitors.unwrap() {
-                    monitor(i, res_norm);
-                }
+            let alpha = rho / sigma;
+
+            // q = u - alpha v
+            for i in 0..n { q[i] = u[i] - alpha * v[i]; }
+
+            // x += alpha * (u + q)
+            for i in 0..n { x[i] += alpha * (u[i] + q[i]); }
+
+            // r -= alpha * A (u + q)
+            for i in 0..n { upq[i] = u[i] + q[i]; }
+            a.matvec(upq, w);
+            for i in 0..n { r[i] -= alpha * w[i]; }
+
+            rnorm = Self::nrm2(r, comm);
+            if let Some(ms) = monitors {
+                for m in ms { m(k, rnorm); }
             }
 
-            #[cfg(feature = "logging")]
-            trace!("CGS iteration {}: residual = {:?}", i, res_norm);
-            
-            // Check convergence using new interface
-            let (reason, new_stats) = self.conv.check(res_norm, res0, i);
-            stats = new_stats;
-            if reason != crate::utils::convergence::ConvergedReason::Continued {
-                *x = V::from(xk.clone());
-                
-                #[cfg(feature = "logging")]
-                trace!("CGS converged after {} iterations: {:?}", i, reason);
-                return Ok(stats);
+            // convergence / divergence tests
+            if rnorm <= thr {
+                return Ok(SolveStats {
+                    iterations: k,
+                    final_residual: rnorm,
+                    reason: if rnorm <= self.atol { ConvergedReason::ConvergedAtol }
+                            else                  { ConvergedReason::ConvergedRtol },
+                });
             }
-            
+            if !rnorm.is_finite() || rnorm >= self.dtol {
+                return Ok(SolveStats {
+                    iterations: k,
+                    final_residual: rnorm,
+                    reason: ConvergedReason::DivergedDtol,
+                });
+            }
+
+            // rho, beta updates
             rho_old = rho;
-            rho = ip.dot(&r_tld, &r, comm);
-        }
-        
-        *x = V::from(xk);
-        
-        #[cfg(feature = "logging")]
-        trace!("CGS solve completed: {} iterations, final residual: {:?}", 
-               stats.iterations, stats.final_residual);
-        
-        Ok(stats)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::traits::MatVec;
-
-    /// Simple dense matrix for testing
-    #[derive(Clone)]
-    struct DenseMat {
-        data: Vec<Vec<f64>>,
-    }
-    impl MatVec<Vec<f64>> for DenseMat {
-        /// Matrix-vector multiplication: y = A x
-        fn matvec(&self, x: &Vec<f64>, y: &mut Vec<f64>) {
-            for (i, row) in self.data.iter().enumerate() {
-                y[i] = row.iter().zip(x.iter()).map(|(a, b)| a * b).sum();
+            rho = Self::dot(&r_tld, r, comm);
+            if rho.abs() <= f64::EPSILON {
+                return Err(KError::IndefiniteMatrix); // breakdown
             }
-        }
-    }
+            let beta = rho / rho_old;
 
-    #[test]
-    fn cgs_solves_large_well_conditioned_nonsym() {
-        // 5x5 diagonally dominant, non-symmetric system
-        // A = [[10,2,0,0,0],[3,15,4,0,0],[0,-2,8,1,0],[0,0,1,7,3],[0,0,0,2,12]]
-        // x_true = [1,2,3,4,5]
-        // b = A * x_true
-        let a = DenseMat {
-            data: vec![
-                vec![10.0, 2.0, 0.0, 0.0, 0.0],
-                vec![3.0, 15.0, 4.0, 0.0, 0.0],
-                vec![0.0, -2.0, 8.0, 1.0, 0.0],
-                vec![0.0, 0.0, 1.0, 7.0, 3.0],
-                vec![0.0, 0.0, 0.0, 2.0, 12.0],
-            ]
-        };
-        let x_true = vec![1.0, 2.0, 3.0, 4.0, 5.0];
-        let b = {
-            let mut b = vec![0.0; 5];
-            a.matvec(&x_true, &mut b);
-            b
-        };
-        let mut x = vec![0.0; 5];
-        let mut solver = CgsSolver::new(1e-10, 200);
-        let stats = solver.solve(&a, None, &b, &mut x, &crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm), None, None).unwrap();
-        let tol = 1e-6;
-        for (xi, ei) in x.iter().zip(x_true.iter()) {
-            assert!((xi - ei).abs() <= tol, "xi = {:.6}, expected = {:.6}", xi, ei);
+            // u = r + beta q
+            for i in 0..n { u[i] = r[i] + beta * q[i]; }
+            // p = u + beta (q + beta p)
+            for i in 0..n { p[i] = u[i] + beta * (q[i] + beta * p[i]); }
         }
-        assert!(matches!(stats.reason,
-            crate::utils::convergence::ConvergedReason::ConvergedRtol |
-            crate::utils::convergence::ConvergedReason::ConvergedAtol),
-            "CGS did not report Converged reason");
+
+        Ok(SolveStats { iterations: iters, final_residual: rnorm, reason: ConvergedReason::DivergedMaxIts })
     }
 }
+

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -177,6 +177,8 @@ pub mod gmres;
 pub use gmres::GmresSolver;
 pub mod bicgstab;
 pub use bicgstab::BiCgStabSolver;
+pub mod cgs;
+pub use cgs::CgsSolver;
 pub mod pcg;
 pub use pcg::PcgSolver;
 pub mod minres;

--- a/tests/cgs_linop.rs
+++ b/tests/cgs_linop.rs
@@ -1,0 +1,69 @@
+use std::any::Any;
+use std::sync::Arc;
+
+use kryst::context::ksp_context::{KspContext, SolverType};
+use kryst::matrix::op::LinOp;
+
+struct DenseOp {
+    a: Vec<Vec<f64>>,
+}
+
+impl LinOp for DenseOp {
+    type S = f64;
+
+    fn dims(&self) -> (usize, usize) { (self.a.len(), self.a[0].len()) }
+
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        let (m, n) = self.dims();
+        assert_eq!(x.len(), n);
+        assert_eq!(y.len(), m);
+        for i in 0..m {
+            let mut acc = 0.0;
+            for j in 0..n {
+                acc += self.a[i][j] * x[j];
+            }
+            y[i] = acc;
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any { self }
+}
+
+#[test]
+fn cgs_solves_dd_nonsymmetric() {
+    // A 5x5 diagonally dominant non-symmetric matrix (well-conditioned)
+    let a = DenseOp {
+        a: vec![
+            vec![10.0, 2.0, 0.0, 0.0, 0.0],
+            vec![3.0, 15.0, 4.0, 0.0, 0.0],
+            vec![0.0, -2.0, 8.0, 1.0, 0.0],
+            vec![0.0, 0.0, 1.0, 7.0, 3.0],
+            vec![0.0, 0.0, 0.0, 2.0, 12.0],
+        ],
+    };
+    let (m, n) = a.dims();
+    assert_eq!(m, n);
+    let x_true = vec![1.0, 2.0, 3.0, 4.0, 5.0];
+
+    let mut b = vec![0.0; n];
+    a.matvec(&x_true, &mut b);
+
+    let amat: Arc<dyn LinOp<S = f64>> = Arc::new(a);
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Cgs).unwrap();
+    ksp.set_operators(amat.clone(), Some(amat));
+
+    let mut x = vec![0.0; n];
+    let stats = ksp.solve(&b, &mut x).unwrap();
+
+    let tol = 1e-6;
+    for (xi, ei) in x.iter().zip(x_true.iter()) {
+        assert!((xi - ei).abs() <= tol, "xi = {:.6}, expected = {:.6}", xi, ei);
+    }
+    assert!(matches!(
+        stats.reason,
+        kryst::utils::convergence::ConvergedReason::ConvergedRtol
+            | kryst::utils::convergence::ConvergedReason::ConvergedAtol
+    ));
+}
+


### PR DESCRIPTION
## Summary
- implement object-safe CGS solver operating directly on LinOp and slices
- expose CGS in solver module and KSP context
- add LinOp-based CGS unit test

## Testing
- `cargo test --tests` *(fails: no method named `solve` found for struct `CgSolver` in tests/preconditioner_integration.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68a94d2a9c80832997f1fb091033a00c