### PR TITLE
test: update CGS solver tests

### DIFF
--- a/tests/preconditioner_integration.rs
+++ b/tests/preconditioner_integration.rs
@@ -8,7 +8,8 @@
 use kryst::preconditioner::{Jacobi, Ilu0, PcSide};
 use kryst::preconditioner::legacy::Preconditioner;
 use kryst::solver::{CgSolver, GmresSolver};
-use kryst::solver::legacy::LinearSolver;
+use kryst::LinearSolver;
+use kryst::solver::legacy::LinearSolver as LegacyLinearSolver;
 use kryst::solver::gmres::Preconditioning;
 use faer::Mat;
 

--- a/tests/solver_iterative.rs
+++ b/tests/solver_iterative.rs
@@ -7,8 +7,8 @@
 
 use faer::Mat;
 use faer::linalg::solvers::SolveCore;
-use kryst::solver::{CgSolver, GmresSolver};
-use kryst::solver::legacy::LinearSolver;
+use kryst::solver::{CgSolver, GmresSolver, MatSolverAdapter};
+use kryst::LinearSolver;
 use rand::Rng;
 use approx::assert_abs_diff_eq;
 
@@ -65,7 +65,7 @@ fn gmres_vs_direct_on_nonsymmetric() {
     let a = Mat::from_fn(n, n, |i, j| data[j * n + i]);
     let b: Vec<f64> = (0..n).map(|_| rng.r#gen()).collect();
     let mut x_gmres = vec![0.0; n];
-    let mut solver = GmresSolver::new(100, 1e-8, 1000);
+    let mut solver = MatSolverAdapter::new(GmresSolver::new(100, 1e-8, 1000));
     let stats = solver.solve(&a, None, &b, &mut x_gmres, &comm, None, None).unwrap();
     assert!(matches!(stats.reason, kryst::utils::convergence::ConvergedReason::ConvergedRtol | kryst::utils::convergence::ConvergedReason::ConvergedAtol));
     // Direct solve using QR decomposition


### PR DESCRIPTION
## Summary
- use MatSolverAdapter with GMRES in iterative solver tests
- import new LinearSolver trait in preconditioner integration tests

## Testing
- `cargo test --tests` *(fails: direct_pc::lu_preonly_succeeds, direct_pc::qr_preonly_succeeds, preconditioner_integration::pcg_with_jacobi)*
- `cargo test --test solver_iterative`
- `cargo test --test preconditioner_sor`
- `cargo test --test preconditioner_integration` *(fails: pcg_with_jacobi)*

------
https://chatgpt.com/codex/tasks/task_e_68a95123e3148329852298830b01663d