### PR TITLE
Add baseline PCA-GMRES solver

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -6,7 +6,7 @@ use crate::parallel::UniverseComm;
 use crate::preconditioner::{PcReusePolicy, PcSide, Preconditioner};
 use crate::solver::{
     BiCgStabSolver, CgSolver, CgnrSolver, CgsSolver, FgmresSolver, GmresSolver, LinearSolver,
-    MatSolverAdapter, MinresSolver, PcgSolver,
+    MatSolverAdapter, MinresSolver, PcgSolver, PcaGmresSolver,
 };
 use crate::utils::convergence::{ConvergedReason, SolveStats};
 use std::str::FromStr;
@@ -49,6 +49,7 @@ pub enum SolverType {
     Cgs,
     Pcg,
     Minres,
+    PcaGmres,
     Preonly,
 }
 
@@ -65,6 +66,7 @@ impl FromStr for SolverType {
             "cgs" => Ok(SolverType::Cgs),
             "pcg" => Ok(SolverType::Pcg),
             "minres" => Ok(SolverType::Minres),
+            "pca_gmres" | "pcagmres" => Ok(SolverType::PcaGmres),
             "preonly" => Ok(SolverType::Preonly),
             other => Err(KError::UnrecognizedSolverType(other.to_string())),
         }
@@ -139,6 +141,11 @@ impl KspContext {
                 self.rtol,
                 self.maxits,
             ))),
+            SolverType::PcaGmres => {
+                let mut s = PcaGmresSolver::new(self.restart, 1, 1, self.rtol, self.maxits);
+                s.pc_mode = crate::solver::PcaPcMode::Left;
+                Box::new(s)
+            }
             SolverType::Preonly => {
                 return Err(KError::SolveError("Preonly solver not available".into()));
             }

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -193,3 +193,6 @@ pub mod dense_lu;
 pub mod dense_qr;
 pub mod superlu_dist;
 pub use superlu_dist::SuperLuDistSolver;
+
+pub mod pca_gmres;
+pub use pca_gmres::{PcaGmresSolver, PcaPcMode};

--- a/src/solver/pca_gmres.rs
+++ b/src/solver/pca_gmres.rs
@@ -1,579 +1,417 @@
-//! Pipelined, Communication-Avoiding GMRES for Kryst
-//!
-//! This module implements a pipelined, communication-avoiding GMRES (PCA-GMRES) solver with block orthogonalization
-//! and a pipelining skeleton. The algorithm is designed for high-performance distributed and parallel environments,
-//! reducing communication costs by overlapping computation and communication, and by using block Gram-Schmidt
-//! orthogonalization. The implementation supports left/right/no preconditioning, block size and pipeline depth control,
-//! and optional drop tolerance for partial change-of-basis.
-//!
-//! # Features
-//! - Block classical Gram-Schmidt orthogonalization
-//! - Pipelined Krylov subspace construction (skeleton)
-//! - Optional drop tolerance for partial change-of-basis
-//! - Left, right, or no preconditioning
-//! - Parallelization via Rayon (if enabled)
-//! - MPI all-reduce support (if enabled)
-//!
-//! # References
-//! - Hoemmen, M. (2010). Communication-Avoiding Krylov Subspace Methods. PhD thesis, UC Berkeley.
-//! - Ghysels, P., & Vanroose, W. (2014). Hiding global communication latency in the GMRES algorithm on massively parallel machines. SIAM J. Sci. Comput.
-//! - https://github.com/berkeleylab/SLATE/blob/develop/src/ca_gmres.cc
+//! PCA-GMRES (baseline) over &dyn LinOp<f64> with left/right/no preconditioning.
+//! Block size and pipeline depth are accepted but currently executed with s=1,
+//! while keeping the data layout and hooks to enable CA/pipelining next.
 
-use crate::core::traits::{InnerProduct, MatVec};
-use crate::solver::legacy::LinearSolver;
-use crate::utils::convergence::{Convergence, SolveStats};
+use crate::context::ksp_context::Workspace;
 use crate::error::KError;
+use crate::matrix::op::LinOp;
 use crate::parallel::UniverseComm;
-#[cfg(feature = "mpi")]
-use crate::parallel::Comm;
+use crate::preconditioner::{PcSide, Preconditioner};
+use crate::solver::LinearSolver;
+use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 
-#[cfg(feature = "logging")]
-use log::trace;
-#[cfg(feature = "logging")]
-use crate::utils::profiling::StageGuard;
-
-/// Preconditioning modes for PCA-GMRES
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum Preconditioning { None, Left, Right }
-
-/// Pipelined Communication-Avoiding GMRES solver
-///
-/// # Type Parameters
-/// * `T` - Scalar type (e.g., f32, f64)
-pub struct PcaGmresSolver<T> {
-    /// Restart length (m): number of Arnoldi vectors before restart
-    pub restart: usize,
-    /// Pipeline depth (ℓ): number of steps overlapped in the pipeline
-    pub pipeline_depth: usize,
-    /// Block size for communication-avoiding orthogonalization (s)
-    pub block_size: usize,
-    /// Drop tolerance for partial change-of-basis (τ)
-    pub tau: Option<T>,
-    /// Convergence criteria (multi-threshold, max iterations)
-    pub conv: Convergence<T>,
-    /// Preconditioning mode (none, left, right)
-    pub preconditioning: Preconditioning,
+pub enum PcaPcMode {
+    None,
+    Left,
+    Right,
 }
 
-impl<T: num_traits::Float + Send + Sync + From<f64> + std::ops::SubAssign + std::ops::MulAssign + num_traits::ToPrimitive> PcaGmresSolver<T> {
-    /// Create a new PCA-GMRES solver with restart, pipeline depth, block size, tolerance, and max iterations.
-    pub fn new(restart: usize, pipeline_depth: usize, block_size: usize, rtol: T, max_iters: usize) -> Self {
-        let atol = <T as From<f64>>::from(1e-12);
-        let dtol = <T as From<f64>>::from(1e3);
+pub struct PcaGmresSolver {
+    pub restart: usize,
+    pub pipeline_depth: usize, // reserved hook; baseline uses 1
+    pub block_size: usize,     // reserved hook; baseline uses 1
+    pub conv: Convergence<f64>,
+    pub pc_mode: PcaPcMode,
+    /// Choose MGS for better robustness; switch to CGS when s>1 (future)
+    pub modified_gs: bool,
+    /// Happy breakdown tolerance
+    pub haptol: f64,
+}
+
+impl PcaGmresSolver {
+    pub fn new(
+        restart: usize,
+        pipeline_depth: usize,
+        block_size: usize,
+        rtol: f64,
+        maxits: usize,
+    ) -> Self {
         Self {
-            restart,
+            restart: restart.max(1),
             pipeline_depth,
             block_size,
-            tau: None,
-            conv: Convergence {
-                rtol,
-                atol,
-                dtol,
-                max_iters,
-            },
-            preconditioning: Preconditioning::Left,
+            conv: Convergence { rtol, atol: 1e-12, dtol: 1e3, max_iters: maxits },
+            pc_mode: PcaPcMode::Left, // matches former default
+            modified_gs: true,
+            haptol: 1e-12,
         }
     }
 
-    /// Set preconditioning mode (none, left, or right)
-    pub fn with_preconditioning(mut self, mode: Preconditioning) -> Self {
-        self.preconditioning = mode;
-        self
+    #[inline]
+    fn dot(x: &[f64], y: &[f64]) -> f64 {
+        x.iter().zip(y).map(|(a, b)| a * b).sum()
+    }
+    #[inline]
+    fn nrm2(x: &[f64]) -> f64 {
+        x.iter().map(|v| v * v).sum::<f64>().sqrt()
     }
 
-    /// Set partial change-of-basis drop tolerance (for s-step variants)
-    pub fn with_tau(mut self, tau: T) -> Self {
-        self.tau = Some(tau);
-        self
-    }
-
-    /// Setup workspace for the PCA-GMRES solver.
-    ///
-    /// This method configures workspace buffers for efficient computation,
-    /// including Krylov basis vectors, Hessenberg matrix, and temporary vectors.
-    pub fn setup_workspace(&mut self, work: &mut crate::context::ksp_context::Workspace, n: usize) {
-        // Set workspace dimensions for validation
-        work.n = n;
-        work.restart = self.restart;
-        
-        // Ensure workspace has enough q vectors for Krylov basis (restart + 1 vectors)
-        let needed_q = self.restart + 1;
-        while work.q.len() < needed_q {
-            work.q.push(vec![0.0; n]);
+    fn ensure_workspace(&self, w: &mut Workspace, n: usize) {
+        let m = self.restart;
+        // Need: q for basis vectors. For RIGHT PC we also store Z (preconditioned directions).
+        // We re-use q as: V: [0..=m], Z: [m+1 .. m+m] (m slots)
+        let need_q = if matches!(self.pc_mode, PcaPcMode::Right) {
+            2 * m + 1
+        } else {
+            m + 1
+        };
+        if w.q.len() < need_q {
+            w.q.resize(need_q, Vec::new());
         }
-        
-        // Resize existing q vectors to match problem size
-        for q_vec in &mut work.q[..needed_q] {
-            q_vec.resize(n, 0.0);
-        }
-        
-        // Setup Hessenberg matrix H: (restart+1) × restart for PCA-GMRES
-        work.h.resize(self.restart + 1, vec![]);
-        for row in &mut work.h {
-            row.resize(self.restart, 0.0);
-        }
-        
-        // Setup Givens rotation storage
-        work.cs.resize(self.restart, 0.0);
-        work.sn.resize(self.restart, 0.0);
-        
-        // Setup residual vector g for least-squares subproblem
-        work.g.resize(self.restart + 1, 0.0);
-        
-        // Setup temporary vectors for matrix-vector operations
-        work.tmp1.resize(n, 0.0);
-        work.tmp2.resize(n, 0.0);
-        work.tmp3.resize(n, 0.0);
-        work.tmp4.resize(n, 0.0);
-        
-        // PCA-GMRES specific: ensure z vectors for preconditioned basis if needed
-        if matches!(self.preconditioning, Preconditioning::Right) {
-            while work.z.len() < self.restart {
-                work.z.push(vec![0.0; n]);
+        for q in &mut w.q {
+            if q.len() != n {
+                q.resize(n, 0.0);
             }
-            for z_vec in &mut work.z[..self.restart] {
-                z_vec.resize(n, 0.0);
+        }
+
+        // H: (m+1) x m
+        if w.h.len() < m + 1 {
+            w.h.resize(m + 1, Vec::new());
+        }
+        for r in &mut w.h {
+            if r.len() < m {
+                r.resize(m, 0.0);
             }
+        }
+
+        if w.tmp1.len() != n {
+            w.tmp1.resize(n, 0.0);
+        }
+        if w.tmp2.len() != n {
+            w.tmp2.resize(n, 0.0);
+        }
+        if w.cs.len() < m {
+            w.cs.resize(m, 0.0);
+        }
+        if w.sn.len() < m {
+            w.sn.resize(m, 0.0);
+        }
+        if w.g.len() < m + 1 {
+            w.g.resize(m + 1, 0.0);
+        }
+    }
+
+    fn apply_givens(hij: &mut f64, hij1: &mut f64, c: f64, s: f64) {
+        let t = c * (*hij) + s * (*hij1);
+        *hij1 = -s * (*hij) + c * (*hij1);
+        *hij = t;
+    }
+    fn givens(a: f64, b: f64) -> (f64, f64) {
+        if b == 0.0 {
+            (1.0, 0.0)
+        } else {
+            let r = (a * a + b * b).sqrt();
+            (a / r, b / r)
         }
     }
 }
 
-impl<M: ?Sized, V, T> LinearSolver<M, V> for PcaGmresSolver<T>
-where
-    M: MatVec<V> + Sync,
-    (): InnerProduct<V, Scalar = T>,
-    V: AsMut<[T]> + AsRef<[T]> + From<Vec<T>> + Clone + Send + Sync,
-    T: num_traits::Float + Send + Sync + From<f64> + Clone + std::ops::SubAssign + std::ops::MulAssign + std::fmt::Debug + std::fmt::LowerExp + num_traits::ToPrimitive,
-{
+impl LinearSolver for PcaGmresSolver {
     type Error = KError;
-    type Scalar = T;
 
-    /// Solve the linear system Ax = b using pipelined, communication-avoiding GMRES.
-    ///
-    /// # Arguments
-    /// * `a` - Matrix implementing `MatVec`
-    /// * `pc` - Optional preconditioner (left or right)
-    /// * `b` - Right-hand side vector
-    /// * `x` - On input: initial guess; on output: solution vector
-    /// * `comm` - Communicator for parallel operations
-    /// * `monitors` - Optional external monitors for iteration callbacks
-    /// * `work` - Optional workspace for buffer reuse
-    ///
-    /// # Returns
-    /// * `Ok(SolveStats)` if converged or max iterations reached
-    /// * `Err(KError)` on error
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn setup_workspace(&mut self, w: &mut Workspace) {
+        // Shapes fixed at solve-time once n is known; reserve outlines now.
+        let m = self.restart;
+        if w.q.len() < m + 1 {
+            w.q.resize(m + 1, Vec::new());
+        }
+        if w.h.len() < m + 1 {
+            w.h.resize(m + 1, Vec::new());
+        }
+        if w.cs.len() < m {
+            w.cs.resize(m, 0.0);
+        }
+        if w.sn.len() < m {
+            w.sn.resize(m, 0.0);
+        }
+        if w.g.len() < m + 1 {
+            w.g.resize(m + 1, 0.0);
+        }
+    }
+
     fn solve(
         &mut self,
-        a: &M,
-        pc: Option<&(dyn crate::preconditioner::legacy::Preconditioner<M, V> + '_)>,
-        b: &V,
-        x: &mut V,
-        comm: &crate::parallel::UniverseComm,
-        monitors: Option<&[Box<dyn Fn(usize, Self::Scalar) + Send + Sync>]>,
-        mut work: Option<&mut crate::context::ksp_context::Workspace>,
-    ) -> Result<SolveStats<T>, KError> {
-        #[cfg(feature = "logging")]
-        let _guard = StageGuard::new("PcaGmresSolve");
-        
-        #[cfg(feature = "logging")]
-        trace!("Starting PCA-GMRES solve");
+        a: &dyn LinOp<S = f64>,
+        pc: Option<&dyn Preconditioner>,
+        b: &[f64],
+        x: &mut [f64],
+        _comm: &UniverseComm,
+        monitors: Option<&[Box<dyn Fn(usize, f64) + Send + Sync>]>,
+        work: Option<&mut Workspace>,
+    ) -> Result<SolveStats<f64>, Self::Error> {
+        let (m, n) = a.dims();
+        if m != n || b.len() != n || x.len() != n {
+            return Err(KError::InvalidInput(
+                "PCA-GMRES: dimension mismatch or non-square operator".into(),
+            ));
+        }
 
-        let n = b.as_ref().len();
-        let ip = ();
-        
-        // Use workspace buffers if available, otherwise allocate locally
-        let use_workspace = work.is_some();
-        
-        // Initial guess xk = 0
-        let mut xk = vec![T::zero(); n];
-        
-        // Get temporary vectors from workspace or allocate locally
-        let (mut tmp, mut r0_vec) = if let Some(workspace) = work.as_ref() {
-            // Use workspace buffers, converting from f64 to T
-            let tmp_vec: Vec<T> = workspace.tmp1.iter().map(|&x| <T as From<f64>>::from(x)).collect();
-            let r0_vec: Vec<T> = workspace.tmp2.iter().map(|&x| <T as From<f64>>::from(x)).collect();
-            (tmp_vec, r0_vec)
+        // Baseline executes with block_size = 1, pipeline_depth = 1,
+        // while keeping memory layout and hooks for later CA/pipelining.
+        let m_restart = self.restart;
+
+        // Workspace
+        let mut owned;
+        let ws = if let Some(w) = work {
+            w
         } else {
-            // Fallback to local allocation
-            (vec![T::zero(); n], vec![T::zero(); n])
+            owned = Workspace {
+                tmp1: vec![0.0; n],
+                tmp2: vec![0.0; n],
+                q: vec![vec![0.0; n]; m_restart + 1],
+                h: vec![vec![0.0; m_restart]; m_restart + 1],
+                cs: vec![0.0; m_restart],
+                sn: vec![0.0; m_restart],
+                g: vec![0.0; m_restart + 1],
+            };
+            &mut owned
         };
-        
-        // Ensure vectors are properly sized
-        tmp.resize(n, T::zero());
-        r0_vec.resize(n, T::zero());
-        // r0 = b - A xk
-        let mut tmp = V::from(tmp);
-        
-        #[cfg(feature = "logging")]
-        let _matvec_guard = StageGuard::new("PcaGmresMatVec");
-        a.matvec(&V::from(xk.clone()), &mut tmp);
-        #[cfg(feature = "logging")]
-        drop(_matvec_guard);
-        
-        r0_vec = tmp.as_ref().iter().zip(b.as_ref())
-            .map(|(&ax, &bi)| bi - ax).collect::<Vec<_>>();
-        let mut r0 = V::from(r0_vec);
-        
-        #[cfg(feature = "logging")]
-        let _norm_guard = StageGuard::new("PcaGmresNorm");
-        let mut beta = ip.norm(&r0, comm);
-        #[cfg(feature = "logging")]
-        drop(_norm_guard);
-        
-        let res0 = beta;
+        self.ensure_workspace(ws, n);
+
+        // Memory layout in ws.q:
+        //   V-basis: q[0..=m]
+        //   Z-basis (RIGHT PC only): q[m+1 .. m+m] (length m)
+        let v_off = 0usize;
+        let z_off = m_restart + 1;
+
+        // r = b - A x
+        a.matvec(x, &mut ws.tmp1);
+        for i in 0..n {
+            ws.tmp1[i] = b[i] - ws.tmp1[i];
+        }
+        let mut beta0 = Self::nrm2(&ws.tmp1);
+        let bnorm = Self::nrm2(b).max(1e-32);
+        let thr = self.conv.atol.max(self.conv.rtol * bnorm);
+
+        // Initialize v0
+        if beta0 > 0.0 {
+            let v0 = &mut ws.q[v_off + 0][..];
+            for i in 0..n {
+                v0[i] = ws.tmp1[i] / beta0;
+            }
+        } else {
+            ws.q[v_off + 0].fill(0.0);
+        }
+        ws.g.fill(0.0);
+        ws.g[0] = beta0;
+
+        let mut total_iters = 0usize;
+        let mut res = beta0;
         let mut stats = SolveStats {
             iterations: 0,
-            final_residual: beta,
-            reason: crate::utils::convergence::ConvergedReason::Continued,
+            final_residual: res,
+            reason: ConvergedReason::Continued,
         };
 
-        let mut iteration = 0;
-        // Number of outer cycles (restarts)
-        let n_outer = (self.conv.max_iters + self.restart - 1) / self.restart;
-        for _outer in 0..n_outer {
-            #[cfg(feature = "logging")]
-            let _restart_guard = StageGuard::new("PcaGmresRestart");
-            
-            #[cfg(feature = "logging")]
-            trace!("PCA-GMRES restart cycle {}", _outer + 1);
-            
-            // Build initial Arnoldi vector (normalized residual)
-            let mut v_basis: Vec<V> = Vec::with_capacity(self.restart + 1);
-            let v0 = r0.as_ref().iter().map(|&ri| ri / beta).collect::<Vec<_>>();
-            v_basis.push(V::from(v0));
-
-            // Hessenberg matrix and Givens rotation storage
-            let m = self.restart;
-            let (mut h, mut g, mut cs, mut sn) = if let Some(workspace) = work.as_mut() {
-                // Use workspace buffers, converting from f64 to T as needed
-                let h_converted: Vec<Vec<T>> = workspace.h.iter()
-                    .map(|row| row.iter().map(|&x| <T as From<f64>>::from(x)).collect())
-                    .collect();
-                let g_converted: Vec<T> = workspace.g.iter().map(|&x| <T as From<f64>>::from(x)).collect();
-                let cs_converted: Vec<T> = workspace.cs.iter().map(|&x| <T as From<f64>>::from(x)).collect();
-                let sn_converted: Vec<T> = workspace.sn.iter().map(|&x| <T as From<f64>>::from(x)).collect();
-                
-                (h_converted, g_converted, cs_converted, sn_converted)
+        if let Some(mons) = monitors {
+            for m in mons {
+                m(0, res);
+            }
+        }
+        if res <= thr {
+            stats.final_residual = res;
+            stats.reason = if res <= self.conv.atol {
+                ConvergedReason::ConvergedAtol
             } else {
-                // Fallback to local allocation
-                let h = vec![vec![T::zero(); m]; m+1];
-                let g = vec![T::zero(); m+1];
-                let cs = vec![T::zero(); m];
-                let sn = vec![T::zero(); m];
-                (h, g, cs, sn)
+                ConvergedReason::ConvergedRtol
             };
-            
-            // Initialize g[0] = beta regardless of source
-            g[0] = beta;
-            g[0] = beta;
+            return Ok(stats);
+        }
 
-            // Iterate m steps (one at a time, not in blocks for now)
-            let s = 1; // Force block size to 1 to fix the algorithm
-            let mut j = 0;
-            while j < m {
-                #[cfg(feature = "logging")]
-                let _iter_guard = StageGuard::new("PcaGmresIteration");
-                
-                #[cfg(feature = "logging")]
-                trace!("PCA-GMRES iteration {}", iteration + 1);
-                
-                let t = std::cmp::min(s, m - j);
-                // 1) Generate the next Krylov vector
-                let mut w = V::from(vec![T::zero(); n]);
-                
-                #[cfg(feature = "logging")]
-                let _matvec_guard = StageGuard::new("PcaGmresMatVec");
-                a.matvec(&v_basis[j], &mut w);
-                #[cfg(feature = "logging")]
-                drop(_matvec_guard);
-                
-                if let (Preconditioning::Right, Some(pc)) = (self.preconditioning, pc) {
-                    let mut z = V::from(vec![T::zero(); n]);
-                    pc.apply(crate::preconditioner::PcSide::Right, &w, &mut z).unwrap();
-                    w = z;
-                }
-                
-                let mut v_block = vec![w];
-
-                // 2) Block Classical Gram-Schmidt with overlapped reduction
-                // Gather local inner-products into a temp array
-                let mut local_dot = vec![T::zero(); (j+1)*t];
-                
-                #[cfg(feature = "logging")]
-                let _dot_guard = StageGuard::new("PcaGmresDotProduct");
-                for i in 0..=j {
-                    for k in 0..t {
-                        local_dot[i*t + k] = ip.dot(&v_basis[i], &v_block[k], comm);
+        'outer: while total_iters < self.conv.max_iters {
+            // Arnoldi up to m_restart steps
+            let mut arnoldi_steps = 0usize;
+            for j in 0..m_restart.min(self.conv.max_iters - total_iters) {
+                // w = A * (direction)
+                match self.pc_mode {
+                    PcaPcMode::None => {
+                        a.matvec(&ws.q[v_off + j], &mut ws.tmp2);
                     }
-                }
-                #[cfg(feature = "logging")]
-                drop(_dot_guard);
-                // Kick off a non-blocking all-reduce on local_dot → global_dot (if MPI enabled)
-                #[cfg(feature = "mpi")]
-                let global_dot = {
-                    // Use proper communicator for MPI reductions
-                    if let UniverseComm::Mpi(mpi_comm) = comm {
-                        // For now, use blocking all-reduce until we implement non-blocking
-                        let mut global_dot = vec![T::zero(); (j+1)*t];
-                        for k in 0..(j+1)*t {
-                            global_dot[k] = <T as From<f64>>::from(mpi_comm.all_reduce(local_dot[k].to_f64().unwrap_or(0.0)));
+                    PcaPcMode::Left => {
+                        // w = M^{-1} A v_j
+                        a.matvec(&ws.q[v_off + j], &mut ws.tmp1);
+                        if let Some(p) = pc {
+                            p.apply(PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
+                        } else {
+                            ws.tmp2.copy_from_slice(&ws.tmp1);
                         }
-                        global_dot
-                    } else {
-                        local_dot // fallback to local computation
                     }
-                };
-                #[cfg(not(feature = "mpi"))]
-                let global_dot = local_dot;
-                
-                // Perform local orthogonalization during computation
-                #[cfg(feature = "logging")]
-                let _axpy_guard = StageGuard::new("PcaGmresAxpy");
+                    PcaPcMode::Right => {
+                        // z_j = M^{-1} v_j; w = A z_j
+                        if let Some(p) = pc {
+                            let (v_part, z_part) = ws.q.split_at_mut(z_off);
+                            let vj = &v_part[v_off + j];
+                            let zj = &mut z_part[j][..];
+                            p.apply(PcSide::Right, vj, zj)?;
+                            a.matvec(zj, &mut ws.tmp2);
+                        } else {
+                            // no PC: treat as None path
+                            a.matvec(&ws.q[v_off + j], &mut ws.tmp2);
+                        }
+                    }
+                }
+
+                // Classical GS + optional re-orthogonalization
                 for i in 0..=j {
-                    for k in 0..t {
-                        let coeff = global_dot[i*t + k];
-                        let qi = v_basis[i].as_ref();
-                        v_block[k].as_mut().iter_mut()
-                            .zip(qi)
-                            .for_each(|(vk, &q)| *vk -= coeff * q);
+                    let hij = Self::dot(&ws.tmp2, &ws.q[v_off + i]);
+                    ws.h[i][j] = hij;
+                    for (w, &vi) in ws.tmp2.iter_mut().zip(&ws.q[v_off + i]) {
+                        *w -= hij * vi;
                     }
                 }
-                #[cfg(feature = "logging")]
-                drop(_axpy_guard);
-                
-                // write back the fully reduced coefficients:
-                for i in 0..=j {
-                    for k in 0..t {
-                        h[i][j+k] = global_dot[i*t + k];
-                    }
-                }
-                // Intra-block orthogonalization
-                for k in 0..t {
-                    let _vk = &mut v_block[k];
-                    for i in 0..k {
-                        #[cfg(feature = "logging")]
-                        let _dot_guard = StageGuard::new("PcaGmresDotProduct");
-                        let r_ij = ip.dot(&v_basis[j+i], &v_block[k], comm);
-                        #[cfg(feature = "logging")]
-                        drop(_dot_guard);
-                        
-                        h[j+i][j+k] = r_ij;
-                        let qji = v_basis[j+i].as_ref();
-                        
-                        #[cfg(feature = "logging")]
-                        let _axpy_guard = StageGuard::new("PcaGmresAxpy");
-                        v_block[k].as_mut().iter_mut()
-                          .zip(qji)
-                          .for_each(|(vki, &qii)| *vki -= r_ij * qii);
-                        #[cfg(feature = "logging")]
-                        drop(_axpy_guard);
-                    }
-                    // Normalize v_block[k]
-                    #[cfg(feature = "logging")]
-                    let _norm_guard = StageGuard::new("PcaGmresNorm");
-                    let norm_vk = ip.norm(&v_block[k], comm);
-                    #[cfg(feature = "logging")]
-                    drop(_norm_guard);
-                    
-                    h[j+k+1][j+k] = norm_vk;
-                    let inv = T::one() / norm_vk;
-                    v_block[k].as_mut().iter_mut().for_each(|vki| *vki *= inv);
-                }
-
-                // 3) Append new orthonormalized vectors to basis
-                for k in 0..t {
-                    v_basis.push(v_block[k].clone());
-                }
-
-                // 4) Apply Givens rotations to H and update g (pipeline step)
-                for k in 0..t {
-                    let col = j + k;
-                    // apply previous rotations
-                    for i in 0..col {
-                        let temp = cs[i] * h[i][col] + sn[i] * h[i+1][col];
-                        h[i+1][col] = -sn[i] * h[i][col] + cs[i] * h[i+1][col];
-                        h[i][col] = temp;
-                    }
-                    // form new rotation for column col
-                    let h_kk = h[col][col];
-                    let h_k1k = h[col+1][col];
-                    let r = (h_kk*h_kk + h_k1k*h_k1k).sqrt();
-                    if r.abs() < T::epsilon() {
-                        cs[col] = T::one();
-                        sn[col] = T::zero();
-                    } else {
-                        cs[col] = h_kk / r;
-                        sn[col] = h_k1k / r;
-                    }
-                    // apply rotation
-                    h[col][col] = cs[col] * h_kk + sn[col] * h_k1k;
-                    h[col+1][col] = T::zero();
-                    // update g
-                    let temp = cs[col] * g[col] + sn[col] * g[col+1];
-                    g[col+1] = -sn[col] * g[col] + cs[col] * g[col+1];
-                    g[col] = temp;
-                }
-
-                // 5) Check convergence on residual
-                let gnorm = g[j + t].abs();
-                iteration += t;
-                
-                #[cfg(feature = "logging")]
-                trace!("PCA-GMRES iteration {}: residual = {:.3e}", iteration, gnorm.to_f64().unwrap_or(0.0));
-                
-                let (reason, sstats) = self.conv.check(gnorm, res0, iteration);
-                stats = sstats.clone();
-                
-                // Invoke monitors if provided
-                if let Some(monitor_fns) = monitors {
-                    for monitor in monitor_fns.iter() {
-                        monitor(iteration, gnorm);
-                    }
-                }
-                
-                if reason == crate::utils::convergence::ConvergedReason::ConvergedRtol
-                    || reason == crate::utils::convergence::ConvergedReason::ConvergedAtol {
-                    break;
-                }
-                j += t;
-            }
-
-            // 6) Solve least-squares H y = g via back-substitution
-            let m_eff = j;
-            let mut y = vec![T::zero(); m_eff];
-            // Back-substitution for upper-triangular H
-            for i in (0..m_eff).rev() {
-                let mut sum = g[i];
-                for k in i+1..m_eff { sum = sum - h[i][k] * y[k]; }
-                if h[i][i].abs() > T::epsilon() {
-                    y[i] = sum / h[i][i];
-                }
-            }
-
-            // 7) Update solution xk += Q[:,0..m_eff] * y
-            #[cfg(feature = "logging")]
-            let _axpy_guard = StageGuard::new("PcaGmresAxpy");
-            for i in 0..m_eff {
-                let coeff = y[i];
-                let qi = &v_basis[i];
-                xk.iter_mut()
-                   .zip(qi.as_ref())
-                   .for_each(|(xi, &qi)| *xi = *xi + coeff * qi);
-            }
-            #[cfg(feature = "logging")]
-            drop(_axpy_guard);
-
-            // 8) Compute new residual r0 = b - A xk
-            #[cfg(feature = "logging")]
-            let _matvec_guard = StageGuard::new("PcaGmresMatVec");
-            a.matvec(&V::from(xk.clone()), &mut tmp);
-            #[cfg(feature = "logging")]
-            drop(_matvec_guard);
-            
-            r0_vec = tmp.as_ref().iter().zip(b.as_ref())
-                        .map(|(&ax, &bi)| bi - ax).collect();
-            r0 = V::from(r0_vec.clone());
-            
-            #[cfg(feature = "logging")]
-            let _norm_guard = StageGuard::new("PcaGmresNorm");
-            beta = ip.norm(&r0, comm);
-            #[cfg(feature = "logging")]
-            drop(_norm_guard);
-            
-            stats.final_residual = beta;
-            if beta <= self.conv.rtol * res0 {
-                stats.reason = crate::utils::convergence::ConvergedReason::ConvergedRtol;
-                break;
-            }
-            if iteration >= self.conv.max_iters {
-                stats.reason = crate::utils::convergence::ConvergedReason::DivergedMaxIts;
-                break;
-            }
-            
-            // Write computed values back to workspace for next iteration if available
-            if let Some(workspace) = work.as_mut() {
-                // Write back Hessenberg matrix (convert T back to f64)
-                for (i, h_row) in h.iter().enumerate() {
-                    if i < workspace.h.len() {
-                        for (j, &h_val) in h_row.iter().enumerate() {
-                            if j < workspace.h[i].len() {
-                                workspace.h[i][j] = h_val.to_f64().unwrap_or(0.0);
+                if self.modified_gs {
+                    for i in 0..=j {
+                        let corr = Self::dot(&ws.tmp2, &ws.q[v_off + i]);
+                        if corr.abs() > 1e-12 {
+                            ws.h[i][j] += corr;
+                            for (w, &vi) in ws.tmp2.iter_mut().zip(&ws.q[v_off + i]) {
+                                *w -= corr * vi;
                             }
                         }
                     }
                 }
-                
-                // Write back Givens rotation vectors
-                for (i, &cs_val) in cs.iter().enumerate() {
-                    if i < workspace.cs.len() {
-                        workspace.cs[i] = cs_val.to_f64().unwrap_or(0.0);
+                // h[j+1, j] = ||w||
+                let hij1 = Self::nrm2(&ws.tmp2);
+                ws.h[j + 1][j] = hij1;
+
+                // v_{j+1}
+                let vnext = &mut ws.q[v_off + (j + 1)][..];
+                if hij1 > 0.0 {
+                    for i in 0..n {
+                        vnext[i] = ws.tmp2[i] / hij1;
+                    }
+                } else {
+                    vnext.fill(0.0);
+                }
+
+                // Apply previous Givens
+                for i in 0..j {
+                    let (top, rest) = ws.h.split_at_mut(i + 1);
+                    let row_i = &mut top[i];
+                    let row_ip1 = &mut rest[0];
+                    Self::apply_givens(&mut row_i[j], &mut row_ip1[j], ws.cs[i], ws.sn[i]);
+                }
+                // New Givens to zero h[j+1, j]
+                let (top, rest) = ws.h.split_at_mut(j + 1);
+                let row_j = &mut top[j];
+                let row_j1 = &mut rest[0];
+                let (c, s) = Self::givens(row_j[j], row_j1[j]);
+                ws.cs[j] = c;
+                ws.sn[j] = s;
+                Self::apply_givens(&mut row_j[j], &mut row_j1[j], c, s);
+
+                // Update RHS g
+                let t = c * ws.g[j] + s * ws.g[j + 1];
+                ws.g[j + 1] = -s * ws.g[j] + c * ws.g[j + 1];
+                ws.g[j] = t;
+
+                res = ws.g[j + 1].abs();
+                total_iters += 1;
+                arnoldi_steps = j + 1;
+
+                if let Some(mons) = monitors {
+                    for m in mons {
+                        m(total_iters, res);
                     }
                 }
-                for (i, &sn_val) in sn.iter().enumerate() {
-                    if i < workspace.sn.len() {
-                        workspace.sn[i] = sn_val.to_f64().unwrap_or(0.0);
+                let (reason, sstats) = self.conv.check(res, beta0, total_iters);
+                stats = sstats;
+                if matches!(
+                    reason,
+                    ConvergedReason::ConvergedRtol | ConvergedReason::ConvergedAtol
+                ) {
+                    break;
+                }
+            }
+
+            // Back-substitute y
+            let k = arnoldi_steps;
+            let mut y = vec![0.0; k];
+            for i in (0..k).rev() {
+                let mut sum = ws.g[i];
+                for l in (i + 1)..k {
+                    sum -= ws.h[i][l] * y[l];
+                }
+                y[i] = sum / ws.h[i][i];
+            }
+
+            // Update x
+            match self.pc_mode {
+                PcaPcMode::Right if pc.is_some() => {
+                    // x += Σ y_i * z_i
+                    for i in 0..k {
+                        let zi = &ws.q[z_off + i][..];
+                        for (xj, &zij) in x.iter_mut().zip(zi) {
+                            *xj += y[i] * zij;
+                        }
                     }
                 }
-                
-                // Write back g vector
-                for (i, &g_val) in g.iter().enumerate() {
-                    if i < workspace.g.len() {
-                        workspace.g[i] = g_val.to_f64().unwrap_or(0.0);
+                _ => {
+                    // x += Σ y_i * v_i
+                    for i in 0..k {
+                        let vi = &ws.q[v_off + i][..];
+                        for (xj, &vij) in x.iter_mut().zip(vi) {
+                            *xj += y[i] * vij;
+                        }
                     }
                 }
             }
+
+            // Restart: r = b - A x
+            a.matvec(x, &mut ws.tmp1);
+            for i in 0..n {
+                ws.tmp1[i] = b[i] - ws.tmp1[i];
+            }
+            beta0 = Self::nrm2(&ws.tmp1);
+            ws.g.fill(0.0);
+            ws.g[0] = beta0;
+            let v0 = &mut ws.q[v_off + 0][..];
+            if beta0 > 0.0 {
+                for i in 0..n {
+                    v0[i] = ws.tmp1[i] / beta0;
+                }
+            } else {
+                v0.fill(0.0);
+            }
+
+            if total_iters >= self.conv.max_iters {
+                break 'outer;
+            }
+            if beta0 <= thr {
+                stats.reason = if beta0 <= self.conv.atol {
+                    ConvergedReason::ConvergedAtol
+                } else {
+                    ConvergedReason::ConvergedRtol
+                };
+                stats.final_residual = beta0;
+                break 'outer;
+            }
         }
 
-        #[cfg(feature = "logging")]
-        trace!("PCA-GMRES solve completed after {} iterations", stats.iterations);
-
-        *x = V::from(xk);
+        if matches!(stats.reason, ConvergedReason::Continued) {
+            stats.final_residual = res;
+            stats.reason = if res <= thr {
+                ConvergedReason::ConvergedRtol
+            } else {
+                ConvergedReason::DivergedMaxIts
+            };
+        }
         Ok(stats)
     }
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::traits::MatVec;
-
-    /// Simple dense matrix for testing
-    #[derive(Clone)]
-    struct DenseMat {
-        data: Vec<Vec<f64>>,
-    }
-    impl MatVec<Vec<f64>> for DenseMat {
-        /// Matrix-vector multiplication: y = A x
-        fn matvec(&self, x: &Vec<f64>, y: &mut Vec<f64>) {
-            for (i, row) in self.data.iter().enumerate() {
-                y[i] = row.iter().zip(x.iter()).map(|(a, b)| a * b).sum();
-            }
-        }
-    }
-
-    #[test]
-    #[ignore = "PCA-GMRES algorithm needs debugging - temporarily disabled"]
-    fn pca_gmres_solves_small_system() {
-        // 3x3 system: A = [[4,1,2],[1,3,1],[2,1,3]], x_true = [1,2,3]
-        let a = DenseMat {
-            data: vec![
-                vec![4.0, 1.0, 2.0],
-                vec![1.0, 3.0, 1.0],
-                vec![2.0, 1.0, 3.0],
-            ]
-        };
-        let x_true = vec![1.0, 2.0, 3.0];
-        let mut b = vec![0.0; 3];
-        a.matvec(&x_true, &mut b);
-        let mut x = vec![0.0; 3];
-        let mut solver = PcaGmresSolver::new(6, 2, 2, 1e-10, 30);
-        let stats = solver.solve(&a, None, &b, &mut x, &crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm), None, None).unwrap();
-        let tol = 1e-8;
-        for (xi, ei) in x.iter().zip(x_true.iter()) {
-            assert!((xi - ei).abs() < tol, "xi = {}, expected = {}", xi, ei);
-        }
-        assert!(matches!(stats.reason,
-            crate::utils::convergence::ConvergedReason::ConvergedRtol |
-            crate::utils::convergence::ConvergedReason::ConvergedAtol), "PCA-GMRES did not report Converged reason");
-    }
-}

--- a/tests/pcagmres.rs
+++ b/tests/pcagmres.rs
@@ -1,0 +1,76 @@
+use std::sync::Arc;
+
+use faer::Mat;
+use kryst::error::KError;
+use kryst::matrix::op::LinOp;
+use kryst::parallel::UniverseComm;
+use kryst::preconditioner::{PcSide, Preconditioner};
+use kryst::solver::{LinearSolver, PcaGmresSolver, PcaPcMode};
+
+#[test]
+fn pcagmres_solves_dd_nonsym_right_pc() {
+    // Build simple non-symmetric, diagonally dominant 5x5 matrix
+    let data = [
+        [10.0, 2.0, 0.0, 0.0, 0.0],
+        [3.0, 15.0, 4.0, 0.0, 0.0],
+        [0.0, -2.0, 8.0, 1.0, 0.0],
+        [0.0, 0.0, 1.0, 7.0, 3.0],
+        [0.0, 0.0, 0.0, 2.0, 12.0],
+    ];
+    let mut a = Mat::<f64>::zeros(5, 5);
+    for i in 0..5 {
+        for j in 0..5 {
+            a[(i, j)] = data[i][j];
+        }
+    }
+    let aop: Arc<dyn LinOp<S = f64>> = Arc::new(a.clone());
+
+    // Right Jacobi preconditioner
+    struct RJ {
+        d: [f64; 5],
+    }
+    impl Preconditioner for RJ {
+        fn setup(&mut self, _pmat: &dyn LinOp<S = f64>) -> Result<(), KError> {
+            Ok(())
+        }
+        fn apply(&self, side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
+            match side {
+                PcSide::Right => {
+                    for i in 0..5 {
+                        z[i] = r[i] / self.d[i];
+                    }
+                }
+                _ => z.copy_from_slice(r),
+            }
+            Ok(())
+        }
+    }
+    let pc = RJ {
+        d: [10.0, 15.0, 8.0, 7.0, 12.0],
+    };
+
+    // x_true = [1,2,3,4,5], b = A * x_true
+    let x_true = [1.0, 2.0, 3.0, 4.0, 5.0];
+    let mut b = [0.0; 5];
+    aop.matvec(&x_true, &mut b);
+
+    let mut x = [0.0; 5];
+    let mut solver = PcaGmresSolver::new(20, 1, 1, 1e-10, 200);
+    solver.pc_mode = PcaPcMode::Right;
+    let stats = solver
+        .solve(
+            aop.as_ref(),
+            Some(&pc),
+            &b,
+            &mut x,
+            &UniverseComm::NoComm(kryst::parallel::NoComm),
+            None,
+            None,
+        )
+        .unwrap();
+    assert!(stats.final_residual <= 1e-6, "res={}", stats.final_residual);
+    for (xi, &xt) in x.iter().zip(x_true.iter()) {
+        assert!((xi - xt).abs() <= 1e-6, "xi = {}, expected = {}", xi, xt);
+    }
+}
+


### PR DESCRIPTION
## Summary
- implement object-safe baseline PCA-GMRES solver with left/right/no preconditioning
- register PCA-GMRES in solver module and KSP context
- add regression test validating right-preconditioned solve

## Testing
- `cargo test --lib --tests`

------
https://chatgpt.com/codex/tasks/task_e_68a95ead7f508329aa6f0b44d5232d67