### PR TITLE
Add QMR solver with transpose support

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -6,7 +6,7 @@ use crate::parallel::UniverseComm;
 use crate::preconditioner::{PcReusePolicy, PcSide, Preconditioner};
 use crate::solver::{
     BiCgStabSolver, CgSolver, CgnrSolver, CgsSolver, FgmresSolver, GmresSolver, LinearSolver,
-    MatSolverAdapter, MinresSolver, PcgSolver, PcaGmresSolver,
+    MatSolverAdapter, MinresSolver, PcaGmresSolver, PcgSolver, QmrSolver,
 };
 use crate::utils::convergence::{ConvergedReason, SolveStats};
 use std::str::FromStr;
@@ -50,6 +50,7 @@ pub enum SolverType {
     Pcg,
     Minres,
     PcaGmres,
+    Qmr,
     Preonly,
 }
 
@@ -67,6 +68,7 @@ impl FromStr for SolverType {
             "pcg" => Ok(SolverType::Pcg),
             "minres" => Ok(SolverType::Minres),
             "pca_gmres" | "pcagmres" => Ok(SolverType::PcaGmres),
+            "qmr" => Ok(SolverType::Qmr),
             "preonly" => Ok(SolverType::Preonly),
             other => Err(KError::UnrecognizedSolverType(other.to_string())),
         }
@@ -146,6 +148,7 @@ impl KspContext {
                 s.pc_mode = crate::solver::PcaPcMode::Left;
                 Box::new(s)
             }
+            SolverType::Qmr => Box::new(crate::solver::QmrSolver::new(self.rtol, self.maxits)),
             SolverType::Preonly => {
                 return Err(KError::SolveError("Preonly solver not available".into()));
             }

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -32,7 +32,10 @@ where
     T: ComplexField,
 {
     fn mattransvec(&self, x: &Vec<T>, y: &mut Vec<T>) {
-        LinOp::t_matvec(self, &x[..], &mut y[..]).expect("t_matvec not supported");
+        if !LinOp::supports_transpose(self) {
+            panic!("t_matvec not supported");
+        }
+        LinOp::t_matvec(self, &x[..], &mut y[..]);
     }
 }
 
@@ -84,13 +87,13 @@ pub trait SubmatrixExtract {
 pub trait MatVecOp<T> {
     /// Compute y = alpha * A * x + beta * y
     fn mat_vec(&self, alpha: T, x: &[T], beta: T, y: &mut [T]) -> Result<(), crate::KError>;
-    
+
     /// Compute y = alpha * A^T * x + beta * y (transpose operation)
     fn mat_vec_trans(&self, alpha: T, x: &[T], beta: T, y: &mut [T]) -> Result<(), crate::KError>;
-    
+
     /// Get the number of rows
     fn nrows(&self) -> usize;
-    
+
     /// Get the number of columns  
     fn ncols(&self) -> usize;
 }
@@ -99,18 +102,26 @@ pub trait MatVecOp<T> {
 pub trait DotOp<T> {
     /// Compute the dot product x^T * y
     fn dot(&self, x: &[T], y: &[T]) -> T;
-    
+
     /// Compute the 2-norm of a vector
     fn norm2(&self, x: &[T]) -> T;
 }
 
 /// Implementation for dense matrices (faer Mat)
 impl MatVecOp<f64> for faer::Mat<f64> {
-    fn mat_vec(&self, alpha: f64, x: &[f64], beta: f64, y: &mut [f64]) -> Result<(), crate::KError> {
+    fn mat_vec(
+        &self,
+        alpha: f64,
+        x: &[f64],
+        beta: f64,
+        y: &mut [f64],
+    ) -> Result<(), crate::KError> {
         if x.len() != self.ncols() || y.len() != self.nrows() {
-            return Err(crate::KError::InvalidInput("Matrix-vector dimension mismatch".to_string()));
+            return Err(crate::KError::InvalidInput(
+                "Matrix-vector dimension mismatch".to_string(),
+            ));
         }
-        
+
         for i in 0..self.nrows() {
             let mut sum = 0.0;
             for j in 0..self.ncols() {
@@ -120,12 +131,20 @@ impl MatVecOp<f64> for faer::Mat<f64> {
         }
         Ok(())
     }
-    
-    fn mat_vec_trans(&self, alpha: f64, x: &[f64], beta: f64, y: &mut [f64]) -> Result<(), crate::KError> {
+
+    fn mat_vec_trans(
+        &self,
+        alpha: f64,
+        x: &[f64],
+        beta: f64,
+        y: &mut [f64],
+    ) -> Result<(), crate::KError> {
         if x.len() != self.nrows() || y.len() != self.ncols() {
-            return Err(crate::KError::InvalidInput("Matrix-vector dimension mismatch".to_string()));
+            return Err(crate::KError::InvalidInput(
+                "Matrix-vector dimension mismatch".to_string(),
+            ));
         }
-        
+
         for j in 0..self.ncols() {
             let mut sum = 0.0;
             for i in 0..self.nrows() {
@@ -135,19 +154,31 @@ impl MatVecOp<f64> for faer::Mat<f64> {
         }
         Ok(())
     }
-    
-    fn nrows(&self) -> usize { faer::Mat::nrows(self) }
-    fn ncols(&self) -> usize { faer::Mat::ncols(self) }
+
+    fn nrows(&self) -> usize {
+        faer::Mat::nrows(self)
+    }
+    fn ncols(&self) -> usize {
+        faer::Mat::ncols(self)
+    }
 }
 
 /// Implementation for sparse matrices (CsrMatrix)
 impl MatVecOp<f64> for crate::matrix::sparse::CsrMatrix<f64> {
-    fn mat_vec(&self, alpha: f64, x: &[f64], beta: f64, y: &mut [f64]) -> Result<(), crate::KError> {
+    fn mat_vec(
+        &self,
+        alpha: f64,
+        x: &[f64],
+        beta: f64,
+        y: &mut [f64],
+    ) -> Result<(), crate::KError> {
         use crate::matrix::sparse::SparseMatrix;
         if x.len() != SparseMatrix::ncols(self) || y.len() != SparseMatrix::nrows(self) {
-            return Err(crate::KError::InvalidInput("Matrix-vector dimension mismatch".to_string()));
+            return Err(crate::KError::InvalidInput(
+                "Matrix-vector dimension mismatch".to_string(),
+            ));
         }
-        
+
         // Use the existing spmv method and scale appropriately
         if beta == 0.0 {
             // y = alpha * A * x (zero y first)
@@ -176,7 +207,7 @@ impl MatVecOp<f64> for crate::matrix::sparse::CsrMatrix<f64> {
         }
         Ok(())
     }
-    
+
     fn mat_vec_trans(
         &self,
         alpha: f64,
@@ -222,9 +253,9 @@ impl MatVecOp<f64> for crate::matrix::sparse::CsrMatrix<f64> {
 
         // Access CSR structure. These accessor names assume your CSR exposes them.
         // If your type uses different getters, adjust accordingly.
-        let row_ptr = self.row_ptr();   // &[usize] of length m+1
-        let col_idx = self.col_idx();   // &[usize] of length nnz
-        let values  = self.values();    // &[f64]   of length nnz
+        let row_ptr = self.row_ptr(); // &[usize] of length m+1
+        let col_idx = self.col_idx(); // &[usize] of length nnz
+        let values = self.values(); // &[f64]   of length nnz
 
         // y_j += alpha * a_ij * x_i  for all nonzeros a_ij
         let m = SparseMatrix::nrows(self);
@@ -245,14 +276,13 @@ impl MatVecOp<f64> for crate::matrix::sparse::CsrMatrix<f64> {
         Ok(())
     }
 
-    
-    fn nrows(&self) -> usize { 
+    fn nrows(&self) -> usize {
         use crate::matrix::sparse::SparseMatrix;
-        SparseMatrix::nrows(self) 
+        SparseMatrix::nrows(self)
     }
-    fn ncols(&self) -> usize { 
+    fn ncols(&self) -> usize {
         use crate::matrix::sparse::SparseMatrix;
-        SparseMatrix::ncols(self) 
+        SparseMatrix::ncols(self)
     }
 }
 
@@ -263,7 +293,7 @@ impl DotOp<f64> for StandardDotOp {
     fn dot(&self, x: &[f64], y: &[f64]) -> f64 {
         x.iter().zip(y.iter()).map(|(a, b)| a * b).sum()
     }
-    
+
     fn norm2(&self, x: &[f64]) -> f64 {
         self.dot(x, x).sqrt()
     }
@@ -275,7 +305,7 @@ impl DotOp<f64> for StandardDotOp {
 pub trait KernelOp<T> {
     /// The communicator type for this kernel (e.g., UniverseComm for MPI, () for local)
     type Comm: crate::parallel::Comm;
-    
+
     /// Matrix-vector product with communicator support: y = alpha * A * x + beta * y
     fn kernel_mat_vec(
         &self,
@@ -286,7 +316,7 @@ pub trait KernelOp<T> {
         y: &mut [T],
         comm: &Self::Comm,
     ) -> Result<(), crate::KError>;
-    
+
     /// Transpose matrix-vector product: y = alpha * A^T * x + beta * y
     fn kernel_mat_vec_trans(
         &self,
@@ -297,34 +327,19 @@ pub trait KernelOp<T> {
         y: &mut [T],
         comm: &Self::Comm,
     ) -> Result<(), crate::KError>;
-    
+
     /// Global dot product with reduction across processes
-    fn kernel_dot(
-        &self,
-        x: &[T],
-        y: &[T],
-        comm: &Self::Comm,
-    ) -> T;
-    
+    fn kernel_dot(&self, x: &[T], y: &[T], comm: &Self::Comm) -> T;
+
     /// Global norm computation with reduction
-    fn kernel_norm2(
-        &self,
-        x: &[T],
-        comm: &Self::Comm,
-    ) -> T;
-    
+    fn kernel_norm2(&self, x: &[T], comm: &Self::Comm) -> T;
+
     /// Vector operations: y = alpha * x + beta * y
-    fn kernel_axpby(
-        &self,
-        alpha: T,
-        x: &[T],
-        beta: T,
-        y: &mut [T],
-    );
-    
+    fn kernel_axpby(&self, alpha: T, x: &[T], beta: T, y: &mut [T]);
+
     /// Copy operation: y = x
     fn kernel_copy(&self, x: &[T], y: &mut [T]);
-    
+
     /// Scale operation: x = alpha * x
     fn kernel_scale(&self, alpha: T, x: &mut [T]);
 }
@@ -334,7 +349,7 @@ pub struct LocalKernel;
 
 impl KernelOp<f64> for LocalKernel {
     type Comm = crate::parallel::NoComm;
-    
+
     fn kernel_mat_vec(
         &self,
         matrix: &dyn MatVecOp<f64>,
@@ -347,7 +362,7 @@ impl KernelOp<f64> for LocalKernel {
         // For local operations, no communication needed
         matrix.mat_vec(alpha, x, beta, y)
     }
-    
+
     fn kernel_mat_vec_trans(
         &self,
         matrix: &dyn MatVecOp<f64>,
@@ -359,27 +374,27 @@ impl KernelOp<f64> for LocalKernel {
     ) -> Result<(), crate::KError> {
         matrix.mat_vec_trans(alpha, x, beta, y)
     }
-    
+
     fn kernel_dot(&self, x: &[f64], y: &[f64], _comm: &Self::Comm) -> f64 {
         let dot_op = StandardDotOp;
         dot_op.dot(x, y)
     }
-    
+
     fn kernel_norm2(&self, x: &[f64], _comm: &Self::Comm) -> f64 {
         let dot_op = StandardDotOp;
         dot_op.norm2(x)
     }
-    
+
     fn kernel_axpby(&self, alpha: f64, x: &[f64], beta: f64, y: &mut [f64]) {
         for (y_val, x_val) in y.iter_mut().zip(x.iter()) {
             *y_val = alpha * x_val + beta * (*y_val);
         }
     }
-    
+
     fn kernel_copy(&self, x: &[f64], y: &mut [f64]) {
         y.copy_from_slice(x);
     }
-    
+
     fn kernel_scale(&self, alpha: f64, x: &mut [f64]) {
         for val in x.iter_mut() {
             *val *= alpha;
@@ -393,7 +408,7 @@ pub struct DistributedKernel;
 
 impl KernelOp<f64> for DistributedKernel {
     type Comm = crate::parallel::UniverseComm;
-    
+
     fn kernel_mat_vec(
         &self,
         matrix: &dyn MatVecOp<f64>,
@@ -407,7 +422,7 @@ impl KernelOp<f64> for DistributedKernel {
         // For now, delegate to local operation
         matrix.mat_vec(alpha, x, beta, y)
     }
-    
+
     fn kernel_mat_vec_trans(
         &self,
         matrix: &dyn MatVecOp<f64>,
@@ -420,7 +435,7 @@ impl KernelOp<f64> for DistributedKernel {
         // TODO: Add proper distributed transpose operations
         matrix.mat_vec_trans(alpha, x, beta, y)
     }
-    
+
     fn kernel_dot(&self, x: &[f64], y: &[f64], comm: &Self::Comm) -> f64 {
         use crate::parallel::Comm;
         // Compute local dot product
@@ -428,22 +443,22 @@ impl KernelOp<f64> for DistributedKernel {
         // Reduce across all processes
         comm.all_reduce_f64(local_dot)
     }
-    
+
     fn kernel_norm2(&self, x: &[f64], comm: &Self::Comm) -> f64 {
         self.kernel_dot(x, x, comm).sqrt()
     }
-    
+
     fn kernel_axpby(&self, alpha: f64, x: &[f64], beta: f64, y: &mut [f64]) {
         // Vector operations are local in distributed setting
         for (y_val, x_val) in y.iter_mut().zip(x.iter()) {
             *y_val = alpha * x_val + beta * (*y_val);
         }
     }
-    
+
     fn kernel_copy(&self, x: &[f64], y: &mut [f64]) {
         y.copy_from_slice(x);
     }
-    
+
     fn kernel_scale(&self, alpha: f64, x: &mut [f64]) {
         for val in x.iter_mut() {
             *val *= alpha;
@@ -455,26 +470,33 @@ impl KernelOp<f64> for DistributedKernel {
 pub trait AmgKernel {
     /// Associated communicator type  
     type Comm: crate::parallel::Comm;
-    
+
     /// Matrix-vector multiplication with alpha/beta scaling
-    fn matvec<M>(&self, alpha: f64, a: &M, x: &[f64], beta: f64, y: &mut [f64]) -> Result<(), crate::KError>
+    fn matvec<M>(
+        &self,
+        alpha: f64,
+        a: &M,
+        x: &[f64],
+        beta: f64,
+        y: &mut [f64],
+    ) -> Result<(), crate::KError>
     where
         M: MatVecOp<f64>;
-    
+
     /// Global dot product with communicator reduction
     fn dot(&self, x: &[f64], y: &[f64], comm: &Self::Comm) -> f64;
-    
+
     /// Global norm with communicator reduction  
     fn norm(&self, x: &[f64], comm: &Self::Comm) -> f64 {
         self.dot(x, x, comm).sqrt()
     }
-    
+
     /// Vector scaling: x = alpha * x
     fn scale(&self, alpha: f64, x: &mut [f64]);
-    
+
     /// Vector copy: y = x
     fn copy(&self, x: &[f64], y: &mut [f64]);
-    
+
     /// AXPY operation: y = alpha * x + y
     fn axpy(&self, alpha: f64, x: &[f64], y: &mut [f64]);
 }
@@ -490,28 +512,35 @@ impl LocalAmgKernel {
 
 impl AmgKernel for LocalAmgKernel {
     type Comm = crate::parallel::NoComm;
-    
-    fn matvec<M>(&self, alpha: f64, a: &M, x: &[f64], beta: f64, y: &mut [f64]) -> Result<(), crate::KError>
+
+    fn matvec<M>(
+        &self,
+        alpha: f64,
+        a: &M,
+        x: &[f64],
+        beta: f64,
+        y: &mut [f64],
+    ) -> Result<(), crate::KError>
     where
-        M: MatVecOp<f64>
+        M: MatVecOp<f64>,
     {
         a.mat_vec(alpha, x, beta, y)
     }
-    
+
     fn dot(&self, x: &[f64], y: &[f64], _comm: &Self::Comm) -> f64 {
         x.iter().zip(y.iter()).map(|(a, b)| a * b).sum()
     }
-    
+
     fn scale(&self, alpha: f64, x: &mut [f64]) {
         for val in x.iter_mut() {
             *val *= alpha;
         }
     }
-    
+
     fn copy(&self, x: &[f64], y: &mut [f64]) {
         y.copy_from_slice(x);
     }
-    
+
     fn axpy(&self, alpha: f64, x: &[f64], y: &mut [f64]) {
         for (y_val, x_val) in y.iter_mut().zip(x.iter()) {
             *y_val += alpha * x_val;
@@ -530,33 +559,40 @@ impl DistributedAmgKernel {
 
 impl AmgKernel for DistributedAmgKernel {
     type Comm = crate::parallel::UniverseComm;
-    
-    fn matvec<M>(&self, alpha: f64, a: &M, x: &[f64], beta: f64, y: &mut [f64]) -> Result<(), crate::KError>
+
+    fn matvec<M>(
+        &self,
+        alpha: f64,
+        a: &M,
+        x: &[f64],
+        beta: f64,
+        y: &mut [f64],
+    ) -> Result<(), crate::KError>
     where
-        M: MatVecOp<f64>
+        M: MatVecOp<f64>,
     {
         // For now, delegate to trait method (TODO: implement proper distributed matvec)
         a.mat_vec(alpha, x, beta, y)
     }
-    
+
     fn dot(&self, x: &[f64], y: &[f64], comm: &Self::Comm) -> f64 {
         use crate::parallel::Comm;
         // Compute local dot product, then reduce across processes
         let local_dot: f64 = x.iter().zip(y.iter()).map(|(a, b)| a * b).sum();
         comm.all_reduce_f64(local_dot)
     }
-    
+
     fn scale(&self, alpha: f64, x: &mut [f64]) {
         // Vector operations are local even in distributed setting
         for val in x.iter_mut() {
             *val *= alpha;
         }
     }
-    
+
     fn copy(&self, x: &[f64], y: &mut [f64]) {
         y.copy_from_slice(x);
     }
-    
+
     fn axpy(&self, alpha: f64, x: &[f64], y: &mut [f64]) {
         for (y_val, x_val) in y.iter_mut().zip(x.iter()) {
             *y_val += alpha * x_val;
@@ -573,17 +609,49 @@ mod tests {
     fn test_traits_exist() {
         // This test just verifies that all traits compile and can be referenced
         // More comprehensive tests would require mock implementations
-        
+
         // Test that trait bounds can be specified
-        fn _test_matvec_bound<T, V>(_: &T) where T: MatVec<V> {}
-        fn _test_mattransvec_bound<T, V>(_: &T) where T: MatTransVec<V> {}
-        fn _test_inner_product_bound<T, V>(_: &T) where T: InnerProduct<V> {}
-        fn _test_indexing_bound<T>(_: &T) where T: Indexing {}
-        fn _test_mat_shape_bound<T>(_: &T) where T: MatShape {}
-        fn _test_row_pattern_bound<T>(_: &T) where T: RowPattern {}
-        fn _test_matrix_get_bound<T, U>(_: &T) where T: MatrixGet<U> {}
-        fn _test_submatrix_extract_bound<T>(_: &T) where T: SubmatrixExtract {}
-        
+        fn _test_matvec_bound<T, V>(_: &T)
+        where
+            T: MatVec<V>,
+        {
+        }
+        fn _test_mattransvec_bound<T, V>(_: &T)
+        where
+            T: MatTransVec<V>,
+        {
+        }
+        fn _test_inner_product_bound<T, V>(_: &T)
+        where
+            T: InnerProduct<V>,
+        {
+        }
+        fn _test_indexing_bound<T>(_: &T)
+        where
+            T: Indexing,
+        {
+        }
+        fn _test_mat_shape_bound<T>(_: &T)
+        where
+            T: MatShape,
+        {
+        }
+        fn _test_row_pattern_bound<T>(_: &T)
+        where
+            T: RowPattern,
+        {
+        }
+        fn _test_matrix_get_bound<T, U>(_: &T)
+        where
+            T: MatrixGet<U>,
+        {
+        }
+        fn _test_submatrix_extract_bound<T>(_: &T)
+        where
+            T: SubmatrixExtract,
+        {
+        }
+
         // All traits should compile
         assert!(true);
     }
@@ -592,10 +660,10 @@ mod tests {
     fn test_inner_product_scalar_trait_bounds() {
         // Test that the associated Scalar type has the required bounds
         fn _check_scalar_bounds<T: Copy + PartialOrd + From<f64> + Into<f64>>() {}
-        
+
         // f64 should satisfy the bounds
         _check_scalar_bounds::<f64>();
-        
+
         assert!(true);
     }
 
@@ -605,11 +673,11 @@ mod tests {
         trait TestMatVec<V> {
             fn matvec(&self, x: &V, y: &mut V);
         }
-        
+
         trait TestMatTransVec<V> {
             fn mattransvec(&self, x: &V, y: &mut V);
         }
-        
+
         trait TestInnerProduct<V> {
             type Scalar: Copy + PartialOrd + From<f64> + Into<f64>;
             fn dot(&self, x: &V, y: &V, comm: &impl crate::parallel::Comm) -> Self::Scalar;
@@ -619,7 +687,7 @@ mod tests {
                 (global_sq.sqrt()).into()
             }
         }
-        
+
         // All method signatures should compile
         assert!(true);
     }

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -1,8 +1,7 @@
-use std::any::Any;
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
 use faer::traits::ComplexField;
-use crate::error::KError;
+use std::any::Any;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct StructureId(pub u64);
@@ -19,9 +18,14 @@ pub trait LinOp: Send + Sync + Any {
     /// Compute y = A x.
     fn matvec(&self, x: &[Self::S], y: &mut [Self::S]);
 
-    /// Optional transpose/adjoint matvec. Default returns an error.
-    fn t_matvec(&self, _x: &[Self::S], _y: &mut [Self::S]) -> Result<(), KError> {
-        Err(KError::InvalidInput("t_matvec not supported by this operator".into()))
+    /// Whether this operator supports `t_matvec`.
+    fn supports_transpose(&self) -> bool {
+        false
+    }
+
+    /// Optional transpose/adjoint matvec. Default panics if unsupported.
+    fn t_matvec(&self, _x: &[Self::S], _y: &mut [Self::S]) {
+        panic!("LinOp::t_matvec called but supports_transpose() == false");
     }
 
     /// Downcast hook for specialized solvers/preconditioners.
@@ -29,11 +33,15 @@ pub trait LinOp: Send + Sync + Any {
 
     /// Changes when the nonzero pattern / shape changes.
     /// Default 0 -> unknown; higher layers may fall back to pointer identity.
-    fn structure_id(&self) -> StructureId { StructureId(0) }
+    fn structure_id(&self) -> StructureId {
+        StructureId(0)
+    }
 
     /// Changes when only numerical values change.
     /// Default 0 -> unknown.
-    fn values_id(&self) -> ValuesId { ValuesId(0) }
+    fn values_id(&self) -> ValuesId {
+        ValuesId(0)
+    }
 }
 
 /// Simple bumpable counters for LinOp implementors/wrappers.
@@ -58,8 +66,8 @@ impl ChangeIds {
 }
 
 // --- Optional wrappers for dense and CSR matrices -------------------------
-use faer::Mat;
 use crate::matrix::sparse::CsrMatrix;
+use faer::Mat;
 
 pub struct DenseOp {
     mat: Arc<Mat<f64>>,
@@ -72,17 +80,28 @@ impl DenseOp {
         ids.bump_values();
         Self { mat, ids }
     }
-    pub fn mark_structure_changed(&self) { self.ids.bump_structure(); }
-    pub fn mark_values_changed(&self) { self.ids.bump_values(); }
-    pub fn inner(&self) -> &Mat<f64> { &self.mat }
+    pub fn mark_structure_changed(&self) {
+        self.ids.bump_structure();
+    }
+    pub fn mark_values_changed(&self) {
+        self.ids.bump_values();
+    }
+    pub fn inner(&self) -> &Mat<f64> {
+        &self.mat
+    }
 }
 impl LinOp for DenseOp {
     type S = f64;
-    fn dims(&self) -> (usize, usize) { (self.mat.nrows(), self.mat.ncols()) }
+    fn dims(&self) -> (usize, usize) {
+        (self.mat.nrows(), self.mat.ncols())
+    }
     fn matvec(&self, x: &[f64], y: &mut [f64]) {
         let _ = crate::matrix::utils::parallel_mat_vec(&self.mat, x, y);
     }
-    fn t_matvec(&self, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+    fn supports_transpose(&self) -> bool {
+        true
+    }
+    fn t_matvec(&self, x: &[f64], y: &mut [f64]) {
         assert_eq!(x.len(), self.mat.nrows());
         assert_eq!(y.len(), self.mat.ncols());
         for j in 0..self.mat.ncols() {
@@ -92,11 +111,16 @@ impl LinOp for DenseOp {
             }
             y[j] = sum;
         }
-        Ok(())
     }
-    fn as_any(&self) -> &dyn Any { &*self.mat }
-    fn structure_id(&self) -> StructureId { self.ids.structure_id() }
-    fn values_id(&self) -> ValuesId { self.ids.values_id() }
+    fn as_any(&self) -> &dyn Any {
+        &*self.mat
+    }
+    fn structure_id(&self) -> StructureId {
+        self.ids.structure_id()
+    }
+    fn values_id(&self) -> ValuesId {
+        self.ids.values_id()
+    }
 }
 
 pub struct CsrOp {
@@ -110,19 +134,30 @@ impl CsrOp {
         ids.bump_values();
         Self { csr, ids }
     }
-    pub fn mark_structure_changed(&self) { self.ids.bump_structure(); }
-    pub fn mark_values_changed(&self) { self.ids.bump_values(); }
-    pub fn inner(&self) -> &CsrMatrix<f64> { &self.csr }
+    pub fn mark_structure_changed(&self) {
+        self.ids.bump_structure();
+    }
+    pub fn mark_values_changed(&self) {
+        self.ids.bump_values();
+    }
+    pub fn inner(&self) -> &CsrMatrix<f64> {
+        &self.csr
+    }
 }
 impl LinOp for CsrOp {
     type S = f64;
-    fn dims(&self) -> (usize, usize) { (self.csr.nrows(), self.csr.ncols()) }
-    fn matvec(&self, x: &[f64], y: &mut [f64]) { self.csr.spmv(x, y); }
-    fn t_matvec(&self, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
-        // y <- A^T x using CSR structure
-        if x.len() != self.csr.nrows() || y.len() != self.csr.ncols() {
-            return Err(KError::InvalidInput("t_matvec dimension mismatch".into()));
-        }
+    fn dims(&self) -> (usize, usize) {
+        (self.csr.nrows(), self.csr.ncols())
+    }
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        self.csr.spmv(x, y);
+    }
+    fn supports_transpose(&self) -> bool {
+        true
+    }
+    fn t_matvec(&self, x: &[f64], y: &mut [f64]) {
+        assert_eq!(x.len(), self.csr.nrows());
+        assert_eq!(y.len(), self.csr.ncols());
         y.fill(0.0);
         let rp = self.csr.row_ptr();
         let ci = self.csr.col_idx();
@@ -133,11 +168,16 @@ impl LinOp for CsrOp {
                 y[ci[idx]] += vv[idx] * xi;
             }
         }
-        Ok(())
     }
-    fn as_any(&self) -> &dyn Any { &*self.csr }
-    fn structure_id(&self) -> StructureId { self.ids.structure_id() }
-    fn values_id(&self) -> ValuesId { self.ids.values_id() }
+    fn as_any(&self) -> &dyn Any {
+        &*self.csr
+    }
+    fn structure_id(&self) -> StructureId {
+        self.ids.structure_id()
+    }
+    fn values_id(&self) -> ValuesId {
+        self.ids.values_id()
+    }
 }
 
 // --- Direct adapters ------------------------------------------------------
@@ -146,7 +186,9 @@ use std::hash::{Hash, Hasher};
 
 impl LinOp for Mat<f64> {
     type S = f64;
-    fn dims(&self) -> (usize, usize) { (self.nrows(), self.ncols()) }
+    fn dims(&self) -> (usize, usize) {
+        (self.nrows(), self.ncols())
+    }
     fn matvec(&self, x: &[f64], y: &mut [f64]) {
         assert_eq!(x.len(), self.ncols());
         assert_eq!(y.len(), self.nrows());
@@ -158,8 +200,10 @@ impl LinOp for Mat<f64> {
             y[i] = sum;
         }
     }
-    fn t_matvec(&self, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
-        // y <- A^T x
+    fn supports_transpose(&self) -> bool {
+        true
+    }
+    fn t_matvec(&self, x: &[f64], y: &mut [f64]) {
         assert_eq!(x.len(), self.nrows());
         assert_eq!(y.len(), self.ncols());
         for j in 0..self.ncols() {
@@ -169,27 +213,36 @@ impl LinOp for Mat<f64> {
             }
             y[j] = sum;
         }
-        Ok(())
     }
-    fn as_any(&self) -> &dyn Any { self }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
     fn structure_id(&self) -> StructureId {
         let mut h = DefaultHasher::new();
         self.nrows().hash(&mut h);
         self.ncols().hash(&mut h);
         StructureId(h.finish())
     }
-    fn values_id(&self) -> ValuesId { ValuesId(0) }
+    fn values_id(&self) -> ValuesId {
+        ValuesId(0)
+    }
 }
 
 use crate::matrix::sparse::SparseMatrix;
 impl LinOp for CsrMatrix<f64> {
     type S = f64;
-    fn dims(&self) -> (usize, usize) { (self.nrows(), self.ncols()) }
-    fn matvec(&self, x: &[f64], y: &mut [f64]) { self.spmv(x, y); }
-    fn t_matvec(&self, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
-        if x.len() != self.nrows() || y.len() != self.ncols() {
-            return Err(KError::InvalidInput("t_matvec dimension mismatch".into()));
-        }
+    fn dims(&self) -> (usize, usize) {
+        (self.nrows(), self.ncols())
+    }
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        self.spmv(x, y);
+    }
+    fn supports_transpose(&self) -> bool {
+        true
+    }
+    fn t_matvec(&self, x: &[f64], y: &mut [f64]) {
+        assert_eq!(x.len(), self.nrows());
+        assert_eq!(y.len(), self.ncols());
         y.fill(0.0);
         let rp = self.row_ptr();
         let ci = self.col_idx();
@@ -200,14 +253,17 @@ impl LinOp for CsrMatrix<f64> {
                 y[ci[idx]] += vv[idx] * xi;
             }
         }
-        Ok(())
     }
-    fn as_any(&self) -> &dyn Any { self }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
     fn structure_id(&self) -> StructureId {
         let mut h = DefaultHasher::new();
         self.row_ptr().hash(&mut h);
         self.col_idx().hash(&mut h);
         StructureId(h.finish())
     }
-    fn values_id(&self) -> ValuesId { ValuesId(0) }
+    fn values_id(&self) -> ValuesId {
+        ValuesId(0)
+    }
 }

--- a/src/matrix/op_shell.rs
+++ b/src/matrix/op_shell.rs
@@ -2,14 +2,13 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
 use super::op::{LinOp, StructureId, ValuesId};
-use crate::error::KError;
 
 /// Matrix-free "shell" operator.
 pub struct MatShell<S> {
     m: usize,
     n: usize,
     mv: Arc<dyn Fn(&[S], &mut [S]) + Send + Sync>,
-    mvt: Option<Arc<dyn Fn(&[S], &mut [S]) + Send + Sync>>, 
+    mvt: Option<Arc<dyn Fn(&[S], &mut [S]) + Send + Sync>>,
     sid: AtomicU64,
     vid: AtomicU64,
 }
@@ -50,20 +49,33 @@ impl MatShell<f64> {
 impl LinOp for MatShell<f64> {
     type S = f64;
 
-    fn dims(&self) -> (usize, usize) { (self.m, self.n) }
+    fn dims(&self) -> (usize, usize) {
+        (self.m, self.n)
+    }
 
-    fn matvec(&self, x: &[f64], y: &mut [f64]) { (self.mv)(x, y) }
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        (self.mv)(x, y)
+    }
 
-    fn t_matvec(&self, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+    fn supports_transpose(&self) -> bool {
+        self.mvt.is_some()
+    }
+
+    fn t_matvec(&self, x: &[f64], y: &mut [f64]) {
         if let Some(f) = &self.mvt {
             f(x, y);
-            Ok(())
         } else {
-            Err(KError::InvalidInput("t_matvec not supported by this operator".into()))
+            panic!("LinOp::t_matvec called but supports_transpose() == false");
         }
     }
 
-    fn structure_id(&self) -> StructureId { StructureId(self.sid.load(Ordering::Relaxed)) }
-    fn values_id(&self) -> ValuesId { ValuesId(self.vid.load(Ordering::Relaxed)) }
-    fn as_any(&self) -> &dyn std::any::Any { self }
+    fn structure_id(&self) -> StructureId {
+        StructureId(self.sid.load(Ordering::Relaxed))
+    }
+    fn values_id(&self) -> ValuesId {
+        ValuesId(self.vid.load(Ordering::Relaxed))
+    }
+    fn as_any(&self) -> &dyn std::any::Any {
+        self
+    }
 }

--- a/src/solver/cgnr.rs
+++ b/src/solver/cgnr.rs
@@ -2,7 +2,7 @@ use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::parallel::UniverseComm;
-use crate::preconditioner::{Preconditioner, PcSide};
+use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, SolveStats};
 
@@ -18,7 +18,12 @@ pub struct CgnrSolver {
 
 impl CgnrSolver {
     pub fn new(rtol: f64, maxits: usize) -> Self {
-        Self { rtol, atol: 1e-12, dtol: 1e3, maxits }
+        Self {
+            rtol,
+            atol: 1e-12,
+            dtol: 1e3,
+            maxits,
+        }
     }
 
     #[inline]
@@ -105,9 +110,7 @@ impl LinearSolver for CgnrSolver {
             return Err(KError::InvalidInput("CGNR: x has wrong length".into()));
         }
 
-        let mut probe_y = vec![0.0; ncols];
-        let probe = a.t_matvec(&vec![0.0; m], &mut probe_y);
-        if probe.is_err() {
+        if !a.supports_transpose() {
             return Err(KError::InvalidInput(
                 "CGNR requires t_matvec; provide an operator that implements A^T·x".into(),
             ));
@@ -131,9 +134,13 @@ impl LinearSolver for CgnrSolver {
             r.copy_from_slice(b);
         }
 
-        a.t_matvec(r, z)?;
+        a.t_matvec(r, z);
 
-        let mut zhat_buf: Vec<f64> = if pc.is_some() { vec![0.0; ncols] } else { Vec::new() };
+        let mut zhat_buf: Vec<f64> = if pc.is_some() {
+            vec![0.0; ncols]
+        } else {
+            Vec::new()
+        };
         if let Some(pc) = pc {
             pc.apply(PcSide::Left, z, &mut zhat_buf)?;
         }
@@ -183,7 +190,7 @@ impl LinearSolver for CgnrSolver {
                 r[i] -= alpha * ap[i];
             }
 
-            a.t_matvec(r, z)?;
+            a.t_matvec(r, z);
             if let Some(pc) = pc {
                 pc.apply(PcSide::Left, z, &mut zhat_buf)?;
             }
@@ -231,4 +238,3 @@ impl LinearSolver for CgnrSolver {
         })
     }
 }
-

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -194,5 +194,8 @@ pub mod dense_qr;
 pub mod superlu_dist;
 pub use superlu_dist::SuperLuDistSolver;
 
+pub mod qmr;
+pub use qmr::QmrSolver;
+
 pub mod pca_gmres;
 pub use pca_gmres::{PcaGmresSolver, PcaPcMode};

--- a/src/solver/qmr.rs
+++ b/src/solver/qmr.rs
@@ -1,405 +1,209 @@
-//! QMR solver (Saad §7.3)
-//!
-//! This module implements the Quasi-Minimal Residual (QMR) algorithm for solving large, sparse,
-//! nonsymmetric linear systems Ax = b. QMR is based on the Bi-Lanczos process and is designed to
-//! minimize the residual norm in a quasi-minimal sense. It is suitable for nonsymmetric and indefinite
-//! systems, and does not require breakdown-avoiding look-ahead as in BiCG.
-//!
-//! # Features
-//! - Handles general nonsymmetric systems
-//! - Uses both A and A^T (matrix and its transpose)
-//! - No preconditioning in this implementation
-//! - Tracks true residual for convergence
-//!
-//! # References
-//! - Saad, Y. (2003). Iterative Methods for Sparse Linear Systems, 2nd Edition. SIAM. §7.3
-//! - https://en.wikipedia.org/wiki/Quasi-minimal_residual_method
-
-use std::iter::Sum;
-
-use crate::solver::legacy::LinearSolver;
-use crate::core::traits::{MatVec, InnerProduct, MatTransVec};
-use crate::preconditioner::legacy::Preconditioner;
-use crate::utils::convergence::{Convergence, SolveStats};
+use crate::context::ksp_context::Workspace;
 use crate::error::KError;
-use num_traits::Float;
+use crate::matrix::op::LinOp;
+use crate::parallel::UniverseComm;
+use crate::preconditioner::Preconditioner;
+use crate::solver::LinearSolver;
+use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 
-#[cfg(feature = "logging")]
-use log::trace;
-#[cfg(feature = "logging")]
-use crate::utils::profiling::StageGuard;
-
-/// Quasi-Minimal Residual (QMR) method for nonsymmetric A
-pub struct QmrSolver<T> {
-    /// Convergence criteria (multi-threshold, max iterations)
-    pub conv: Convergence<T>,
+pub struct QmrSolver {
+    pub conv: Convergence<f64>,
 }
 
-impl<T: Float> QmrSolver<T> {
-    /// Create a new QMR solver with given tolerance and maximum iterations.
-    pub fn new(rtol: T, max_iters: usize) -> Self {
-        let atol = num_traits::cast(1e-12).unwrap_or(T::epsilon());
-        let dtol = num_traits::cast(1e3).unwrap_or(T::one());
+impl QmrSolver {
+    pub fn new(rtol: f64, maxits: usize) -> Self {
         Self {
             conv: Convergence {
                 rtol,
-                atol,
-                dtol,
-                max_iters,
-            }
+                atol: 1e-12,
+                dtol: 1e3,
+                max_iters: maxits,
+            },
         }
     }
 
-    /// Setup workspace for the QMR solver.
-    ///
-    /// Allocates temporary vectors needed for the QMR algorithm:
-    /// r, r_tld, p, p_tld, v, v_tld, s, t vectors.
-    pub fn setup_workspace(&mut self, work: &mut crate::context::ksp_context::Workspace, n: usize) {
-        work.n = n;
-        work.restart = 1; // QMR doesn't use restart like GMRES
-        
-        // Ensure we have enough temporary vectors for QMR (need 8 vectors total)
-        work.tmp1.resize(n, 0.0);
-        work.tmp2.resize(n, 0.0);
-        work.tmp3.resize(n, 0.0);
-        work.tmp4.resize(n, 0.0);
-        
-        // Use q vectors for additional workspace (r_tld, p, p_tld, v)
-        while work.q.len() < 4 {
-            work.q.push(vec![0.0; n]);
+    #[inline]
+    fn dot(x: &[f64], y: &[f64]) -> f64 {
+        x.iter().zip(y).map(|(a, b)| a * b).sum()
+    }
+
+    fn ensure_workspace(work: &mut Workspace, n: usize) {
+        let need = 6; // r_tld, p, p_tld, v, v_tld, s
+        if work.tmp1.len() != n {
+            work.tmp1.resize(n, 0.0);
         }
-        for q_vec in &mut work.q[..4] {
-            q_vec.resize(n, 0.0);
+        if work.tmp2.len() != n {
+            work.tmp2.resize(n, 0.0);
+        }
+        while work.q.len() < need {
+            work.q.push(Vec::new());
+        }
+        for q in &mut work.q[..need] {
+            if q.len() != n {
+                q.resize(n, 0.0);
+            }
         }
     }
 }
 
-impl<M: ?Sized, V, T> LinearSolver<M, V> for QmrSolver<T>
-where
-    M: 'static + MatVec<V> + MatTransVec<V> + Send + Sync,
-    (): InnerProduct<V, Scalar = T>,
-    V: From<Vec<T>> + AsRef<[T]> + AsMut<[T]> + Clone + Send + Sync,
-    T: Float + From<f64> + std::fmt::Debug + Sum + Send + Sync + std::fmt::LowerExp,
-{
+impl LinearSolver for QmrSolver {
     type Error = KError;
-    type Scalar = T;
 
-    /// Solve the linear system Ax = b using the QMR algorithm.
-    ///
-    /// This unified method handles all solve variants with optional monitoring,
-    /// profiling, and workspace for maximum efficiency.
-    ///
-    /// # Arguments
-    /// * `a` - Matrix implementing `MatVec` and `MatTransVec`
-    /// * `_pc` - (Unused) Optional preconditioner (not supported in this implementation)
-    /// * `b` - Right-hand side vector
-    /// * `x` - On input: initial guess; on output: solution vector
-    /// * `comm` - Communicator for parallel reductions
-    /// * `monitors` - Optional callbacks to invoke at each iteration with (iteration, residual_norm)
-    /// * `work` - Optional pre-allocated workspace containing temporary vectors
-    ///
-    /// # Returns
-    /// * `Ok(SolveStats)` if converged or max iterations reached
-    /// * `Err(KError)` on error
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
+
+    fn setup_workspace(&mut self, work: &mut Workspace) {
+        let n = work.tmp1.len();
+        Self::ensure_workspace(work, n);
+    }
+
     fn solve(
         &mut self,
-        a: &M,
-        _pc: Option<&(dyn crate::preconditioner::legacy::Preconditioner<M, V> + '_)>,
-        b: &V,
-        x: &mut V,
-        comm: &crate::parallel::UniverseComm,
-        monitors: Option<&[Box<dyn Fn(usize, Self::Scalar) + Send + Sync>]>,
-        mut work: Option<&mut crate::context::ksp_context::Workspace>,
-    ) -> Result<SolveStats<Self::Scalar>, Self::Error> {
-        #[cfg(feature = "logging")]
-        let _guard = StageGuard::new("QmrSolve");
-        
-        let monitors = monitors.unwrap_or(&[]);
-        
-        // Only use monitors if monitoring is enabled at runtime
-        let use_monitors = crate::utils::profiling::is_monitoring_enabled() && !monitors.is_empty();
-        
-        #[cfg(feature = "logging")]
-        trace!("Starting QMR solve, monitoring: {}, workspace: {}", use_monitors, work.is_some());
-
-        let n = b.as_ref().len();
-        let ip = ();
-        
-        // Get workspace vectors or allocate locally
-        // QMR needs 8 work vectors: r, r_tld, p, p_tld, v, v_tld, s, t
-        let (mut r, mut r_tld, mut p, mut p_tld, mut v, mut v_tld, mut s, mut t) = 
-            if let Some(workspace) = work.as_mut() {
-                // Use workspace buffers, converting from f64 to T
-                let r = workspace.tmp1.iter().map(|&x| <T as From<f64>>::from(x)).collect::<Vec<_>>();
-                let r_tld = workspace.tmp2.iter().map(|&x| <T as From<f64>>::from(x)).collect::<Vec<_>>();
-                let p = workspace.tmp3.iter().map(|&x| <T as From<f64>>::from(x)).collect::<Vec<_>>();
-                let p_tld = workspace.tmp4.iter().map(|&x| <T as From<f64>>::from(x)).collect::<Vec<_>>();
-                let v = workspace.q[0].iter().map(|&x| <T as From<f64>>::from(x)).collect::<Vec<_>>();
-                let v_tld = workspace.q[1].iter().map(|&x| <T as From<f64>>::from(x)).collect::<Vec<_>>();
-                let s = workspace.q[2].iter().map(|&x| <T as From<f64>>::from(x)).collect::<Vec<_>>();
-                let t = workspace.q[3].iter().map(|&x| <T as From<f64>>::from(x)).collect::<Vec<_>>();
-                (r, r_tld, p, p_tld, v, v_tld, s, t)
-            } else {
-                // Fallback to local allocation
-                (
-                    vec![T::zero(); n], vec![T::zero(); n], vec![T::zero(); n], vec![T::zero(); n],
-                    vec![T::zero(); n], vec![T::zero(); n], vec![T::zero(); n], vec![T::zero(); n]
-                )
-            };
-
-        let mut x_j = x.clone();
-        
-        // r0 = b - A x0
-        #[cfg(feature = "logging")]
-        let _matvec_guard = StageGuard::new("QmrMatVec");
-        a.matvec(x, &mut V::from(r.clone()));
-        #[cfg(feature = "logging")]
-        drop(_matvec_guard);
-        
-        for i in 0..n {
-            r[i] = b.as_ref()[i] - r[i];
+        a: &dyn LinOp<S = f64>,
+        _pc: Option<&dyn Preconditioner>,
+        b: &[f64],
+        x: &mut [f64],
+        _comm: &UniverseComm,
+        monitors: Option<&[Box<dyn Fn(usize, f64) + Send + Sync>]>,
+        work: Option<&mut Workspace>,
+    ) -> Result<SolveStats<f64>, Self::Error> {
+        let (m, ncols) = a.dims();
+        if m != ncols {
+            return Err(KError::InvalidInput("QMR requires square A".into()));
         }
-        
-        // r_tld0 = arbitrary, use r0
-        r_tld.copy_from_slice(&r);
-        
-        #[cfg(feature = "logging")]
-        let _norm_guard = StageGuard::new("QmrNorm");
-        let norm_r0 = ip.norm(&V::from(r.clone()), comm);
-        #[cfg(feature = "logging")]
-        drop(_norm_guard);
-        
-        let mut stats = SolveStats {
-            iterations: 0,
-            final_residual: norm_r0,
-            reason: crate::utils::convergence::ConvergedReason::Continued,
+        if b.len() != m || x.len() != ncols {
+            return Err(KError::InvalidInput("QMR: size mismatch".into()));
+        }
+        if !a.supports_transpose() {
+            return Err(KError::InvalidInput("QMR requires A^T".into()));
+        }
+
+        let mons = monitors.unwrap_or(&[]);
+        let mut local_work;
+        let w = match work {
+            Some(w) => w,
+            None => {
+                local_work = Workspace::new(ncols);
+                Self::ensure_workspace(&mut local_work, ncols);
+                &mut local_work
+            }
         };
-        
-        // Invoke monitors for iteration 0
-        if use_monitors {
-            for monitor in monitors {
-                monitor(0, norm_r0);
+        Self::ensure_workspace(w, ncols);
+
+        let (r, t) = (&mut w.tmp1, &mut w.tmp2);
+        let (r_tld, p, p_tld, v, v_tld, s) = {
+            let (a, rest) = w.q.split_at_mut(1);
+            let (b, rest) = rest.split_at_mut(1);
+            let (c, rest) = rest.split_at_mut(1);
+            let (d, rest) = rest.split_at_mut(1);
+            let (e, rest) = rest.split_at_mut(1);
+            let (f, _) = rest.split_at_mut(1);
+            (
+                &mut a[0], &mut b[0], &mut c[0], &mut d[0], &mut e[0], &mut f[0],
+            )
+        };
+
+        // r = b - A x
+        a.matvec(x, r);
+        for i in 0..ncols {
+            r[i] = b[i] - r[i];
+        }
+        r_tld.copy_from_slice(r);
+
+        let mut res = Self::dot(r, r).sqrt();
+        let res0 = res;
+        if !mons.is_empty() {
+            for m in mons {
+                m(0, res);
             }
         }
-        
-        #[cfg(feature = "logging")]
-        let _dot_guard = StageGuard::new("QmrDotProduct");
-        let mut rho = ip.dot(&V::from(r_tld.clone()), &V::from(r.clone()), comm);
-        #[cfg(feature = "logging")]
-        drop(_dot_guard);
-        
-        if rho == T::zero() {
-            *x = x_j;
-            
-            #[cfg(feature = "logging")]
-            let _norm_guard = StageGuard::new("QmrNorm");
-            stats.final_residual = ip.norm(&V::from(r.clone()), comm);
-            #[cfg(feature = "logging")]
-            drop(_norm_guard);
-            
-            stats.reason = crate::utils::convergence::ConvergedReason::ConvergedAtol;
-            return Ok(stats);
+        let mut stats = SolveStats {
+            iterations: 0,
+            final_residual: res,
+            reason: ConvergedReason::Continued,
+        };
+        let (reason, s0) = self.conv.check(res, res0, 0);
+        if reason != ConvergedReason::Continued {
+            return Ok(s0);
         }
-        
-        #[allow(unused_assignments)]
-        let mut beta = T::zero();
-        let mut res_norm = norm_r0;
-        
-        for j in 0..self.conv.max_iters {
-            #[cfg(feature = "logging")]
-            let _iter_guard = StageGuard::new("QmrIteration");
-            
-            #[cfg(feature = "logging")]
-            trace!("QMR iteration {}", j + 1);
-            
-            if j == 0 {
-                // First iteration: initialize p and p_tld
-                p.copy_from_slice(&r);
-                p_tld.copy_from_slice(&r_tld);
+
+        let mut rho = Self::dot(r_tld, r);
+        if rho == 0.0 {
+            return Ok(s0);
+        }
+
+        for k in 0..self.conv.max_iters {
+            if k == 0 {
+                p.copy_from_slice(r);
+                p_tld.copy_from_slice(r_tld);
             } else {
-                let rho_prev = rho;
-                
-                #[cfg(feature = "logging")]
-                let _dot_guard = StageGuard::new("QmrDotProduct");
-                rho = ip.dot(&V::from(r_tld.clone()), &V::from(r.clone()), comm);
-                #[cfg(feature = "logging")]
-                drop(_dot_guard);
-                
-                if rho == T::zero() {
+                let rho_new = Self::dot(r_tld, r);
+                if rho_new == 0.0 {
                     break;
                 }
-                beta = rho / rho_prev;
-                
-                // Update search directions
-                #[cfg(feature = "logging")]
-                let _axpy_guard = StageGuard::new("QmrAxpy");
-                for i in 0..n {
+                let beta = rho_new / rho;
+                for i in 0..ncols {
                     p[i] = r[i] + beta * p[i];
                     p_tld[i] = r_tld[i] + beta * p_tld[i];
                 }
-                #[cfg(feature = "logging")]
-                drop(_axpy_guard);
+                rho = rho_new;
             }
-            
-            // v = A p
-            #[cfg(feature = "logging")]
-            let _matvec_guard = StageGuard::new("QmrMatVec");
-            a.matvec(&V::from(p.clone()), &mut V::from(v.clone()));
-            #[cfg(feature = "logging")]
-            drop(_matvec_guard);
-            
-            // v_tld = A^T p_tld
-            #[cfg(feature = "logging")]
-            let _mattrans_guard = StageGuard::new("QmrMatTransVec");
-            a.mattransvec(&V::from(p_tld.clone()), &mut V::from(v_tld.clone()));
-            #[cfg(feature = "logging")]
-            drop(_mattrans_guard);
-            
-            #[cfg(feature = "logging")]
-            let _dot_guard = StageGuard::new("QmrDotProduct");
-            let sigma = ip.dot(&V::from(p_tld.clone()), &V::from(v.clone()), comm);
-            #[cfg(feature = "logging")]
-            drop(_dot_guard);
-            
-            if sigma == T::zero() {
+
+            a.matvec(p, v);
+            a.t_matvec(p_tld, v_tld);
+
+            let sigma = Self::dot(p_tld, v);
+            if sigma == 0.0 {
                 break;
             }
             let alpha = rho / sigma;
-            
-            // s = r - alpha v
-            #[cfg(feature = "logging")]
-            let _axpy_guard = StageGuard::new("QmrAxpy");
-            for i in 0..n {
+
+            for i in 0..ncols {
                 s[i] = r[i] - alpha * v[i];
             }
-            #[cfg(feature = "logging")]
-            drop(_axpy_guard);
-            
-            // t = A s
-            #[cfg(feature = "logging")]
-            let _matvec_guard = StageGuard::new("QmrMatVec");
-            a.matvec(&V::from(s.clone()), &mut V::from(t.clone()));
-            #[cfg(feature = "logging")]
-            drop(_matvec_guard);
-            
-            #[cfg(feature = "logging")]
-            let _dot_guard = StageGuard::new("QmrDotProduct");
-            let t_dot_s = ip.dot(&V::from(t.clone()), &V::from(s.clone()), comm);
-            let t_dot_t = ip.dot(&V::from(t.clone()), &V::from(t.clone()), comm);
-            #[cfg(feature = "logging")]
-            drop(_dot_guard);
-            
-            let omega = if t_dot_t != T::zero() { t_dot_s / t_dot_t } else { T::zero() };
-            
-            // x_{j+1} = x_j + alpha p + omega s
-            #[cfg(feature = "logging")]
-            let _axpy_guard = StageGuard::new("QmrAxpy");
-            for i in 0..n {
-                x_j.as_mut()[i] = x_j.as_ref()[i] + alpha * p[i] + omega * s[i];
+            a.matvec(s, t);
+            let ts = Self::dot(t, s);
+            let tt = Self::dot(t, t);
+            let omega = if tt != 0.0 { ts / tt } else { 0.0 };
+
+            for i in 0..ncols {
+                x[i] += alpha * p[i] + omega * s[i];
             }
-            #[cfg(feature = "logging")]
-            drop(_axpy_guard);
-            
-            // r = s - omega t
-            #[cfg(feature = "logging")]
-            let _axpy_guard = StageGuard::new("QmrAxpy");
-            for i in 0..n {
+            for i in 0..ncols {
                 r[i] = s[i] - omega * t[i];
             }
-            #[cfg(feature = "logging")]
-            drop(_axpy_guard);
-            
-            // Check convergence with true residual
-            #[cfg(feature = "logging")]
-            let _matvec_guard = StageGuard::new("QmrMatVec");
-            a.matvec(&x_j, &mut V::from(t.clone()));
-            #[cfg(feature = "logging")]
-            drop(_matvec_guard);
-            
-            for i in 0..n {
-                t[i] = b.as_ref()[i] - t[i];
+
+            // true residual
+            a.matvec(x, t);
+            for i in 0..ncols {
+                t[i] = b[i] - t[i];
             }
-            
-            #[cfg(feature = "logging")]
-            let _norm_guard = StageGuard::new("QmrNorm");
-            res_norm = ip.norm(&V::from(t.clone()), comm);
-            #[cfg(feature = "logging")]
-            drop(_norm_guard);
-            
-            #[cfg(feature = "logging")]
-            trace!("QMR iteration {}: residual = {:.3e}", j + 1, res_norm.to_f64().unwrap_or(0.0));
-            
-            // Invoke monitors if enabled
-            if use_monitors {
-                for monitor in monitors {
-                    monitor(j + 1, res_norm);
+            res = Self::dot(t, t).sqrt();
+
+            if !mons.is_empty() {
+                for m in mons {
+                    m(k + 1, res);
                 }
             }
-            
-            let (reason, s_stats) = self.conv.check(res_norm, norm_r0, j+1);
-            stats = s_stats;
-            if reason == crate::utils::convergence::ConvergedReason::ConvergedRtol
-                || reason == crate::utils::convergence::ConvergedReason::ConvergedAtol {
-                *x = x_j.clone();
-                stats.final_residual = res_norm;
-                stats.reason = reason;
+            let (reason, st) = self.conv.check(res, res0, k + 1);
+            stats = st;
+            if matches!(
+                reason,
+                ConvergedReason::ConvergedRtol | ConvergedReason::ConvergedAtol
+            ) {
                 return Ok(stats);
             }
         }
-        
-        #[cfg(feature = "logging")]
-        trace!("QMR solve completed after {} iterations", stats.iterations);
-        
-        *x = x_j;
-        stats.final_residual = res_norm;
+
+        stats.final_residual = res;
+        if stats.reason == ConvergedReason::Continued {
+            stats.reason = if res <= self.conv.rtol * res0 {
+                ConvergedReason::ConvergedRtol
+            } else {
+                ConvergedReason::DivergedMaxIts
+            };
+        }
         Ok(stats)
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::core::traits::MatVec;
-
-    /// Simple dense matrix for testing
-    #[derive(Clone, Debug)]
-    struct DenseMat { data: Vec<Vec<f64>> }
-    impl MatVec<Vec<f64>> for DenseMat {
-        /// Matrix-vector multiplication: y = A x
-        fn matvec(&self, x: &Vec<f64>, y: &mut Vec<f64>) {
-            for i in 0..x.len() {
-                y[i] = self.data[i].iter().zip(x).map(|(a,b)| a*b).sum();
-            }
-        }
-    }
-    impl crate::core::traits::MatTransVec<Vec<f64>> for DenseMat {
-        /// Matrix-transpose-vector multiplication: y = A^T x
-        fn mattransvec(&self, x: &Vec<f64>, y: &mut Vec<f64>) {
-            let n = self.data.len();
-            let m = self.data[0].len();
-            for j in 0..m {
-                y[j] = 0.0;
-                for i in 0..n {
-                    y[j] += self.data[i][j] * x[i];
-                }
-            }
-        }
-    }
-
-    #[ignore]
-    #[test]
-    fn qmr_solves_small_nonsym() {
-        // A simple 2×2 nonsymmetric system
-        // [2 1; 0 3] x = [3; 6] ⇒ x = [1;2]
-        let a = DenseMat { data: vec![vec![2.0,1.0], vec![0.0,3.0]] };
-        let b = vec![3.0,6.0];
-        let mut x = vec![0.0,0.0];
-        let mut solver = QmrSolver::new(1e-10, 50);
-        let stats = solver.solve(&a, None, &b, &mut x, &crate::parallel::UniverseComm::NoComm(crate::parallel::NoComm), None, None).unwrap();
-        assert!((x[0]-1.0).abs() < 1e-4);
-        assert!((x[1]-2.0).abs() < 1e-4);
-        assert!(matches!(stats.reason,
-            crate::utils::convergence::ConvergedReason::ConvergedRtol |
-            crate::utils::convergence::ConvergedReason::ConvergedAtol), "QMR did not report Converged reason");
     }
 }

--- a/tests/qmr.rs
+++ b/tests/qmr.rs
@@ -1,0 +1,36 @@
+use faer::Mat;
+use kryst::matrix::op::LinOp;
+use kryst::parallel::UniverseComm;
+use kryst::solver::{LinearSolver, QmrSolver};
+use std::sync::Arc;
+
+#[test]
+fn qmr_solves_simple_nonsymmetric() {
+    // A = [[2,1],[0,3]]; b = A * [1,2] = [4,6]
+    let mut a_mat = Mat::<f64>::zeros(2, 2);
+    a_mat[(0, 0)] = 2.0;
+    a_mat[(0, 1)] = 1.0;
+    a_mat[(1, 0)] = 0.0;
+    a_mat[(1, 1)] = 3.0;
+    let a: Arc<dyn LinOp<S = f64>> = Arc::new(a_mat);
+    let b = [4.0, 6.0];
+    let mut x = [0.0, 0.0];
+    let mut solver = QmrSolver::new(1e-12, 100);
+    let stats = solver
+        .solve(
+            a.as_ref(),
+            None,
+            &b,
+            &mut x,
+            &UniverseComm::NoComm(kryst::parallel::NoComm),
+            None,
+            None,
+        )
+        .expect("solve");
+    assert!(
+        (x[0] - 1.0).abs() < 1e-8 && (x[1] - 2.0).abs() < 1e-8,
+        "x = {:?}",
+        x
+    );
+    assert!(stats.final_residual <= 1e-10);
+}


### PR DESCRIPTION
## Summary
- extend `LinOp` with optional transpose support
- implement object-safe QMR solver over `&dyn LinOp`
- wire QMR into solver registry and add smoke test

## Testing
- `cargo test --tests`


------
https://chatgpt.com/codex/tasks/task_e_68a9613c2fc4832985a848afbabde544