### PR TITLE
Add mutable preconditioner support and flexible FGMRES

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,5 @@
+cargo-features = ["edition2024"]
+
 [package]
 name = "kryst"
 version = "1.2.1"

--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -393,21 +393,36 @@ impl KspContext {
             });
         }
 
-        let solver = self
-            .solver
-            .as_mut()
-            .ok_or_else(|| KError::SolveError("No solver".into()))?;
         let monitors = if self.monitors.is_empty() {
             None
         } else {
             Some(self.monitors.as_slice())
         };
+        let comm = UniverseComm::NoComm(crate::parallel::NoComm);
+        let pc = self.pc.as_mut().map(|b| b.as_mut() as &mut dyn Preconditioner);
+        let solver = self
+            .solver
+            .as_mut()
+            .ok_or_else(|| KError::SolveError("No solver".into()))?;
+
+        if let Some(fgmres) = solver.as_any_mut().downcast_mut::<crate::solver::FgmresSolver>() {
+            return fgmres.solve_flexible(
+                amat.as_ref(),
+                pc,
+                b,
+                x,
+                &comm,
+                monitors,
+                self.work.as_mut(),
+            );
+        }
+
         solver.solve(
             amat.as_ref(),
-            self.pc.as_deref(),
+            pc.map(|p| p as &dyn Preconditioner),
             b,
             x,
-            &UniverseComm::NoComm(crate::parallel::NoComm),
+            &comm,
             monitors,
             self.work.as_mut(),
         )
@@ -434,6 +449,11 @@ impl KspContext {
     /// Clear all registered monitors.
     pub fn clear_monitors(&mut self) {
         self.monitors.clear();
+    }
+
+    #[cfg(test)]
+    pub fn set_preconditioner(&mut self, pc: Box<dyn Preconditioner>) {
+        self.pc = Some(pc);
     }
 
     /// Invoke all monitors with the provided iteration and residual.

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -74,6 +74,15 @@ impl Preconditioner for NoOpPreconditioner {
         z.copy_from_slice(r);
         Ok(())
     }
+
+    fn apply_mut(
+        &mut self,
+        side: PcSide,
+        x: &[f64],
+        y: &mut [f64],
+    ) -> Result<(), KError> {
+        self.apply(side, x, y)
+    }
 }
 
 /// Adapter for matrix-based preconditioners implementing [`PreconditionerMat`].

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -1,6 +1,14 @@
 //! Preconditioners for linear solvers.
 //!
 //! This module defines the Preconditioner trait and includes implementations such as Jacobi, ILU, SOR, AMG, Additive Schwarz, and more.
+//!
+//! ## Flexible preconditioners
+//!
+//! Flexible Krylov methods call [`Preconditioner::apply_mut`], allowing
+//! preconditioners to update internal state between applications.
+//! Non-flexible solvers continue to invoke [`Preconditioner::apply`].
+//! The default `apply_mut` simply forwards to `apply`, so existing
+//! implementations remain unchanged unless they opt in to mutation.
 
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -69,6 +77,19 @@ pub trait Preconditioner: Send + Sync {
     /// Apply M⁻¹ to input vector, writing result to output slice.
     fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError>;
 
+    /// Mutable application (flexible/nonlinear preconditioners).
+    ///
+    /// By default, delegates to [`apply`], so existing preconditioners
+    /// remain immutable unless they explicitly override this method.
+    fn apply_mut(
+        &mut self,
+        side: PcSide,
+        x: &[f64],
+        y: &mut [f64],
+    ) -> Result<(), KError> {
+        self.apply(side, x, y)
+    }
+
     /// Attempt to solve `op * x = b` directly using the preconditioner.
     ///
     /// The default implementation returns [`KError::SolveError`] indicating
@@ -99,6 +120,10 @@ pub trait Preconditioner: Send + Sync {
         self.setup(a)
     }
 }
+
+/// Marker trait: any [`Preconditioner`] can be treated as flexible via [`apply_mut`].
+pub trait FlexiblePreconditioner: Preconditioner {}
+impl<T: Preconditioner + ?Sized> FlexiblePreconditioner for T {}
 
 /// Internal trait for preconditioners that operate directly on dense matrices.
 pub trait PreconditionerMat: Send + Sync {
@@ -156,6 +181,10 @@ impl Preconditioner for LegacyOpPreconditioner {
         self.inner.apply(side, &x_vec, &mut y_vec)?;
         y.copy_from_slice(&y_vec);
         Ok(())
+    }
+
+    fn apply_mut(&mut self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        self.apply(side, x, y)
     }
 }
 
@@ -219,5 +248,25 @@ mod tests {
             KError::SolveError(msg) => assert!(msg.contains("direct_solve not supported")),
             _ => panic!("unexpected error variant"),
         }
+    }
+
+    #[test]
+    fn default_apply_mut_forwards_to_apply() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+        struct CountPc {
+            calls: AtomicUsize,
+        }
+        impl Preconditioner for CountPc {
+            fn setup(&mut self, _a: &dyn LinOp<S = f64>) -> Result<(), KError> { Ok(()) }
+            fn apply(&self, _side: PcSide, _x: &[f64], _y: &mut [f64]) -> Result<(), KError> {
+                self.calls.fetch_add(1, Ordering::Relaxed);
+                Ok(())
+            }
+        }
+        let mut pc = CountPc { calls: AtomicUsize::new(0) };
+        let x = [0.0; 2];
+        let mut y = [0.0; 2];
+        pc.apply_mut(PcSide::Left, &x, &mut y).unwrap();
+        assert_eq!(pc.calls.load(Ordering::Relaxed), 1);
     }
 }

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -112,6 +112,272 @@ impl FgmresSolver {
             (a / r, b / r)
         }
     }
+
+    pub fn solve_flexible(
+        &mut self,
+        a: &dyn LinOp<S = f64>,
+        mut pc: Option<&mut dyn Preconditioner>,
+        b: &[f64],
+        x: &mut [f64],
+        comm: &UniverseComm,
+        monitors: Option<&[Box<dyn Fn(usize, f64) + Send + Sync>]>,
+        work: Option<&mut Workspace>,
+    ) -> Result<SolveStats<f64>, KError> {
+        let (m, n) = a.dims();
+        if m != n {
+            return Err(KError::InvalidInput(
+                "FGMRES requires a square operator".into(),
+            ));
+        }
+        if b.len() != n || x.len() != n {
+            return Err(KError::InvalidInput("FGMRES: vector size mismatch".into()));
+        }
+
+        let block_m = if self.preallocate {
+            self.restart.min(self.maxits)
+        } else {
+            self.restart
+        };
+
+        let mut owned_ws;
+        let ws = if let Some(ws) = work {
+            ws
+        } else {
+            owned_ws = Workspace {
+                tmp1: vec![0.0; n],
+                tmp2: vec![0.0; n],
+                q: vec![vec![0.0; n]; 2 * block_m + 1],
+                h: vec![vec![0.0; block_m]; block_m + 1],
+                cs: vec![0.0; block_m],
+                sn: vec![0.0; block_m],
+                g: vec![0.0; block_m + 1],
+            };
+            &mut owned_ws
+        };
+        self.ensure_workspace(ws, n, block_m);
+
+        let v_off = 0usize;
+        let z_off = block_m + 1;
+
+        a.matvec(x, &mut ws.tmp1);
+        for i in 0..n {
+            ws.tmp1[i] = b[i] - ws.tmp1[i];
+        }
+        let mut beta0 = Self::nrm2(&ws.tmp1, comm);
+        let bnorm = Self::nrm2(b, comm).max(1e-32);
+        let thr = self.atol.max(self.rtol * bnorm);
+
+        if beta0 > 0.0 {
+            let v0 = &mut ws.q[v_off + 0][..];
+            for i in 0..n {
+                v0[i] = ws.tmp1[i] / beta0;
+            }
+        }
+
+        ws.g.fill(0.0);
+        ws.g[0] = beta0;
+
+        let mut total_iters = 0usize;
+        let mut res = beta0;
+        let mut stats = SolveStats {
+            iterations: 0,
+            final_residual: res,
+            reason: ConvergedReason::Continued,
+        };
+
+        if let Some(mons) = monitors {
+            for m in mons {
+                m(0, res);
+            }
+        }
+        if res <= thr {
+            stats.final_residual = res;
+            stats.reason = if res <= self.atol {
+                ConvergedReason::ConvergedAtol
+            } else {
+                ConvergedReason::ConvergedRtol
+            };
+            return Ok(stats);
+        }
+
+        while total_iters < self.maxits {
+            let m_this = if self.preallocate {
+                block_m.min(self.maxits - total_iters)
+            } else {
+                self.restart.min(self.maxits - total_iters)
+            };
+
+            let mut arnoldi_steps = 0usize;
+            let mut converged = false;
+
+            for j in 0..m_this {
+                let (v_part, z_part) = ws.q.split_at_mut(z_off);
+                {
+                    let vj = &v_part[v_off + j][..];
+                    let zj = &mut z_part[j][..];
+                    if let Some(pc_) = pc.as_deref_mut() {
+                        pc_.apply_mut(PcSide::Right, vj, zj)?;
+                    } else {
+                        zj.copy_from_slice(vj);
+                    }
+                }
+                {
+                    let zj = &z_part[j][..];
+                    a.matvec(zj, &mut ws.tmp2);
+                }
+
+                for i in 0..=j {
+                    let vi = &v_part[v_off + i][..];
+                    let hij = Self::dot(&ws.tmp2, vi, comm);
+                    ws.h[i][j] = hij;
+                    for (w_i, &vi_val) in ws.tmp2.iter_mut().zip(vi) {
+                        *w_i -= hij * vi_val;
+                    }
+                }
+
+                if matches!(self.orthog, Orthog::Modified) {
+                    for i in 0..=j {
+                        let vi = &v_part[v_off + i][..];
+                        let corr = Self::dot(&ws.tmp2, vi, comm);
+                        if corr.abs() > 1e-12 {
+                            ws.h[i][j] += corr;
+                            for (w_i, &vi_val) in ws.tmp2.iter_mut().zip(vi) {
+                                *w_i -= corr * vi_val;
+                            }
+                        }
+                    }
+                }
+
+                let hij1 = Self::nrm2(&ws.tmp2, comm);
+                ws.h[j + 1][j] = hij1;
+
+                {
+                    let v_next = &mut v_part[v_off + j + 1][..];
+                    if hij1 > 0.0 {
+                        for i in 0..n {
+                            v_next[i] = ws.tmp2[i] / hij1;
+                        }
+                    } else {
+                        v_next.fill(0.0);
+                    }
+                }
+
+                for i in 0..j {
+                    let (top, bottom) = ws.h.split_at_mut(i + 1);
+                    let hij = &mut top[i][j];
+                    let hij1 = &mut bottom[0][j];
+                    Self::apply_givens(hij, hij1, ws.cs[i], ws.sn[i]);
+                }
+                let (c, s) = {
+                    let (top, bottom) = ws.h.split_at_mut(j + 1);
+                    let hjj = top[j][j];
+                    let hj1j = bottom[0][j];
+                    Self::givens(hjj, hj1j)
+                };
+                ws.cs[j] = c;
+                ws.sn[j] = s;
+                {
+                    let (top, bottom) = ws.h.split_at_mut(j + 1);
+                    let hjj = &mut top[j][j];
+                    let hj1j = &mut bottom[0][j];
+                    Self::apply_givens(hjj, hj1j, c, s);
+                }
+                let t = c * ws.g[j] + s * ws.g[j + 1];
+                ws.g[j + 1] = -s * ws.g[j] + c * ws.g[j + 1];
+                ws.g[j] = t;
+
+                res = ws.g[j + 1].abs();
+                total_iters += 1;
+                arnoldi_steps = j + 1;
+
+                if let Some(mons) = monitors {
+                    for m in mons {
+                        m(total_iters, res);
+                    }
+                }
+
+                let res0 = beta0;
+                let (reason, sstats) = crate::utils::convergence::Convergence {
+                    rtol: self.rtol,
+                    atol: self.atol,
+                    dtol: self.dtol,
+                    max_iters: self.maxits,
+                }
+                .check(res, res0, total_iters);
+                stats = sstats;
+                if matches!(
+                    reason,
+                    ConvergedReason::ConvergedRtol | ConvergedReason::ConvergedAtol
+                ) {
+                    stats.final_residual = res;
+                    stats.iterations = total_iters;
+                    converged = true;
+                    break;
+                }
+            }
+
+            let k = arnoldi_steps;
+            let mut y = vec![0.0; k];
+            for i in (0..k).rev() {
+                let mut sum = ws.g[i];
+                for l in (i + 1)..k {
+                    sum -= ws.h[i][l] * y[l];
+                }
+                y[i] = sum / ws.h[i][i];
+            }
+
+            for i in 0..k {
+                let zi = &ws.q[z_off + i][..];
+                for (xj, &zij) in x.iter_mut().zip(zi) {
+                    *xj += y[i] * zij;
+                }
+            }
+
+            if converged {
+                stats.reason = if res <= self.atol {
+                    ConvergedReason::ConvergedAtol
+                } else {
+                    ConvergedReason::ConvergedRtol
+                };
+                stats.final_residual = res;
+                break;
+            }
+
+            if total_iters >= self.maxits {
+                break;
+            }
+
+            a.matvec(x, &mut ws.tmp1);
+            for i in 0..n {
+                ws.tmp1[i] = b[i] - ws.tmp1[i];
+            }
+            beta0 = Self::nrm2(&ws.tmp1, comm);
+            ws.g.fill(0.0);
+            ws.g[0] = beta0;
+            let v0 = &mut ws.q[v_off + 0][..];
+            if beta0 > 0.0 {
+                for i in 0..n {
+                    v0[i] = ws.tmp1[i] / beta0;
+                }
+            } else {
+                v0.fill(0.0);
+            }
+            if let Some(hook) = self.modify_pc_on_restart.as_mut() {
+                hook(total_iters, beta0)?;
+            }
+        }
+
+        stats.iterations = total_iters;
+        stats.final_residual = res;
+        if matches!(stats.reason, ConvergedReason::Continued) {
+            stats.reason = if res <= thr {
+                ConvergedReason::ConvergedRtol
+            } else {
+                ConvergedReason::DivergedMaxIts
+            };
+        }
+        Ok(stats)
+    }
 }
 
 impl LinearSolver for FgmresSolver {

--- a/tests/fgmres_flexible.rs
+++ b/tests/fgmres_flexible.rs
@@ -1,0 +1,48 @@
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+
+use kryst::error::KError;
+use kryst::matrix::op::LinOp;
+use kryst::parallel::UniverseComm;
+use kryst::preconditioner::{PcSide, Preconditioner};
+use kryst::solver::FgmresSolver;
+
+struct MutableCountPc {
+    hits: Arc<AtomicUsize>,
+}
+
+impl Preconditioner for MutableCountPc {
+    fn setup(&mut self, _a: &dyn LinOp<S = f64>) -> Result<(), KError> { Ok(()) }
+    fn apply(&self, _side: PcSide, _x: &[f64], _y: &mut [f64]) -> Result<(), KError> {
+        panic!("FGMRES should not call immutable apply");
+    }
+    fn apply_mut(&mut self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        self.hits.fetch_add(1, Ordering::Relaxed);
+        y.copy_from_slice(x);
+        Ok(())
+    }
+}
+
+#[test]
+fn fgmres_uses_apply_mut() {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let mut pc = MutableCountPc { hits: hits.clone() };
+
+    let a = faer::Mat::<f64>::from_fn(2, 2, |i, j| if i == j {1.0} else {0.0});
+    let amat = &a as &dyn LinOp<S = f64>;
+    let mut solver = FgmresSolver::new(1e-6, 10, 2);
+    let b = [1.0, 2.0];
+    let mut x = [0.0, 0.0];
+    solver
+        .solve_flexible(
+            amat,
+            Some(&mut pc),
+            &b,
+            &mut x,
+            &UniverseComm::NoComm(kryst::parallel::NoComm),
+            None,
+            None,
+        )
+        .unwrap();
+
+    assert!(hits.load(Ordering::Relaxed) > 0, "apply_mut was not invoked");
+}


### PR DESCRIPTION
## Summary
- allow preconditioners to mutate state during application via new `apply_mut`
- dispatch mutable PCs to a new `FgmresSolver::solve_flexible`
- provide a regression test ensuring FGMRES uses the mutable path

## Testing
- `cargo +nightly test --lib --tests` *(fails: solver::tfqmr::tests::tfqmr_solves_diag_dom, solver::tfqmr::tests::tfqmr_solves_small_nonsym)*

------
https://chatgpt.com/codex/tasks/task_e_68a96fe5b0c08329a55c49af2be08e9e