### PR TITLE
LinOp as communicator source

### DIFF
--- a/examples/mpi_amg_gmres_demo.rs
+++ b/examples/mpi_amg_gmres_demo.rs
@@ -39,7 +39,7 @@ use kryst::parallel::MpiComm;
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize MPI and create communicator
     #[cfg(feature = "mpi")]
-    let comm = UniverseComm::Mpi(MpiComm::new());
+    let comm = UniverseComm::Mpi(std::sync::Arc::new(MpiComm::new()));
     #[cfg(not(feature = "mpi"))]
     let comm = UniverseComm::NoComm(kryst::parallel::NoComm);
 

--- a/examples/mpi_parallel_demo.rs
+++ b/examples/mpi_parallel_demo.rs
@@ -104,7 +104,7 @@ fn example_communicator_splitting() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(all(feature="rayon", not(feature="mpi")))]
     let main_comm = parallel::UniverseComm::Rayon(parallel::RayonComm::new());
     #[cfg(feature="mpi")]
-    let main_comm = parallel::UniverseComm::Mpi(parallel::MpiComm::new());
+    let main_comm = parallel::UniverseComm::Mpi(std::sync::Arc::new(parallel::MpiComm::new()));
     
     println!("Main communicator - Rank: {}, Size: {}", 
              main_comm.rank(), main_comm.size());
@@ -157,7 +157,7 @@ fn example_ksp_with_comm() -> Result<(), Box<dyn std::error::Error>> {
     #[cfg(all(feature="rayon", not(feature="mpi")))]
     let comm = parallel::UniverseComm::Rayon(parallel::RayonComm::new());
     #[cfg(feature="mpi")]
-    let comm = parallel::UniverseComm::Mpi(parallel::MpiComm::new());
+    let comm = parallel::UniverseComm::Mpi(std::sync::Arc::new(parallel::MpiComm::new()));
     
     // Setup KSP context with communicator
     let mut ksp = context::ksp_context::KspContext::new();

--- a/examples/superlu_dist_demo.rs
+++ b/examples/superlu_dist_demo.rs
@@ -63,7 +63,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             );
             println!();
         }
-        UniverseComm::Mpi(mpi_comm)
+        UniverseComm::Mpi(std::sync::Arc::new(mpi_comm))
     };
 
     #[cfg(not(feature = "mpi"))]

--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -267,8 +267,20 @@ impl KspContext {
         amat: Arc<dyn LinOp<S = f64>>,
         pmat: Option<Arc<dyn LinOp<S = f64>>>,
     ) -> &mut Self {
+        let pmat = pmat.unwrap_or_else(|| amat.clone());
+        let ac = amat.comm();
+        let pc = pmat.comm();
+        if ac != pc {
+            self.invalidate_setup();
+            let msg = format!(
+                "Amat/Pmat communicator mismatch: A={}, P={}",
+                ac.id(),
+                pc.id()
+            );
+            panic!("{}", msg);
+        }
         self.amat = Some(amat.clone());
-        self.pmat = Some(pmat.unwrap_or(amat));
+        self.pmat = Some(pmat);
         self.invalidate_setup();
         self
     }
@@ -380,12 +392,7 @@ impl KspContext {
             let pc = self.pc.as_mut().ok_or_else(|| {
                 KError::SolveError("PREONLY requires a direct PC (LU/QR/SuperLU_DIST)".into())
             })?;
-            pc.direct_solve(
-                pmat.as_ref(),
-                b,
-                x,
-                &UniverseComm::NoComm(crate::parallel::NoComm),
-            )?;
+            pc.direct_solve(pmat.as_ref(), b, x)?;
             return Ok(SolveStats {
                 iterations: 1,
                 final_residual: 0.0,
@@ -398,7 +405,7 @@ impl KspContext {
         } else {
             Some(self.monitors.as_slice())
         };
-        let comm = UniverseComm::NoComm(crate::parallel::NoComm);
+        let comm = amat.comm();
         let pc = self.pc.as_mut().map(|b| b.as_mut() as &mut dyn Preconditioner);
         let solver = self
             .solver

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -1,6 +1,7 @@
 use faer::traits::ComplexField;
 use std::any::Any;
 use std::sync::Arc;
+use crate::parallel::{UniverseComm, NoComm};
 use std::sync::atomic::{AtomicU64, Ordering};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
@@ -41,6 +42,11 @@ pub trait LinOp: Send + Sync + Any {
     /// Default 0 -> unknown.
     fn values_id(&self) -> ValuesId {
         ValuesId(0)
+    }
+
+    /// The communicator that owns this operator. Defaults to serial `NoComm`.
+    fn comm(&self) -> UniverseComm {
+        UniverseComm::NoComm(NoComm)
     }
 }
 

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -4,6 +4,7 @@ use mpi::datatype::Equivalence;
 use mpi::topology::{Communicator, Color};
 #[cfg(feature = "mpi")]
 use mpi::traits::*;
+use std::sync::Arc;
 
 /// Abstract communicator for reductions & splits
 pub trait Comm: Send + Sync + 'static {
@@ -50,7 +51,7 @@ pub trait Comm: Send + Sync + 'static {
 }
 
 /// Default no‐MPI/no‐parallel communicator for serial execution
-#[derive(Clone)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct NoComm;
 
 impl Comm for NoComm {
@@ -103,14 +104,60 @@ pub mod rayon_comm;
 #[cfg(feature="rayon")]
 pub use rayon_comm::RayonComm;
 
+#[derive(Clone)]
 pub enum UniverseComm {
     NoComm(NoComm),
     #[cfg(feature="mpi")]
-    Mpi(MpiComm),
+    Mpi(Arc<MpiComm>),
     #[cfg(feature="rayon")]
     Rayon(RayonComm),
     #[cfg(not(any(feature="mpi", feature="rayon")))]
     Serial,
+}
+
+impl std::fmt::Debug for UniverseComm {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            UniverseComm::NoComm(_) => f.write_str("NoComm"),
+            #[cfg(feature="mpi")]
+            UniverseComm::Mpi(comm) => write!(f, "MpiComm {{ id: {} }}", comm.world.as_raw()),
+            #[cfg(feature="rayon")]
+            UniverseComm::Rayon(_) => f.write_str("Rayon"),
+            #[cfg(not(any(feature="mpi", feature="rayon")))]
+            UniverseComm::Serial => f.write_str("Serial"),
+        }
+    }
+}
+
+impl PartialEq for UniverseComm {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (UniverseComm::NoComm(_), UniverseComm::NoComm(_)) => true,
+            #[cfg(feature="mpi")]
+            (UniverseComm::Mpi(a), UniverseComm::Mpi(b)) => a.world.as_raw() == b.world.as_raw(),
+            #[cfg(feature="rayon")]
+            (UniverseComm::Rayon(_), UniverseComm::Rayon(_)) => true,
+            #[cfg(not(any(feature="mpi", feature="rayon")))]
+            (UniverseComm::Serial, UniverseComm::Serial) => true,
+            _ => false,
+        }
+    }
+}
+
+impl Eq for UniverseComm {}
+
+impl UniverseComm {
+    pub fn id(&self) -> u64 {
+        match self {
+            UniverseComm::NoComm(_) => 0,
+            #[cfg(feature="mpi")]
+            UniverseComm::Mpi(comm) => comm.world.as_raw() as u64,
+            #[cfg(feature="rayon")]
+            UniverseComm::Rayon(_) => 0,
+            #[cfg(not(any(feature="mpi", feature="rayon")))]
+            UniverseComm::Serial => 0,
+        }
+    }
 }
 
 impl Comm for UniverseComm {
@@ -224,13 +271,13 @@ impl Comm for UniverseComm {
                 let sub = comm.world.split_by_color_with_key(Color::with_value(color), key).expect("Failed to split communicator");
                 let sub_rank = sub.rank() as usize;
                 let sub_size = sub.size() as usize;
-                let new_comm = MpiComm { 
+                let new_comm = MpiComm {
                     _universe: mpi::initialize().unwrap(), // Workaround for universe sharing
-                    world: sub, 
-                    rank: sub_rank, 
-                    size: sub_size 
+                    world: sub,
+                    rank: sub_rank,
+                    size: sub_size
                 };
-                UniverseComm::Mpi(new_comm)
+                UniverseComm::Mpi(Arc::new(new_comm))
             },
             #[cfg(feature="rayon")]
             UniverseComm::Rayon(_comm) => UniverseComm::Rayon(RayonComm::new()),

--- a/src/parallel/mpi_comm.rs
+++ b/src/parallel/mpi_comm.rs
@@ -26,6 +26,8 @@
 use mpi::traits::*;
 #[cfg(feature = "mpi")]
 use mpi::topology::{SimpleCommunicator, Communicator, Color};
+#[cfg(feature = "mpi")]
+use std::sync::Arc;
 
 /// MPI communicator wrapper for distributed parallelism.
 ///
@@ -151,12 +153,12 @@ impl super::Comm for MpiComm {
     fn split(&self, color: i32, key: i32) -> super::UniverseComm {
         // For now, we'll return a simplified implementation that doesn't actually split
         // A proper implementation would need to handle universe sharing differently
-        super::UniverseComm::Mpi(MpiComm {
+        super::UniverseComm::Mpi(Arc::new(MpiComm {
             _universe: mpi::initialize().unwrap(), // This is a workaround
             world: self.world.duplicate(),
             rank: self.rank,
             size: self.size,
-        })
+        }))
     }
 
     /// Parallel matrix-vector multiplication (currently serial, placeholder for distributed version).

--- a/src/preconditioner/direct/lu_pc.rs
+++ b/src/preconditioner/direct/lu_pc.rs
@@ -1,7 +1,6 @@
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};
-use crate::parallel::UniverseComm;
 use faer::Mat;
 
 pub struct LuPc;
@@ -31,7 +30,6 @@ impl Preconditioner for LuPc {
         pmat: &dyn LinOp<S = f64>,
         b: &[f64],
         x: &mut [f64],
-        _comm: &UniverseComm,
     ) -> Result<(), KError> {
         let a = pmat
             .as_any()

--- a/src/preconditioner/direct/qr_pc.rs
+++ b/src/preconditioner/direct/qr_pc.rs
@@ -1,7 +1,6 @@
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};
-use crate::parallel::UniverseComm;
 use faer::Mat;
 
 pub struct QrPc;
@@ -30,7 +29,6 @@ impl Preconditioner for QrPc {
         pmat: &dyn LinOp<S = f64>,
         b: &[f64],
         x: &mut [f64],
-        _comm: &UniverseComm,
     ) -> Result<(), KError> {
         let a = pmat
             .as_any()

--- a/src/preconditioner/direct/superlu_dist_pc.rs
+++ b/src/preconditioner/direct/superlu_dist_pc.rs
@@ -6,11 +6,13 @@ use crate::parallel::UniverseComm;
 #[cfg(feature = "superlu_dist")]
 use crate::matrix::sparse::CsrMatrix;
 
-pub struct SuperLuDistPc;
+pub struct SuperLuDistPc {
+    comm: Option<UniverseComm>,
+}
 
 impl SuperLuDistPc {
     pub fn new() -> Self {
-        Self
+        Self { comm: None }
     }
 }
 
@@ -18,6 +20,7 @@ impl Preconditioner for SuperLuDistPc {
     fn setup(&mut self, pmat: &dyn LinOp<S = f64>) -> Result<(), KError> {
         #[cfg(feature = "superlu_dist")]
         {
+            self.comm = Some(pmat.comm());
             pmat.as_any()
                 .downcast_ref::<CsrMatrix<f64>>()
                 .ok_or_else(|| {
@@ -45,7 +48,6 @@ impl Preconditioner for SuperLuDistPc {
         pmat: &dyn LinOp<S = f64>,
         b: &[f64],
         x: &mut [f64],
-        comm: &UniverseComm,
     ) -> Result<(), KError> {
         #[cfg(feature = "superlu_dist")]
         {
@@ -53,11 +55,12 @@ impl Preconditioner for SuperLuDistPc {
                 .as_any()
                 .downcast_ref::<CsrMatrix<f64>>()
                 .ok_or_else(|| KError::InvalidInput("SuperLU_DIST PC requires CSR matrix".into()))?;
-            crate::solver::superlu_dist::solve(a, b, x, comm)
+            let comm = self.comm.clone().unwrap_or_else(|| pmat.comm());
+            crate::solver::superlu_dist::solve(a, b, x, &comm)
         }
         #[cfg(not(feature = "superlu_dist"))]
         {
-            let _ = (pmat, b, x, comm);
+            let _ = (pmat, b, x);
             Err(KError::SolveError("superlu_dist feature not enabled".into()))
         }
     }

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -9,10 +9,13 @@
 //! Non-flexible solvers continue to invoke [`Preconditioner::apply`].
 //! The default `apply_mut` simply forwards to `apply`, so existing
 //! implementations remain unchanged unless they opt in to mutation.
+//!
+//! Preconditioners obtain the parallel communicator from the operator via
+//! [`LinOp::comm()`], eliminating the need to thread communicator handles
+//! through solver interfaces.
 
 use crate::error::KError;
 use crate::matrix::op::LinOp;
-use crate::parallel::UniverseComm;
 use faer::Mat;
 use std::str::FromStr;
 
@@ -99,7 +102,6 @@ pub trait Preconditioner: Send + Sync {
         _op: &dyn LinOp<S = f64>,
         _b: &[f64],
         _x: &mut [f64],
-        _comm: &UniverseComm,
     ) -> Result<(), KError> {
         Err(KError::SolveError(
             "direct_solve not supported by this preconditioner".into(),
@@ -243,7 +245,7 @@ mod tests {
         let mut pc = Dummy;
         let a = Mat::<f64>::zeros(1, 1);
         let mut x = [0.0];
-        let err = pc.direct_solve(&a, &[1.0], &mut x, &UniverseComm::NoComm(crate::parallel::NoComm)).unwrap_err();
+        let err = pc.direct_solve(&a, &[1.0], &mut x).unwrap_err();
         match err {
             KError::SolveError(msg) => assert!(msg.contains("direct_solve not supported")),
             _ => panic!("unexpected error variant"),

--- a/tests/comm.rs
+++ b/tests/comm.rs
@@ -1,0 +1,32 @@
+use std::sync::Arc;
+use faer::Mat;
+use kryst::matrix::op::LinOp;
+use kryst::parallel::{UniverseComm, NoComm};
+
+#[test]
+fn dense_linop_default_comm_is_no_comm() {
+    let a = Mat::<f64>::zeros(4, 4);
+    let op: &dyn LinOp<S = f64> = &a;
+    assert_eq!(op.comm(), UniverseComm::NoComm(NoComm));
+}
+
+#[cfg(not(any(feature = "mpi", feature = "rayon")))]
+#[test]
+#[should_panic(expected = "communicator mismatch")]
+fn set_operators_panics_on_comm_mismatch() {
+    use kryst::context::ksp_context::KspContext;
+
+    struct SerialOp;
+    impl LinOp for SerialOp {
+        type S = f64;
+        fn dims(&self) -> (usize, usize) { (1, 1) }
+        fn matvec(&self, _x: &[f64], _y: &mut [f64]) {}
+        fn as_any(&self) -> &dyn std::any::Any { self }
+        fn comm(&self) -> UniverseComm { UniverseComm::Serial }
+    }
+
+    let a = Arc::new(Mat::<f64>::zeros(1, 1));
+    let p = Arc::new(SerialOp);
+    let mut ksp = KspContext::new();
+    ksp.set_operators(a, Some(p));
+}


### PR DESCRIPTION
## Summary
- track parallel communicators via `LinOp::comm`
- validate consistent communicators in `KspContext::set_operators`
- streamline preconditioner `direct_solve` and store MPI context in SuperLU_DIST PC
- add basic communicator tests

## Testing
- `cargo test` *(fails: command terminated early)*

------
https://chatgpt.com/codex/tasks/task_e_68aa114429908329a05e0043b7628970