### PR TITLE
Gate legacy preconditioner bridge and remove MatOp adapter

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,6 +50,9 @@ mpi = ["dep:mpi"]
 logging = ["dep:log"]
 mpi_examples = ["mpi"]
 
+# Optional, OFF by default, so new PCs must target the modern trait.
+legacy-pc-bridge = []
+
 [[example]]
 name = "mpi_amg_gmres_demo"
 required-features = ["mpi_examples"]

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -2,10 +2,9 @@ use crate::config::options::PcOptions;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::direct::{LuPc, QrPc, SuperLuDistPc};
-use crate::preconditioner::{
-    jacobi::Jacobi, ChebyshevPre, Ilup, Ilut, Ilutp, LegacyOpPreconditioner, MatSorType, PcSide,
-    Preconditioner, PreconditionerMat, Sor,
-};
+use crate::preconditioner::{jacobi::Jacobi, LegacyOpPreconditioner, PcSide, Preconditioner};
+#[cfg(feature = "legacy-pc-bridge")]
+use crate::preconditioner::{ChebyshevPre, Ilup, Ilut, Ilutp, MatSorType, Sor};
 use faer::Mat;
 use std::str::FromStr;
 
@@ -85,30 +84,6 @@ impl Preconditioner for NoOpPreconditioner {
     }
 }
 
-/// Adapter for matrix-based preconditioners implementing [`PreconditionerMat`].
-struct MatOpPreconditioner {
-    inner: Box<dyn PreconditionerMat>,
-}
-
-impl MatOpPreconditioner {
-    fn new(inner: Box<dyn PreconditionerMat>) -> Self {
-        Self { inner }
-    }
-}
-
-impl Preconditioner for MatOpPreconditioner {
-    fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
-        let m = a
-            .as_any()
-            .downcast_ref::<Mat<f64>>()
-            .ok_or_else(|| KError::InvalidInput("expected faer::Mat<f64>".into()))?;
-        self.inner.setup_mat(m)
-    }
-
-    fn apply(&self, side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
-        self.inner.apply_vec(side, r, z)
-    }
-}
 
 /// Factory for creating preconditioners.
 pub struct PcFactory;
@@ -121,26 +96,76 @@ impl PcFactory {
         match pc_type {
             PcType::Jacobi => Ok(Box::new(Jacobi::new())),
             PcType::Ilut => {
-                let ilut = Ilut::new(0, 0.0);
-                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilut))))
-            }
+                #[cfg(feature = "legacy-pc-bridge")]
+                {
+                    let ilut = Ilut::new(0, 0.0);
+                    return Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilut))));
+                }
+                #[cfg(not(feature = "legacy-pc-bridge"))]
+                {
+                    return Err(KError::Unsupported(
+                        "Ilut requires --features legacy-pc-bridge (or port to modern Preconditioner)",
+                    ));
+                }
+            },
             PcType::Ilutp => {
-                let ilutp = Ilutp::new();
-                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilutp))))
-            }
+                #[cfg(feature = "legacy-pc-bridge")]
+                {
+                    let ilutp = Ilutp::new();
+                    return Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilutp))));
+                }
+                #[cfg(not(feature = "legacy-pc-bridge"))]
+                {
+                    return Err(KError::Unsupported(
+                        "Ilutp requires --features legacy-pc-bridge (or port to modern Preconditioner)",
+                    ));
+                }
+            },
             PcType::Ilup => {
-                let ilup = Ilup::new(0);
-                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilup))))
-            }
+                #[cfg(feature = "legacy-pc-bridge")]
+                {
+                    let ilup = Ilup::new(0);
+                    return Ok(Box::new(LegacyOpPreconditioner::new(Box::new(ilup))));
+                }
+                #[cfg(not(feature = "legacy-pc-bridge"))]
+                {
+                    return Err(KError::Unsupported(
+                        "Ilup requires --features legacy-pc-bridge (or port to modern Preconditioner)",
+                    ));
+                }
+            },
             PcType::Sor => {
-                let sor =
-                    Sor::<Mat<f64>, Vec<f64>, f64>::new(1.0, 1, 0, MatSorType::APPLY_LOWER, 0.0);
-                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(sor))))
-            }
+                #[cfg(feature = "legacy-pc-bridge")]
+                {
+                    let sor = Sor::<Mat<f64>, Vec<f64>, f64>::new(
+                        1.0,
+                        1,
+                        0,
+                        MatSorType::APPLY_LOWER,
+                        0.0,
+                    );
+                    return Ok(Box::new(LegacyOpPreconditioner::new(Box::new(sor))));
+                }
+                #[cfg(not(feature = "legacy-pc-bridge"))]
+                {
+                    return Err(KError::Unsupported(
+                        "SOR requires --features legacy-pc-bridge (or port to modern Preconditioner)",
+                    ));
+                }
+            },
             PcType::Chebyshev => {
-                let pre = ChebyshevPre::new(Mat::zeros(0, 0), 0, 1.0, 1.0);
-                Ok(Box::new(LegacyOpPreconditioner::new(Box::new(pre))))
-            }
+                #[cfg(feature = "legacy-pc-bridge")]
+                {
+                    let pre = ChebyshevPre::new(Mat::zeros(0, 0), 0, 1.0, 1.0);
+                    return Ok(Box::new(LegacyOpPreconditioner::new(Box::new(pre))));
+                }
+                #[cfg(not(feature = "legacy-pc-bridge"))]
+                {
+                    return Err(KError::Unsupported(
+                        "Chebyshev requires --features legacy-pc-bridge (or port to modern Preconditioner)",
+                    ));
+                }
+            },
             PcType::None => Ok(Box::new(NoOpPreconditioner)),
             PcType::Lu => Ok(Box::new(LuPc::new())),
             PcType::Qr => Ok(Box::new(QrPc::new())),

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -16,6 +16,7 @@
 
 use crate::error::KError;
 use crate::matrix::op::LinOp;
+#[cfg(feature = "legacy-pc-bridge")]
 use faer::Mat;
 use std::str::FromStr;
 
@@ -127,15 +128,6 @@ pub trait Preconditioner: Send + Sync {
 pub trait FlexiblePreconditioner: Preconditioner {}
 impl<T: Preconditioner + ?Sized> FlexiblePreconditioner for T {}
 
-/// Internal trait for preconditioners that operate directly on dense matrices.
-pub trait PreconditionerMat: Send + Sync {
-    /// Set up the preconditioner from a dense matrix.
-    fn setup_mat(&mut self, a: &Mat<f64>) -> Result<(), KError>;
-
-    /// Apply M⁻¹ to input slice.
-    fn apply_vec(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError>;
-}
-
 /// Legacy generic preconditioner traits retained for transitional adapters.
 pub mod legacy {
     use super::PcSide;
@@ -154,22 +146,39 @@ pub mod legacy {
     }
 }
 
-/// Adapter that wraps a legacy matrix-based preconditioner and exposes the new
-/// object-safe [`Preconditioner`] interface.
+#[cfg(feature = "legacy-pc-bridge")]
+use std::sync::Mutex;
+
+#[cfg(feature = "legacy-pc-bridge")]
 pub struct LegacyOpPreconditioner {
-    /// Inner legacy preconditioner operating on dense matrices and vectors.
     inner: Box<dyn legacy::Preconditioner<Mat<f64>, Vec<f64>> + Send + Sync>,
+    scratch: Mutex<Scratch>,
 }
 
+#[cfg(feature = "legacy-pc-bridge")]
+#[derive(Default)]
+struct Scratch {
+    x: Vec<f64>,
+    y: Vec<f64>,
+}
+
+#[cfg(feature = "legacy-pc-bridge")]
 impl LegacyOpPreconditioner {
-    /// Create a new adapter from a boxed legacy preconditioner.
     pub fn new(inner: Box<dyn legacy::Preconditioner<Mat<f64>, Vec<f64>> + Send + Sync>) -> Self {
-        Self { inner }
+        Self { inner, scratch: Mutex::new(Scratch::default()) }
+    }
+
+    #[inline]
+    fn ensure_scratch(s: &mut Scratch, n: usize) {
+        if s.x.len() != n { s.x.resize(n, 0.0); }
+        if s.y.len() != n { s.y.resize(n, 0.0); }
     }
 }
 
+#[cfg(feature = "legacy-pc-bridge")]
 impl Preconditioner for LegacyOpPreconditioner {
     fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        use crate::error::KError;
         let m = a
             .as_any()
             .downcast_ref::<Mat<f64>>()
@@ -178,15 +187,43 @@ impl Preconditioner for LegacyOpPreconditioner {
     }
 
     fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
-        let x_vec = x.to_vec();
-        let mut y_vec = vec![0.0; y.len()];
-        self.inner.apply(side, &x_vec, &mut y_vec)?;
-        y.copy_from_slice(&y_vec);
+        use crate::error::KError;
+        if x.len() != y.len() {
+            return Err(KError::InvalidInput(format!("x.len()={} != y.len()={}", x.len(), y.len())));
+        }
+        let mut s = self.scratch.lock().unwrap();
+        Self::ensure_scratch(&mut s, x.len());
+        s.x.copy_from_slice(x);
+        let Scratch { x: x_buf, y: y_buf } = &mut *s;
+        self.inner.apply(side, &*x_buf, y_buf)?;
+        y.copy_from_slice(&s.y);
         Ok(())
     }
 
     fn apply_mut(&mut self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
         self.apply(side, x, y)
+    }
+}
+
+#[cfg(not(feature = "legacy-pc-bridge"))]
+pub struct LegacyOpPreconditioner {
+    _private: (),
+}
+
+#[cfg(not(feature = "legacy-pc-bridge"))]
+impl LegacyOpPreconditioner {
+    pub fn new(_: Box<dyn legacy::Preconditioner<faer::Mat<f64>, Vec<f64>> + Send + Sync>) -> Self {
+        panic!("legacy-pc-bridge feature is disabled")
+    }
+}
+
+#[cfg(not(feature = "legacy-pc-bridge"))]
+impl Preconditioner for LegacyOpPreconditioner {
+    fn setup(&mut self, _: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        Err(KError::Unsupported("legacy-pc-bridge feature is disabled"))
+    }
+    fn apply(&self, _: PcSide, _: &[f64], _: &mut [f64]) -> Result<(), KError> {
+        Err(KError::Unsupported("legacy-pc-bridge feature is disabled"))
     }
 }
 
@@ -225,50 +262,4 @@ pub use self::sor::MatSorType;
 pub use crate::context::pc_context::{PC, SparsityPattern};
 
 #[cfg(test)]
-mod tests {
-    use super::*;
-    use faer::Mat;
-
-    struct Dummy;
-
-    impl Preconditioner for Dummy {
-        fn setup(&mut self, _pmat: &dyn LinOp<S = f64>) -> Result<(), KError> { Ok(()) }
-
-        fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
-            z.copy_from_slice(r);
-            Ok(())
-        }
-    }
-
-    #[test]
-    fn default_direct_solve_errors() {
-        let mut pc = Dummy;
-        let a = Mat::<f64>::zeros(1, 1);
-        let mut x = [0.0];
-        let err = pc.direct_solve(&a, &[1.0], &mut x).unwrap_err();
-        match err {
-            KError::SolveError(msg) => assert!(msg.contains("direct_solve not supported")),
-            _ => panic!("unexpected error variant"),
-        }
-    }
-
-    #[test]
-    fn default_apply_mut_forwards_to_apply() {
-        use std::sync::atomic::{AtomicUsize, Ordering};
-        struct CountPc {
-            calls: AtomicUsize,
-        }
-        impl Preconditioner for CountPc {
-            fn setup(&mut self, _a: &dyn LinOp<S = f64>) -> Result<(), KError> { Ok(()) }
-            fn apply(&self, _side: PcSide, _x: &[f64], _y: &mut [f64]) -> Result<(), KError> {
-                self.calls.fetch_add(1, Ordering::Relaxed);
-                Ok(())
-            }
-        }
-        let mut pc = CountPc { calls: AtomicUsize::new(0) };
-        let x = [0.0; 2];
-        let mut y = [0.0; 2];
-        pc.apply_mut(PcSide::Left, &x, &mut y).unwrap();
-        assert_eq!(pc.calls.load(Ordering::Relaxed), 1);
-    }
-}
+mod tests;

--- a/src/preconditioner/tests/legacy_bridge.rs
+++ b/src/preconditioner/tests/legacy_bridge.rs
@@ -1,0 +1,38 @@
+#[cfg(feature = "legacy-pc-bridge")]
+#[test]
+fn legacy_bridge_reuses_scratch() {
+    use crate::preconditioner::{PcSide, Preconditioner, legacy};
+    use faer::Mat;
+
+    // Minimal legacy PC that scales input by 2 into output.
+    struct Twice;
+    impl legacy::Preconditioner<Mat<f64>, Vec<f64>> for Twice {
+        fn setup(&mut self, _a: &Mat<f64>) -> Result<(), crate::error::KError> {
+            Ok(())
+        }
+        fn apply(
+            &self,
+            _side: PcSide,
+            r: &Vec<f64>,
+            z: &mut Vec<f64>,
+        ) -> Result<(), crate::error::KError> {
+            for (zi, ri) in z.iter_mut().zip(r.iter()) {
+                *zi = 2.0 * *ri;
+            }
+            Ok(())
+        }
+    }
+
+    let mut adapter = crate::preconditioner::LegacyOpPreconditioner::new(Box::new(Twice));
+    let a = Mat::<f64>::zeros(3, 3);
+    adapter.setup(&a).unwrap();
+
+    let x = [1.0, 3.0, -2.0];
+    let mut y = [0.0; 3];
+    adapter.apply(PcSide::Left, &x, &mut y).unwrap();
+    assert_eq!(y, [2.0, 6.0, -4.0]);
+
+    let mut y2 = [0.0; 3];
+    adapter.apply(PcSide::Left, &x, &mut y2).unwrap();
+    assert_eq!(y2, [2.0, 6.0, -4.0]);
+}

--- a/src/preconditioner/tests/mod.rs
+++ b/src/preconditioner/tests/mod.rs
@@ -1,0 +1,53 @@
+use super::*;
+use faer::Mat;
+
+struct Dummy;
+
+impl Preconditioner for Dummy {
+    fn setup(&mut self, _pmat: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        Ok(())
+    }
+
+    fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
+        z.copy_from_slice(r);
+        Ok(())
+    }
+}
+
+#[test]
+fn default_direct_solve_errors() {
+    let mut pc = Dummy;
+    let a = Mat::<f64>::zeros(1, 1);
+    let mut x = [0.0];
+    let err = pc.direct_solve(&a, &[1.0], &mut x).unwrap_err();
+    match err {
+        KError::SolveError(msg) => assert!(msg.contains("direct_solve not supported")),
+        _ => panic!("unexpected error variant"),
+    }
+}
+
+#[test]
+fn default_apply_mut_forwards_to_apply() {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    struct CountPc {
+        calls: AtomicUsize,
+    }
+    impl Preconditioner for CountPc {
+        fn setup(&mut self, _a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+            Ok(())
+        }
+        fn apply(&self, _side: PcSide, _x: &[f64], _y: &mut [f64]) -> Result<(), KError> {
+            self.calls.fetch_add(1, Ordering::Relaxed);
+            Ok(())
+        }
+    }
+    let mut pc = CountPc {
+        calls: AtomicUsize::new(0),
+    };
+    let x = [0.0; 2];
+    let mut y = [0.0; 2];
+    pc.apply_mut(PcSide::Left, &x, &mut y).unwrap();
+    assert_eq!(pc.calls.load(Ordering::Relaxed), 1);
+}
+
+mod legacy_bridge;


### PR DESCRIPTION
## Summary
- add `legacy-pc-bridge` feature for optional legacy preconditioner support
- drop matrix-only adapter and add reusable scratch buffers to `LegacyOpPreconditioner`
- gate legacy preconditioner factory paths with clear errors when feature is disabled

## Testing
- `cargo test --no-default-features --lib`
- `cargo test --no-default-features --features legacy-pc-bridge --lib`


------
https://chatgpt.com/codex/tasks/task_e_68aa1a6a5f04832980e55897a3467236