### PR TITLE
Enforce valid preconditioning side per solver

### DIFF
--- a/src/solver/bicgstab.rs
+++ b/src/solver/bicgstab.rs
@@ -22,6 +22,7 @@
 
 use crate::core::traits::{InnerProduct, MatVec};
 use crate::error::KError;
+use crate::preconditioner::PcSide;
 use crate::solver::legacy::LinearSolver;
 use crate::utils::convergence::{Convergence, SolveStats, ConvergedReason};
 use crate::utils::profiling::StageGuard;
@@ -87,8 +88,13 @@ where
         work: Option<&mut crate::context::ksp_context::Workspace>,
     ) -> Result<SolveStats<Self::Scalar>, Self::Error> {
         let _solve_stage = StageGuard::new("BiCGStabSolve");
-        
+
         let monitors = monitors.unwrap_or(&[]);
+
+        let pc_side = match pc_side {
+            PcSide::Symmetric => PcSide::Left,
+            s => s,
+        };
         
         // Only use monitors if monitoring is enabled at runtime
         let use_monitors = crate::utils::profiling::is_monitoring_enabled() && !monitors.is_empty();

--- a/src/solver/cg.rs
+++ b/src/solver/cg.rs
@@ -138,6 +138,12 @@ impl LinearSolver for CgSolver {
         #[cfg(feature = "logging")]
         let _guard = StageGuard::new("CG");
 
+        if pc_side != PcSide::Left {
+            return Err(KError::InvalidInput(
+                "CG/MINRES require Left preconditioning (SPD M)".into(),
+            ));
+        }
+
         let n = b.len();
         if x.len() != n {
             return Err(KError::InvalidInput("dimension mismatch x,b".into()));

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -139,6 +139,11 @@ impl FgmresSolver {
             return Err(KError::InvalidInput("FGMRES: vector size mismatch".into()));
         }
 
+        let pc_side = match pc_side {
+            PcSide::Symmetric => PcSide::Left,
+            s => s,
+        };
+
         let block_m = if self.preallocate {
             self.restart.min(self.maxits)
         } else {

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -193,6 +193,11 @@ impl LinearSolver for GmresSolver {
             ));
         }
 
+        let pc_side = match pc_side {
+            PcSide::Symmetric => PcSide::Left,
+            s => s,
+        };
+
         let mut owned_ws;
         let ws = if let Some(w) = work { w } else {
             owned_ws = Workspace::new(n);
@@ -221,18 +226,17 @@ impl LinearSolver for GmresSolver {
                 ws.q.push(ws.tmp2.clone());
                 beta
             }
-            PcSide::Right | PcSide::Symmetric => {
+            PcSide::Right => {
                 let beta = Self::nrm2(&ws.tmp1);
                 let mut v0 = ws.tmp1.clone();
                 if beta > 0.0 {
                     for i in 0..n { v0[i] /= beta; }
                 }
                 ws.q.push(v0);
-                if matches!(pc_side, PcSide::Right) {
-                    ws.z.resize(1, vec![0.0; n]);
-                }
+                ws.z.resize(1, vec![0.0; n]);
                 beta
             }
+            PcSide::Symmetric => unreachable!(),
         };
 
         ws.g[0] = beta;
@@ -260,7 +264,7 @@ impl LinearSolver for GmresSolver {
                         a.matvec(&ws.q[k], &mut ws.tmp1);
                         self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
                     }
-                    PcSide::Right | PcSide::Symmetric => {
+                    PcSide::Right => {
                         self.apply_precond(pc, PcSide::Right, &ws.q[k], &mut ws.tmp2)?;
                         if matches!(pc_side, PcSide::Right) {
                             if ws.z.len() <= k { ws.z.resize(k + 1, vec![0.0; n]); }
@@ -268,6 +272,7 @@ impl LinearSolver for GmresSolver {
                         }
                         a.matvec(&ws.tmp2, &mut ws.tmp1);
                     }
+                    PcSide::Symmetric => unreachable!(),
                 }
 
                 let (hcol, vnext) = Self::orthonormalize(&ws.q, &mut ws.tmp1);
@@ -296,7 +301,8 @@ impl LinearSolver for GmresSolver {
             let y = Self::backsolve(&ws.h, &ws.g, k_steps);
             match pc_side {
                 PcSide::Left => Self::axpy_update(x, &ws.q, &y),
-                PcSide::Right | PcSide::Symmetric => Self::axpy_update(x, &ws.z, &y),
+                PcSide::Right => Self::axpy_update(x, &ws.z, &y),
+                PcSide::Symmetric => unreachable!(),
             }
 
             // Recompute residual
@@ -307,7 +313,8 @@ impl LinearSolver for GmresSolver {
                     self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
                     Self::nrm2(&ws.tmp2)
                 }
-                PcSide::Right | PcSide::Symmetric => Self::nrm2(&ws.tmp1),
+                PcSide::Right => Self::nrm2(&ws.tmp1),
+                PcSide::Symmetric => unreachable!(),
             };
 
             if res <= thr || total_iters >= self.conv.max_iters {
@@ -332,7 +339,7 @@ impl LinearSolver for GmresSolver {
                     ws.q.push(ws.tmp2.clone());
                     ws.g[0] = beta;
                 }
-                PcSide::Right | PcSide::Symmetric => {
+                PcSide::Right => {
                     let beta = Self::nrm2(&ws.tmp1);
                     let mut v0 = ws.tmp1.clone();
                     if beta > 0.0 {
@@ -340,10 +347,9 @@ impl LinearSolver for GmresSolver {
                     }
                     ws.q.push(v0);
                     ws.g[0] = beta;
-                    if matches!(pc_side, PcSide::Right) {
-                        ws.z.resize(1, vec![0.0; n]);
-                    }
+                    ws.z.resize(1, vec![0.0; n]);
                 }
+                PcSide::Symmetric => unreachable!(),
             }
         }
 

--- a/src/solver/minres.rs
+++ b/src/solver/minres.rs
@@ -18,6 +18,7 @@ use crate::solver::legacy::LinearSolver;
 use crate::core::traits::{MatVec, InnerProduct};
 use crate::utils::convergence::{Convergence, SolveStats};
 use crate::error::KError;
+use crate::preconditioner::PcSide;
 use num_traits::Float;
 #[cfg(feature = "logging")]
 use log::trace;
@@ -114,8 +115,13 @@ where
         #[cfg(feature = "logging")]
         trace!("Starting MINRES solve");
 
+        if pc_side != PcSide::Left {
+            return Err(KError::InvalidInput(
+                "CG/MINRES require Left preconditioning (SPD M)".into(),
+            ));
+        }
+
         let _ = pc; // MINRES does not use preconditioner (yet)
-        let _ = pc_side;
         let n = b.as_ref().len();
         let ip = ();
 

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -80,6 +80,12 @@ impl LinearSolver for PcgSolver {
         monitors: Option<&[Box<dyn Fn(usize, f64) + Send + Sync>]>,
         work: Option<&mut Workspace>,
     ) -> Result<SolveStats<f64>, Self::Error> {
+        if pc_side != PcSide::Left {
+            return Err(KError::InvalidInput(
+                "CG/MINRES require Left preconditioning (SPD M)".into(),
+            ));
+        }
+
         let n = b.len();
         if x.len() != n {
             return Err(KError::InvalidInput("dimension mismatch: x,b".into()));

--- a/src/solver/qmr.rs
+++ b/src/solver/qmr.rs
@@ -81,6 +81,10 @@ impl LinearSolver for QmrSolver {
         }
 
         let mons = monitors.unwrap_or(&[]);
+        let pc_side = match pc_side {
+            PcSide::Symmetric => PcSide::Left,
+            s => s,
+        };
         let _ = pc_side;
         let mut local_work;
         let w = match work {

--- a/src/solver/tfqmr.rs
+++ b/src/solver/tfqmr.rs
@@ -77,6 +77,11 @@ impl LinearSolver for TfqmrSolver {
         }
         let mons: &[Box<dyn Fn(usize, f64) + Send + Sync>] = monitors.unwrap_or(&[]);
 
+        let pc_side = match pc_side {
+            PcSide::Symmetric => PcSide::Left,
+            s => s,
+        };
+
         let w = work.ok_or_else(|| {
             KError::InvalidInput("TFQMR requires a Workspace; call via KSP".into())
         })?;


### PR DESCRIPTION
## Summary
- Reject non-left preconditioning for CG, PCG, and MINRES
- Normalize symmetric side to left in GMRES-family and BiCGStab/QMR/TFQMR solvers

## Testing
- `cargo test --lib --tests` *(fails: no method named `setup` for struct `kryst::ilu::Ilu`)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3671e3f4832983165f3c61981915