### PR TITLE
Add tests for preconditioning side behaviors

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -613,3 +613,16 @@ impl KspContext {
         self.invalidate_setup();
     }
 }
+
+#[cfg(test)]
+impl KspContext {
+    /// Test-only: view current workspace (e.g., to inspect GMRES V/Z basis sizes).
+    pub fn debug_workspace(&self) -> Option<&Workspace> {
+        self.work.as_ref()
+    }
+
+    /// Test-only: inject a preconditioner for controlled testing.
+    pub fn set_pc_box_for_tests(&mut self, pc: Box<dyn Preconditioner>) {
+        self.pc = Some(pc);
+    }
+}

--- a/src/preconditioner/sor.rs
+++ b/src/preconditioner/sor.rs
@@ -222,3 +222,6 @@ where
         }
     }
 }
+
+#[cfg(all(test, feature = "legacy-pc-bridge"))]
+mod tests_symmetric;

--- a/src/preconditioner/sor/tests_symmetric.rs
+++ b/src/preconditioner/sor/tests_symmetric.rs
@@ -1,0 +1,46 @@
+#[cfg(all(test, feature = "legacy-pc-bridge"))]
+mod tests_sor_symmetric {
+    use crate::error::KError;
+    use crate::preconditioner::{Preconditioner, PcSide, LegacyOpPreconditioner};
+    use crate::preconditioner::sor::{Sor, MatSorType};
+    use faer::Mat;
+
+    #[test]
+    fn sor_symmetric_is_forward_then_backward() -> Result<(), KError> {
+        // SPD-ish tridiagonal
+        let a = Mat::from_fn(3, 3, |i, j| match (i, j) {
+            (0,0)=>4.0,(0,1)=>-1.0,(0,2)=>0.0,
+            (1,0)=>-1.0,(1,1)=>4.0,(1,2)=>-1.0,
+            (2,0)=>0.0,(2,1)=>-1.0,(2,2)=>3.0,
+            _ => unreachable!(),
+        });
+        let x = [1.0, -2.0, 3.0];
+
+        // Lower-only
+        let sor_lower = Sor::<Mat<f64>, Vec<f64>, f64>::new(1.0, 1, 0, MatSorType::APPLY_LOWER, 0.0);
+        let mut pc_lower = LegacyOpPreconditioner::new(Box::new(sor_lower));
+        pc_lower.setup(&a)?;
+        let mut y_fwd = [0.0; 3];
+        pc_lower.apply(PcSide::Left, &x, &mut y_fwd)?;
+
+        // Upper-only
+        let sor_upper = Sor::<Mat<f64>, Vec<f64>, f64>::new(1.0, 1, 0, MatSorType::APPLY_UPPER, 0.0);
+        let mut pc_upper = LegacyOpPreconditioner::new(Box::new(sor_upper));
+        pc_upper.setup(&a)?;
+        let mut y_bwd = [0.0; 3];
+        pc_upper.apply(PcSide::Left, &y_fwd, &mut y_bwd)?;
+
+        // Symmetric
+        let sor_sym = Sor::<Mat<f64>, Vec<f64>, f64>::new(1.0, 1, 0, MatSorType::SYMMETRIC_SWEEP, 0.0);
+        let mut pc_sym = LegacyOpPreconditioner::new(Box::new(sor_sym));
+        pc_sym.setup(&a)?;
+        let mut y_sym = [0.0; 3];
+        // should not matter which side we pass for an M^{-1} application
+        pc_sym.apply(PcSide::Right, &x, &mut y_sym)?;
+
+        for i in 0..3 {
+            assert!((y_bwd[i] - y_sym[i]).abs() < 1e-12, "symmetric mismatch at {i}");
+        }
+        Ok(())
+    }
+}

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -211,3 +211,6 @@ pub use tfqmr::TfqmrSolver;
 
 pub mod pca_gmres;
 pub use pca_gmres::{PcaGmresSolver, PcaPcMode};
+
+#[cfg(test)]
+mod tests;

--- a/src/solver/tests/cg_side.rs
+++ b/src/solver/tests/cg_side.rs
@@ -1,0 +1,32 @@
+#[cfg(test)]
+mod tests_cg_side {
+    use std::sync::Arc;
+    use crate::context::ksp_context::{KspContext, SolverType};
+    use crate::context::pc_context::PcType;
+    use crate::preconditioner::PcSide;
+    use crate::matrix::op::LinOp;
+    use crate::error::KError;
+    use faer::Mat;
+
+    #[test]
+    fn cg_rejects_right_side() {
+        // SPD 2x2
+        let a = Mat::from_fn(2, 2, |i, j| if i == j { 2.0 } else { 1.0 });
+        let b = [1.0, 0.0];
+        let amat: Arc<dyn LinOp<S=f64>> = Arc::new(a);
+
+        let mut ksp = KspContext::new();
+        ksp.set_type(SolverType::Cg).unwrap();
+        ksp.set_pc_type(PcType::Jacobi, None).unwrap();
+        ksp.set_operators(amat.clone(), None);
+        ksp.pc_side = PcSide::Right; // invalid for CG
+
+        let mut x = [0.0, 0.0];
+        let err = ksp.solve(&b, &mut x).unwrap_err();
+
+        match err {
+            KError::InvalidInput(msg) => assert!(msg.to_lowercase().contains("cg") && msg.to_lowercase().contains("left")),
+            _ => panic!("expected InvalidInput error, got {:?}", err),
+        }
+    }
+}

--- a/src/solver/tests/gmres_left_right.rs
+++ b/src/solver/tests/gmres_left_right.rs
@@ -1,0 +1,79 @@
+#[cfg(test)]
+mod tests_gmres_lr {
+    use std::sync::Arc;
+    use crate::context::ksp_context::{KspContext, SolverType};
+    use crate::context::pc_context::PcType;
+    use crate::preconditioner::PcSide;
+    use crate::matrix::op::LinOp;
+    use crate::error::KError;
+    use faer::Mat;
+
+    fn true_residual_norm(a: &dyn LinOp<S=f64>, x: &[f64], b: &[f64]) -> f64 {
+        let n = b.len();
+        let mut r = b.to_vec();
+        let mut ax = vec![0.0; n];
+        a.matvec(x, &mut ax);
+        for i in 0..n { r[i] -= ax[i]; }
+        (r.iter().map(|v| v*v).sum::<f64>()).sqrt()
+    }
+
+    #[test]
+    fn gmres_left_right_same_solution_jacobi() -> Result<(), KError> {
+        // Nonsymmetric, strictly diagonally dominant (easy to solve)
+        let a = Mat::from_fn(3, 3, |i, j| match (i, j) {
+            (0,0) => 4.0, (0,1) => 1.0, (0,2) => 0.0,
+            (1,0) => -2.0,(1,1) => 3.0, (1,2) => 1.0,
+            (2,0) => 0.0, (2,1) => -1.0,(2,2) => 2.0,
+            _ => unreachable!(),
+        });
+        let b = [1.0, 2.0, 3.0];
+
+        let amat: Arc<dyn LinOp<S=f64>> = Arc::new(a.clone());
+
+        // --- LEFT preconditioning
+        let mut ksp_left = KspContext::new();
+        ksp_left.set_type(SolverType::Gmres)?;
+        ksp_left.set_pc_type(PcType::Jacobi, None)?;
+        ksp_left.set_operators(amat.clone(), None);
+        ksp_left.pc_side = PcSide::Left;
+        ksp_left.rtol = 1e-10;
+        let mut x_left = [0.0; 3];
+        let stats_left = ksp_left.solve(&b, &mut x_left)?;
+
+        // --- RIGHT preconditioning
+        let mut ksp_right = KspContext::new();
+        ksp_right.set_type(SolverType::Gmres)?;
+        ksp_right.set_pc_type(PcType::Jacobi, None)?;
+        ksp_right.set_operators(amat.clone(), None);
+        ksp_right.pc_side = PcSide::Right;
+        ksp_right.rtol = 1e-10;
+        let mut x_right = [0.0; 3];
+        let stats_right = ksp_right.solve(&b, &mut x_right)?;
+
+        // True residuals are small and comparable
+        let res_l = true_residual_norm(amat.as_ref(), &x_left, &b);
+        let res_r = true_residual_norm(amat.as_ref(), &x_right, &b);
+        assert!(res_l < 5e-9, "left true residual too large: {res_l:e}");
+        assert!(res_r < 5e-9, "right true residual too large: {res_r:e}");
+        assert!((res_l - res_r).abs() < 1e-9, "true residuals differ: {res_l:e} vs {res_r:e}");
+
+        // Solutions match to tolerance
+        for i in 0..3 {
+            assert!((x_left[i] - x_right[i]).abs() < 1e-8, "x_left[{i}] != x_right[{i}]");
+        }
+
+        // Internal sanity: Left keeps no Z basis; Right populates it
+        if let Some(wl) = ksp_left.debug_workspace() {
+            assert!(wl.z.is_empty(), "Left GMRES should not populate Z basis");
+        }
+        if let Some(wr) = ksp_right.debug_workspace() {
+            assert!(!wr.z.is_empty(), "Right GMRES should populate Z basis");
+            assert_eq!(wr.z.len(), wr.q.len().saturating_sub(1), "Z basis length should match Krylov dim");
+        }
+
+        // And both reported convergence
+        assert!(matches!(stats_left.reason, crate::utils::convergence::ConvergedReason::ConvergedRtol | crate::utils::convergence::ConvergedReason::ConvergedAtol));
+        assert!(matches!(stats_right.reason, crate::utils::convergence::ConvergedReason::ConvergedRtol | crate::utils::convergence::ConvergedReason::ConvergedAtol));
+        Ok(())
+    }
+}

--- a/src/solver/tests/gmres_right_z_basis.rs
+++ b/src/solver/tests/gmres_right_z_basis.rs
@@ -1,0 +1,62 @@
+#[cfg(test)]
+mod tests_gmres_z_basis {
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use crate::preconditioner::{Preconditioner, PcSide};
+    use crate::context::ksp_context::{KspContext, SolverType};
+    use crate::matrix::op::LinOp;
+    use crate::error::KError;
+    use faer::Mat;
+
+    struct CountingIdentityPc {
+        hits: Arc<AtomicUsize>,
+    }
+    impl CountingIdentityPc {
+        fn new(hits: Arc<AtomicUsize>) -> Self { Self { hits } }
+    }
+    impl Preconditioner for CountingIdentityPc {
+        fn setup(&mut self, _a: &dyn LinOp<S=f64>) -> Result<(), KError> { Ok(()) }
+        fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+            self.hits.fetch_add(1, Ordering::Relaxed);
+            y.copy_from_slice(x);
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn gmres_right_uses_z_basis_and_calls_pc_per_step() -> Result<(), KError> {
+        // A: simple nonsymmetric to avoid early convergence in one step
+        let a = Mat::from_fn(4, 4, |i, j| if i == j { 3.0 } else if j + 1 == i { -1.0 } else { 0.2 });
+        let b = [1.0, 0.0, 0.0, 0.0];
+        let amat: Arc<dyn LinOp<S=f64>> = Arc::new(a);
+
+        // Counting identity PC
+        let hits = Arc::new(AtomicUsize::new(0));
+        let pc = Box::new(CountingIdentityPc::new(hits.clone())) as Box<dyn Preconditioner>;
+
+        // GMRES with a small restart to make a clear "cycle"
+        let mut ksp = KspContext::new();
+        ksp.set_type(SolverType::Gmres)?;
+        ksp.set_operators(amat.clone(), None);
+        ksp.pc_side = PcSide::Right;
+        ksp.restart = 3;   // keep small for predictable cycle
+        ksp.rtol = 1e-12;  // try to make it finish inside a couple cycles
+        ksp.set_pc_box_for_tests(pc);
+
+        let mut x = [0.0; 4];
+        let _stats = ksp.solve(&b, &mut x)?;
+
+        // Inspect workspace
+        let w = ksp.debug_workspace().expect("workspace present");
+        // Krylov dimension of last cycle (q has the Arnoldi basis vectors; q.len() = m+1)
+        let krylov_dim = w.q.len().saturating_sub(1);
+        // Z should have one vector per Arnoldi step
+        assert_eq!(w.z.len(), krylov_dim, "Z basis must match Krylov dimension for Right GMRES");
+
+        // Counting PC should be called once per step in the last cycle at least.
+        let calls = hits.load(Ordering::Relaxed);
+        assert!(calls >= w.z.len(), "PC apply calls ({calls}) must be >= last-cycle steps ({})", w.z.len());
+
+        Ok(())
+    }
+}

--- a/src/solver/tests/mod.rs
+++ b/src/solver/tests/mod.rs
@@ -1,0 +1,3 @@
+mod gmres_left_right;
+mod cg_side;
+mod gmres_right_z_basis;


### PR DESCRIPTION
## Summary
- Expose test-only helpers to inspect GMRES workspace and inject preconditioners
- Add regression tests covering GMRES left/right Jacobi parity, CG side validation, SOR symmetric sweep, and Z-basis use in right-preconditioned GMRES

## Testing
- `cargo test --lib --tests --features legacy-pc-bridge` *(fails: method takes 8 arguments but 7 supplied in tests/pcagmres.rs)*

------
https://chatgpt.com/codex/tasks/task_e_68aa80fe73588329b6dbe524b1e8d8e3