### PR TITLE
Refactor: silence selected clippy warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,15 +1,10 @@
-cargo-features = ["edition2024"]
-
 [package]
 name = "kryst"
 version = "1.2.1"
 edition = "2024"
- 
-[lib]
-doctest = false
+authors = ["Thomas James Mathis <tmathis720@gmail.com>"]
 description = "Krylov subspace and preconditioned iterative solvers for dense and sparse linear systems, with shared and distributed memory parallelism."
 license = "MIT"
-authors = ["Thomas James Mathis <tmathis720@gmail.com>"]
 repository = "https://github.com/tmathis720/kryst"
 documentation = "https://docs.rs/kryst"
 homepage = "https://github.com/tmathis720/kryst"
@@ -25,6 +20,9 @@ exclude = [
     "*.jpg",
     "*.jpeg",
 ]
+
+[lib]
+doctest = false
 
 [dependencies]
 faer = "0.22.6"
@@ -52,6 +50,8 @@ rayon = ["dep:rayon", "dep:num_cpus"]
 mpi = ["dep:mpi"]
 logging = ["dep:log"]
 mpi_examples = ["mpi"]
+superlu_dist = []
+tuning = []
 
 # Optional, OFF by default, so new PCs must target the modern trait.
 legacy-pc-bridge = []

--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -26,11 +26,11 @@ use crate::config::options::{KspOptions, PcOptions};
 use crate::context::pc_context::{DeferredPcInfo, PcFactory, PcType};
 use crate::error::KError;
 use crate::matrix::op::{LinOp, StructureId, ValuesId};
-use crate::parallel::{Comm, UniverseComm};
+use crate::parallel::Comm;
 use crate::preconditioner::{PcReusePolicy, PcSide, Preconditioner};
 use crate::solver::{
     BiCgStabSolver, CgSolver, CgnrSolver, CgsSolver, FgmresSolver, GmresSolver, LinearSolver,
-    MatSolverAdapter, MinresSolver, PcaGmresSolver, PcaPcMode, PcgSolver, QmrSolver, TfqmrSolver,
+    MatSolverAdapter, MinresSolver, PcaGmresSolver, PcaPcMode, PcgSolver,
 };
 use crate::utils::convergence::{ConvergedReason, SolveStats};
 use std::str::FromStr;

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -310,7 +310,7 @@ impl PcFactory {
 
     pub fn construct_deferred_preconditioner(
         info: DeferredPcInfo,
-        matrix: &Mat<f64>,
+        _matrix: &Mat<f64>,
     ) -> Result<Box<dyn Preconditioner>, KError> {
         match info.pc_type {
             PcType::Amg => Err(KError::NotImplemented("AMG not yet implemented".into())),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,8 +30,6 @@ pub use context::*;
 pub use core::*;
 pub use error::*;
 pub use matrix::*;
-pub use preconditioner::*;
-pub use solver::*;
 pub use utils::*;
 
 // Re-export SolveStats at the crate root for convenience

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -299,7 +299,7 @@ impl Comm for UniverseComm {
     }
 }
 
-#[cfg(all(not(feature = "mpi")))]
+#[cfg(not(feature = "mpi"))]
 pub trait Equivalence {}
 
 pub enum ReduceOp {

--- a/src/parallel/mpi_comm.rs
+++ b/src/parallel/mpi_comm.rs
@@ -1,38 +1,24 @@
-#[cfg(feature = "mpi")]
-use mpi::topology::{Color, Communicator, SimpleCommunicator};
-/// MPI-based parallel communication module.
-///
-/// This module provides an implementation of the `Comm` trait using the MPI (Message Passing Interface)
-/// backend for distributed-memory parallelism. It enables communication and collective operations
-/// between processes in a parallel environment, such as scatter, gather, barrier synchronization,
-/// and all-reduce. The implementation is only available when the `mpi` feature is enabled.
-///
-/// # Usage
-///
-/// - The `MpiComm` struct wraps an MPI communicator and exposes methods for parallel operations.
-/// - The `Comm` trait is implemented for `MpiComm`, allowing it to be used as a drop-in replacement
-///   for serial or other parallel communication backends.
-///
-/// # References
-/// - [MPI Standard](https://www.mpi-forum.org/)
-///
-/// # Example
-/// ```no_run
-/// #[cfg(feature = "mpi")]
-/// let comm = MpiComm::new();
-/// println!("Rank: {} / {}", comm.rank(), comm.size());
-/// comm.barrier();
-/// ```
+//! MPI-based parallel communication module.
+//!
+//! This module provides an implementation of the `Comm` trait using the MPI (Message Passing Interface)
+//! backend for distributed-memory parallelism. It enables communication and collective operations
+//! between processes in a parallel environment, such as scatter, gather, barrier synchronization,
+//! and all-reduce.
+//!
+//! # Example
+//! ```no_run
+//! let comm = MpiComm::new();
+//! println!("Rank: {} / {}", comm.rank(), comm.size());
+//! comm.barrier();
+//! ```
 
-#[cfg(feature = "mpi")]
+use mpi::topology::SimpleCommunicator;
 use mpi::traits::*;
-#[cfg(feature = "mpi")]
 use std::sync::Arc;
 
 /// MPI communicator wrapper for distributed parallelism.
 ///
 /// Holds the MPI universe, world communicator, the rank of the current process, and the total number of processes.
-#[cfg(feature = "mpi")]
 pub struct MpiComm {
     /// The MPI universe - must be kept alive for the entire duration
     pub _universe: mpi::environment::Universe,
@@ -44,12 +30,9 @@ pub struct MpiComm {
     pub size: usize,
 }
 
-#[cfg(feature = "mpi")]
 unsafe impl Send for MpiComm {}
-#[cfg(feature = "mpi")]
 unsafe impl Sync for MpiComm {}
 
-#[cfg(feature = "mpi")]
 impl MpiComm {
     /// Initializes MPI and constructs a new `MpiComm` instance.
     ///
@@ -90,7 +73,6 @@ impl MpiComm {
     }
 }
 
-#[cfg(feature = "mpi")]
 impl super::Comm for MpiComm {
     type Vec = Vec<f64>;
 
@@ -168,9 +150,8 @@ impl super::Comm for MpiComm {
     }
 
     /// Split this communicator into sub‐colors
-    fn split(&self, color: i32, key: i32) -> super::UniverseComm {
-        // For now, we'll return a simplified implementation that doesn't actually split
-        // A proper implementation would need to handle universe sharing differently
+    fn split(&self, _color: i32, _key: i32) -> super::UniverseComm {
+        // Placeholder: returns a duplicate of the current communicator
         super::UniverseComm::Mpi(Arc::new(MpiComm {
             _universe: mpi::initialize().unwrap(), // This is a workaround
             world: self.world.duplicate(),

--- a/src/preconditioner/asm.rs
+++ b/src/preconditioner/asm.rs
@@ -6,10 +6,6 @@ use crate::core::traits::MatVec;
 use crate::error::KError;
 use crate::preconditioner::{PcSide, legacy::Preconditioner};
 use crate::solver::legacy::LinearSolver;
-#[cfg(feature = "rayon")]
-use rayon::iter::IntoParallelRefIterator;
-#[cfg(feature = "rayon")]
-use rayon::prelude::*;
 use std::sync::Mutex;
 
 /// Additive Schwarz (overlapping block Jacobi) preconditioner.

--- a/src/preconditioner/builders.rs
+++ b/src/preconditioner/builders.rs
@@ -2,15 +2,18 @@ use crate::error::KError;
 use crate::preconditioner::{
     Preconditioner,
     chebyshev::ChebyshevPre,
-    direct::{LuPc, QrPc, SuperLuDistPc},
+    direct::{LuPc, QrPc},
     jacobi::Jacobi,
     sor::{MatSorType, Sor},
 };
 
+#[cfg(feature = "superlu_dist")]
+use crate::preconditioner::direct::SuperLuDistPc;
+
 use faer::Mat;
 
 #[cfg(feature = "legacy-pc-bridge")]
-use crate::preconditioner::{LegacyOpPreconditioner, ilup::Ilup, ilut::Ilut, ilutp::Ilutp};
+use crate::preconditioner::{LegacyOpPreconditioner, ilup::Ilup, ilut::Ilut};
 
 /// Build a Jacobi preconditioner.
 pub fn build_jacobi() -> Result<Box<dyn Preconditioner>, KError> {

--- a/src/preconditioner/ilu.rs
+++ b/src/preconditioner/ilu.rs
@@ -79,9 +79,6 @@ use faer::traits::ComplexField;
 use num_traits::Float;
 use std::cell::RefCell;
 
-#[cfg(feature = "rayon")]
-use rayon::prelude::*;
-
 #[cfg(feature = "logging")]
 use log::{debug, info, trace, warn};
 

--- a/src/preconditioner/sor.rs
+++ b/src/preconditioner/sor.rs
@@ -26,10 +26,10 @@ use num_traits::Float;
 use std::fmt;
 use std::marker::PhantomData;
 
-/// Bitflags for SOR sweep types and options.
-///
-/// Allows selection of forward, backward, symmetric, and Eisenstat sweeps.
 bitflags! {
+    /// Bitflags for SOR sweep types and options.
+    ///
+    /// Allows selection of forward, backward, symmetric, and Eisenstat sweeps.
     #[derive(Copy, Clone, Debug)]
     pub struct MatSorType: u32 {
         const ZERO_INITIAL_GUESS       = 0b000_00001;

--- a/src/solver/cgs.rs
+++ b/src/solver/cgs.rs
@@ -8,9 +8,6 @@ use crate::utils::convergence::{ConvergedReason, SolveStats};
 
 #[cfg(feature = "logging")]
 use crate::utils::profiling::StageGuard;
-#[cfg(feature = "logging")]
-use log::trace;
-
 pub struct CgsSolver {
     rtol: f64,
     atol: f64,

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -9,9 +9,6 @@ use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, SolveStats};
 
 #[cfg(feature = "logging")]
-use crate::utils::profiling::StageGuard;
-#[cfg(feature = "logging")]
-use log::trace;
 use std::any::Any;
 
 /// Orthogonalization flavor


### PR DESCRIPTION
## Summary
- move crate metadata to `[package]` and define `superlu_dist` and `tuning` features
- drop numerous unused imports and docs, including MPI communicator clean‑ups
- remove ambiguous re-exports from crate root

## Testing
- `cargo clippy --all-targets --all-features -- -D warnings` *(fails: duplicated attribute and 21 errors)*
- `cargo doc --no-deps` *(fails: unresolved links)*
- `cargo test` *(fails: unresolved imports and other warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68aaa8dd2aa88329b2ca7507d63ec4bd