### PR TITLE
Refactor tuning utilities for new KSP API and clean examples

### DIFF
--- a/examples/hypre_amg_demo.rs
+++ b/examples/hypre_amg_demo.rs
@@ -1,10 +1,9 @@
 use faer::Mat;
-use kryst::Preconditioner;
 use kryst::error::KError;
-use kryst::preconditioner::LegacyOpPreconditioner;
-use kryst::preconditioner::PcSide;
 use kryst::preconditioner::amg::{AMG, AMGBuilder, CoarsenType, InterpType, RelaxType};
-use kryst::preconditioner::legacy::Preconditioner as LegacyPreconditioner;
+use kryst::preconditioner::{
+    LegacyOpPreconditioner, PcSide, Preconditioner, legacy::Preconditioner as LegacyPreconditioner,
+};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     println!("    HYPRE-Inspired AMG Preconditioner Demo");

--- a/examples/hypre_gmres_demo.rs
+++ b/examples/hypre_gmres_demo.rs
@@ -8,7 +8,7 @@ use faer::mat;
 use kryst::core::traits::MatVec;
 use kryst::parallel::UniverseComm;
 use kryst::preconditioner::{Jacobi, PcSide, Preconditioner};
-use kryst::{LinearSolver, solver::GmresSolver};
+use kryst::solver::{GmresSolver, LinearSolver};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Build a well-conditioned non-symmetric system

--- a/examples/monitor.rs
+++ b/examples/monitor.rs
@@ -88,13 +88,11 @@ fn main() -> Result<(), KError> {
 
     // Monitor 2: Print progress every iteration
     ksp2.add_monitor(|iter, residual| {
-        if iter % 1 == 0 || residual < 1e-6 {
-            println!("  GMRES iter {}: ||r|| = {:.3e}", iter, residual);
-        }
+        println!("  GMRES iter {}: ||r|| = {:.3e}", iter, residual);
     });
 
     // Monitor 3: Check for stagnation using Arc<Mutex<>>
-    let prev_residual = Arc::new(Mutex::new(std::f64::INFINITY));
+    let prev_residual = Arc::new(Mutex::new(f64::INFINITY));
     let prev_residual_clone = Arc::clone(&prev_residual);
     ksp2.add_monitor(move |iter, residual| {
         if iter > 0 {

--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -719,7 +719,6 @@ impl AMG {
 
         let mut levels = Vec::with_capacity(config.max_levels);
         let mut current_matrix = matrix.clone();
-        let mut current_diag = utils::extract_diagonal_inverse(&current_matrix);
         let mut setup_complexity = 0.0;
         let original_size = matrix.nrows();
 
@@ -807,9 +806,6 @@ impl AMG {
                 utils::apply_truncation(&mut interpolation, config.truncation_factor);
             }
 
-            // Build coarse matrix (Galerkin product: R * A * P) with error checking
-            let coarse_matrix = &restriction * &current_matrix * &interpolation;
-
             // Convert to sparse format for storage and operations
             let sparse_interpolation = utils::to_sparse_with_tolerance(&interpolation, 1e-12);
             let sparse_restriction = utils::to_sparse_with_tolerance(&restriction, 1e-12);
@@ -855,9 +851,8 @@ impl AMG {
                 nnz: coarse_nnz,
             });
 
-            // Update for next iteration using sparse matrix
+            // Update for next iteration using dense coarse matrix
             current_matrix = coarse_matrix;
-            current_diag = coarse_diag;
 
             // Check for stalling (HYPRE-style)
             if current_matrix.nrows() >= n {
@@ -875,13 +870,14 @@ impl AMG {
         // Add the coarsest level
         let final_size = current_matrix.nrows();
         let final_sparse_matrix = utils::to_sparse_with_tolerance(&current_matrix, 1e-12);
+        let final_diag = utils::extract_diagonal_inverse(&current_matrix);
         let final_nnz = final_sparse_matrix.nnz();
 
         levels.push(AMGLevel {
             interpolation: CsrMatrix::identity(final_size),
             restriction: CsrMatrix::identity(final_size),
             coarse_matrix: final_sparse_matrix,
-            diag_inv: current_diag,
+            diag_inv: final_diag,
             nnz: final_nnz,
         });
 
@@ -997,7 +993,6 @@ impl AMG {
     ) -> Self {
         let mut levels = Vec::new();
         let mut current_matrix = a.clone();
-        let mut current_diag = utils::extract_diagonal_inverse(&current_matrix);
         for _level_idx in 0..max_levels {
             let n = current_matrix.nrows();
             if n <= 10 {
@@ -1044,7 +1039,6 @@ impl AMG {
                 nnz: coarse_nnz,
             });
             current_matrix = coarse_matrix_dense;
-            current_diag = coarse_diag;
         }
         // Add the coarsest level (identity prolongation/restriction)
         let diag_inv_final = Self::extract_diagonal_inverse(&current_matrix);

--- a/src/utils/tuning.rs
+++ b/src/utils/tuning.rs
@@ -22,7 +22,7 @@
 //! println!("Best configuration: {:?}", best_config);
 //! ```
 
-use crate::config::options::PcOptions;
+use crate::config::options::{KspOptions, PcOptions};
 use crate::context::KspContext;
 use crate::context::ksp_context::SolverType;
 use crate::context::pc_context::PcType;
@@ -30,6 +30,7 @@ use crate::error::KError;
 use crate::utils::monitor::IterationMonitor;
 use faer::Mat;
 use std::collections::HashMap;
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 /// Configuration for a single parameter combination.
@@ -259,7 +260,7 @@ impl ParameterTuner {
         &mut self,
         config: &ParameterConfig,
         matrix: &Mat<f64>,
-        rhs: &Vec<f64>,
+        rhs: &[f64],
     ) -> Result<PerformanceMetrics, KError> {
         let setup_start = Instant::now();
 
@@ -279,31 +280,36 @@ impl ParameterTuner {
 
         // Configure preconditioner
         if let Some(ref chain) = config.pc_chain {
-            // Use PC chain
-            let mut pc_opts = PcOptions::default();
-            pc_opts.pc_chain = Some(chain.clone());
+            // Build a structured chain from the configuration
+            let stages: Vec<PcOptions> = chain
+                .split("->")
+                .map(|token| {
+                    let mut stage = PcOptions {
+                        pc_type: Some(token.trim().to_string()),
+                        ..Default::default()
+                    };
+                    if token.contains("amg") {
+                        stage.amg_levels = config.amg_levels;
+                        stage.amg_strength_threshold = config.amg_strength_threshold;
+                        stage.amg_nu_pre = config.amg_nu_pre;
+                        stage.amg_nu_post = config.amg_nu_post;
+                    }
+                    if token.contains("chebyshev") {
+                        stage.chebyshev_degree = config.chebyshev_degree;
+                        stage.chebyshev_lambda_min = config.chebyshev_lambda_min;
+                        stage.chebyshev_lambda_max = config.chebyshev_lambda_max;
+                    }
+                    stage
+                })
+                .collect();
 
-            // Set AMG parameters if any preconditioner in chain is AMG
-            if chain.contains("amg") {
-                pc_opts.amg_levels = config.amg_levels;
-                pc_opts.amg_strength_threshold = config.amg_strength_threshold;
-                pc_opts.amg_nu_pre = config.amg_nu_pre;
-                pc_opts.amg_nu_post = config.amg_nu_post;
-            }
-
-            // Set Chebyshev parameters if any preconditioner in chain is Chebyshev
-            if chain.contains("chebyshev") {
-                pc_opts.chebyshev_degree = config.chebyshev_degree;
-                pc_opts.chebyshev_lambda_min = config.chebyshev_lambda_min;
-                pc_opts.chebyshev_lambda_max = config.chebyshev_lambda_max;
-            }
-
-            ksp.set_pc_options(pc_opts);
+            let pc_opts = PcOptions {
+                chain: Some(stages),
+                ..Default::default()
+            };
+            ksp.set_from_all_options(&KspOptions::default(), &pc_opts)?;
         } else {
-            // Single preconditioner
-            ksp.set_pc_type(config.pc_type)?;
-
-            // Set PC-specific options
+            // Single preconditioner with options
             let mut pc_opts = PcOptions::default();
             match config.pc_type {
                 PcType::Amg => {
@@ -319,12 +325,14 @@ impl ParameterTuner {
                 }
                 _ => {} // No special parameters for other types
             }
-            ksp.set_pc_options(pc_opts);
+            ksp.set_pc_type(config.pc_type, Some(&pc_opts))?;
         }
 
         // Setup timing
         let n = matrix.nrows();
-        ksp.setup(matrix, n)?;
+        let aop: Arc<dyn crate::matrix::op::LinOp<S = f64>> = Arc::new(matrix.clone());
+        ksp.set_operators(aop, None);
+        ksp.setup()?;
         let setup_time = setup_start.elapsed();
 
         // Create solution vector
@@ -345,7 +353,7 @@ impl ParameterTuner {
         let solve_start = Instant::now();
         let solve_result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             // Create a simple timeout mechanism using solver iteration callback
-            ksp.solve(matrix, rhs, &mut x)
+            ksp.solve(rhs, &mut x)
         }));
 
         let solve_time = solve_start.elapsed();
@@ -458,7 +466,7 @@ impl ParameterTuner {
     pub fn tune_parameters(
         &mut self,
         matrix: &Mat<f64>,
-        rhs: &Vec<f64>,
+        rhs: &[f64],
         max_trials: usize,
     ) -> Result<(ParameterConfig, Vec<PerformanceMetrics>), KError> {
         let configurations = self.generate_configurations();

--- a/tests/preconditioner_integration.rs
+++ b/tests/preconditioner_integration.rs
@@ -6,9 +6,9 @@
 //! preconditioner and solver interfaces are compatible and robust for a variety of matrix types.
 
 use faer::Mat;
-use kryst::LinearSolver;
 use kryst::preconditioner::legacy::Preconditioner;
 use kryst::preconditioner::{Jacobi, PcSide};
+use kryst::solver::LinearSolver;
 use kryst::solver::{CgSolver, GmresSolver};
 
 /// Construct a symmetric positive definite (SPD) tridiagonal matrix of size `n`.

--- a/tests/solver_iterative.rs
+++ b/tests/solver_iterative.rs
@@ -8,8 +8,8 @@
 use approx::assert_abs_diff_eq;
 use faer::Mat;
 use faer::linalg::solvers::SolveCore;
-use kryst::LinearSolver;
 use kryst::preconditioner::PcSide;
+use kryst::solver::LinearSolver;
 use kryst::solver::{CgSolver, GmresSolver};
 use rand::Rng;
 


### PR DESCRIPTION
## Summary
- Update parameter tuning to use structured preconditioner chains and new operator setup
- Remove unused AMG variables and finalize coarse-level data handling
- Fix trait imports in tests and examples and streamline monitoring example

## Testing
- `cargo fmt --all`
- `cargo clippy`
- `cargo doc --no-deps` *(fails: unresolved intra-doc links)*
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68aaac5c213c8329886bd2008ebaddc9