### PR TITLE
Fix missing Any import and remove unused imports

### DIFF
--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -4,6 +4,7 @@ use mpi::datatype::Equivalence;
 use mpi::topology::{Color, Communicator};
 #[cfg(feature = "mpi")]
 use mpi::traits::*;
+#[cfg(any(feature = "mpi", feature = "rayon"))]
 use std::sync::Arc;
 
 /// Abstract communicator for reductions & splits

--- a/src/preconditioner/builders.rs
+++ b/src/preconditioner/builders.rs
@@ -1,19 +1,25 @@
 use crate::error::KError;
 use crate::preconditioner::{
     Preconditioner,
-    chebyshev::ChebyshevPre,
     direct::{LuPc, QrPc},
     jacobi::Jacobi,
-    sor::{MatSorType, Sor},
+    sor::MatSorType,
+};
+
+#[cfg(feature = "legacy-pc-bridge")]
+use crate::preconditioner::{
+    chebyshev::ChebyshevPre,
+    sor::Sor,
+    LegacyOpPreconditioner,
+    ilup::Ilup,
+    ilut::Ilut,
 };
 
 #[cfg(feature = "superlu_dist")]
 use crate::preconditioner::direct::SuperLuDistPc;
 
-use faer::Mat;
-
 #[cfg(feature = "legacy-pc-bridge")]
-use crate::preconditioner::{LegacyOpPreconditioner, ilup::Ilup, ilut::Ilut};
+use faer::Mat;
 
 /// Build a Jacobi preconditioner.
 pub fn build_jacobi() -> Result<Box<dyn Preconditioner>, KError> {

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -7,8 +7,6 @@ use crate::parallel::UniverseComm;
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, SolveStats};
-
-#[cfg(feature = "logging")]
 use std::any::Any;
 
 /// Orthogonalization flavor


### PR DESCRIPTION
## Summary
- Import `std::any::Any` unconditionally in FGMRES to support trait casting
- Gate `Arc`, `Sor`, `ChebyshevPre`, and `faer::Mat` imports behind appropriate features
- Clean up unused imports to restore CI build

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68aab2eac98083298b1850eec5995281