### PR TITLE
fix: resolve unused warnings across solvers

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -53,6 +53,8 @@
 //!     .build(&matrix)?;
 //! ```
 
+#![allow(dead_code)]
+
 use crate::error::KError;
 use crate::matrix::sparse::{CsrMatrix, SparseMatrix};
 use crate::matrix::utils;
@@ -719,7 +721,7 @@ impl AMG {
 
         let mut levels = Vec::with_capacity(config.max_levels);
         let mut current_matrix = matrix.clone();
-        let mut setup_complexity = 0.0;
+        let mut _setup_complexity = 0.0;
         let original_size = matrix.nrows();
 
         for level_idx in 0..config.max_levels {
@@ -841,7 +843,7 @@ impl AMG {
 
             // HYPRE-style complexity tracking using sparse nnz
             let coarse_nnz = sparse_coarse_matrix.nnz();
-            setup_complexity += coarse_nnz as f64 / original_size as f64;
+            _setup_complexity += coarse_nnz as f64 / original_size as f64;
 
             levels.push(AMGLevel {
                 interpolation: sparse_interpolation,
@@ -886,12 +888,12 @@ impl AMG {
             info!(
                 "AMG Setup Complete: {} levels, complexity={:.2}",
                 levels.len(),
-                setup_complexity
+                _setup_complexity
             );
             if config.print_level > 0 {
                 println!(
                     "AMG Setup: {} -> {} (complexity: {:.2})",
-                    original_size, final_size, setup_complexity
+                    original_size, final_size, _setup_complexity
                 );
             }
         }
@@ -961,10 +963,10 @@ impl AMG {
             ..Default::default()
         };
 
-        Self::new_with_config(a, config).unwrap_or_else(|e| {
+        Self::new_with_config(a, config).unwrap_or_else(|_e| {
             // Fallback to original implementation for compatibility
             #[cfg(feature = "logging")]
-            warn!("AMG: Falling back to legacy constructor due to: {}", e);
+            warn!("AMG: Falling back to legacy constructor due to: {}", _e);
 
             Self::with_smoothing(a, max_levels, base_threshold, 1, 1)
         })

--- a/src/preconditioner/builders.rs
+++ b/src/preconditioner/builders.rs
@@ -50,6 +50,8 @@ pub fn build_sor(
     }
     #[cfg(not(feature = "legacy-pc-bridge"))]
     {
+        // avoid unused parameter warnings when the legacy bridge is disabled
+        let _ = (omega, sweeps, mat_side);
         Err(KError::Unsupported(
             "SOR requires --features legacy-pc-bridge (or port to modern Preconditioner)",
         ))
@@ -69,6 +71,8 @@ pub fn build_chebyshev(
     }
     #[cfg(not(feature = "legacy-pc-bridge"))]
     {
+        // avoid unused parameter warnings when the legacy bridge is disabled
+        let _ = (degree, eig_lo, eig_hi);
         Err(KError::Unsupported(
             "Chebyshev requires --features legacy-pc-bridge (or port to modern Preconditioner)",
         ))
@@ -118,6 +122,7 @@ pub fn build_iluk(level: usize) -> Result<Box<dyn Preconditioner>, KError> {
     }
     #[cfg(not(feature = "legacy-pc-bridge"))]
     {
+        let _ = level;
         Err(KError::Unsupported(
             "ILU(k) requires port or legacy-pc-bridge feature",
         ))
@@ -136,6 +141,7 @@ pub fn build_ilut(
     }
     #[cfg(not(feature = "legacy-pc-bridge"))]
     {
+        let _ = (drop_tol, max_fill);
         Err(KError::Unsupported(
             "ILUT requires port or legacy-pc-bridge feature",
         ))

--- a/src/preconditioner/direct/superlu_dist_pc.rs
+++ b/src/preconditioner/direct/superlu_dist_pc.rs
@@ -8,6 +8,7 @@ use crate::matrix::sparse::CsrMatrix;
 
 #[cfg_attr(docsrs, doc(cfg(feature = "superlu_dist")))]
 pub struct SuperLuDistPc {
+    #[allow(dead_code)]
     comm: Option<UniverseComm>,
 }
 

--- a/src/preconditioner/ilu.rs
+++ b/src/preconditioner/ilu.rs
@@ -369,7 +369,9 @@ pub struct Ilu<T> {
     /// Diagonal factor for modified ILU (extracted from U for efficiency)
     d: Vec<T>,
     /// Permutation arrays (HYPRE: perm, qperm)
+    #[allow(dead_code)]
     row_perm: Vec<usize>,
+    #[allow(dead_code)]
     col_perm: Vec<usize>,
     /// Consolidated preallocated workspace vectors for all operations
     workspace: IluWorkspace<T>,
@@ -553,11 +555,13 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Ilu<T> {
     }
 
     /// Enhanced matrix analysis using matrix utils
+    #[allow(dead_code)]
     fn analyze_matrix_for_ilu(matrix: &Mat<f64>) -> (usize, f64, f64) {
         utils::analyze_matrix_properties(matrix)
     }
 
     /// Check matrix for IEEE issues using matrix utils
+    #[allow(dead_code)]
     fn check_matrix_ieee(matrix: &Mat<f64>) -> Result<(), KError> {
         utils::check_ieee_values(matrix)
     }
@@ -1040,6 +1044,7 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Ilu<T> {
 
     #[cfg(feature = "rayon")]
     /// Parallel forward substitution using level scheduling
+    #[allow(dead_code)]
     fn solve_triangular_parallel_forward(&self, b: &[T], x: &mut [T]) {
         let n = b.len();
         x.copy_from_slice(b);
@@ -1062,6 +1067,7 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Ilu<T> {
 
     #[cfg(feature = "rayon")]
     /// Parallel backward substitution using level scheduling
+    #[allow(dead_code)]
     fn solve_triangular_parallel_backward(&self, b: &[T], x: &mut [T]) {
         let n = b.len();
         x.copy_from_slice(b);

--- a/src/solver/bicgstab.rs
+++ b/src/solver/bicgstab.rs
@@ -109,6 +109,8 @@ where
             use_monitors,
             work.is_some()
         );
+        #[cfg(not(feature = "logging"))]
+        let _ = work;
 
         let _ = pc; // BiCGStab does not use preconditioner (yet)
         let _ = pc_side;

--- a/src/solver/cg.rs
+++ b/src/solver/cg.rs
@@ -116,7 +116,7 @@ impl CgSolver {
             let tmp = &mut wk.tmp1[..];
             (r, z, p, ap, tmp)
         } else {
-            let mut mk = |n| -> &'static mut [f64] { Box::leak(vec![0.0; n].into_boxed_slice()) };
+            let mk = |n| -> &'static mut [f64] { Box::leak(vec![0.0; n].into_boxed_slice()) };
             (mk(n), mk(n), mk(n), mk(n), mk(n))
         }
     }
@@ -182,7 +182,7 @@ impl LinearSolver for CgSolver {
         if rho <= 0.0 || !rho.is_finite() {
             return Err(KError::IndefinitePreconditioner);
         }
-        let mut rsq = Self::dot(r, r, comm);
+        let rsq = Self::dot(r, r, comm);
         let bnorm = Self::nrm2(b, comm).max(1e-32);
         let mut xnorm = Self::nrm2(x, comm);
 
@@ -299,7 +299,6 @@ impl LinearSolver for CgSolver {
             }
 
             rho = rho_new;
-            rsq = rsq_new;
             stats.iterations = k;
             stats.final_residual = res;
         }

--- a/src/solver/cgs.rs
+++ b/src/solver/cgs.rs
@@ -168,7 +168,6 @@ impl LinearSolver for CgsSolver {
         }
 
         // CGS parameters
-        let mut rho_old = 0.0f64;
         let mut rho = Self::dot(&r_tld, r, comm); // (r~, r)
         if rho.abs() <= f64::EPSILON {
             return Err(KError::IndefiniteMatrix); // classic breakdown
@@ -178,6 +177,7 @@ impl LinearSolver for CgsSolver {
         u.copy_from_slice(r);
         p.copy_from_slice(u);
 
+        let mut rho_old: f64;
         let mut iters = 0usize;
         for k in 1..=self.maxits {
             iters = k;

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -415,7 +415,7 @@ impl LinearSolver for FgmresSolver {
     fn solve(
         &mut self,
         a: &dyn LinOp<S = f64>,
-        pc: Option<&dyn Preconditioner>,
+        _pc: Option<&dyn Preconditioner>,
         b: &[f64],
         x: &mut [f64],
         pc_side: PcSide,

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -97,10 +97,10 @@ impl LinearSolver for PcgSolver {
         let mut p_store = Vec::new();
         let mut w_store = Vec::new();
 
-        let mut r: &mut [f64] = &mut [];
-        let mut z: &mut [f64] = &mut [];
-        let mut p: &mut [f64] = &mut [];
-        let mut w: &mut [f64] = &mut [];
+        let r: &mut [f64];
+        let z: &mut [f64];
+        let p: &mut [f64];
+        let w: &mut [f64];
 
         if let Some(wk) = work {
             Self::take_or_resize(&mut wk.tmp1, n);

--- a/src/solver/superlu_dist.rs
+++ b/src/solver/superlu_dist.rs
@@ -111,7 +111,7 @@ impl ProcessGrid {
     /// Create a new process grid from communicator with automatic dimension selection
     pub fn new_auto(comm: &UniverseComm) -> Result<Self, KError> {
         let total_procs = comm.size();
-        let my_rank = comm.rank();
+        let _ = comm.rank();
 
         // Find optimal grid dimensions (as square as possible)
         let (prows, pcols) = Self::determine_optimal_grid(total_procs);
@@ -368,12 +368,12 @@ impl Panel {
     }
 
     /// Get mutable view as faer matrix
-    pub fn as_faer_mut(&mut self) -> MatMut<f64> {
+    pub fn as_faer_mut(&mut self) -> MatMut<'_, f64> {
         MatMut::from_column_major_slice_mut(&mut self.data, self.height, self.width)
     }
 
     /// Get view as faer matrix (using reference)
-    pub fn as_faer(&self) -> faer::MatRef<f64> {
+    pub fn as_faer(&self) -> faer::MatRef<'_, f64> {
         faer::MatRef::from_column_major_slice(&self.data, self.height, self.width)
     }
 
@@ -408,7 +408,7 @@ impl Panel {
                     }
 
                     if max_val < threshold {
-                        let error_msg = if max_val == 0.0 {
+                        let _error_msg = if max_val == 0.0 {
                             format!("Zero pivot encountered at column {}, matrix is singular", k)
                         } else {
                             format!(
@@ -419,7 +419,7 @@ impl Panel {
 
                         // For now, replace tiny pivot and continue, but log warning
                         #[cfg(feature = "logging")]
-                        log::warn!("{}", error_msg);
+                        log::warn!("{}", _error_msg);
 
                         is_singular = true;
                         if max_val == 0.0 {
@@ -710,7 +710,7 @@ impl TriangularSolveData {
         numeric_factor: &NumericFactorization,
     ) -> Self {
         let num_blocks = (n + block_size - 1) / block_size;
-        let local_blocks = num_blocks / distribution.grid.total_procs;
+        let _local_blocks = num_blocks / distribution.grid.total_procs;
 
         let mut local_solution_blocks = Vec::new();
         let mut block_owners = vec![0; num_blocks];
@@ -1326,13 +1326,16 @@ impl Default for SuperLuDistOptions {
 
 /// Graph structure for ordering algorithms
 #[derive(Debug, Clone)]
+#[allow(dead_code)]
 struct Graph {
     /// Number of vertices
+    #[allow(dead_code)]
     n: usize,
     /// Adjacency lists for each vertex
     adj: Vec<Vec<usize>>,
 }
 
+#[allow(dead_code)]
 impl Graph {
     /// Create graph from sparse matrix (A + A^T pattern)
     fn from_matrix_pattern(matrix: &CsrMatrix<f64>) -> Self {
@@ -1617,7 +1620,7 @@ impl OrderingAlgorithms {
     pub fn mmd_ata_ordering_distributed(
         matrix: &CsrMatrix<f64>,
         comm: &UniverseComm,
-        distribution: &BlockCyclicDistribution,
+        _distribution: &BlockCyclicDistribution,
     ) -> Result<Vec<usize>, KError> {
         let n = matrix.nrows();
 
@@ -1627,6 +1630,9 @@ impl OrderingAlgorithms {
 
         // Step 2: Build A + A^T graph
         let graph = Self::build_ata_graph(&global_pattern);
+
+        #[cfg(not(feature = "logging"))]
+        let _ = comm;
 
         // Step 3: Run MMD on the global graph (replicated computation)
         let mut adj_lists = graph.adj;
@@ -1641,6 +1647,8 @@ impl OrderingAlgorithms {
 
         // Main MMD elimination loop (same algorithm, but only log on rank 0)
         for step in 0..n {
+            #[cfg(not(feature = "logging"))]
+            let _ = step;
             let pivot = Self::select_minimum_degree_vertex(&degree, &eliminated);
             if pivot >= n {
                 break;

--- a/src/solver/tfqmr.rs
+++ b/src/solver/tfqmr.rs
@@ -91,7 +91,7 @@ impl LinearSolver for TfqmrSolver {
         })?;
         TfqmrSolver::setup_tfqmr_workspace(w, n);
 
-        let (r, Au) = (&mut w.tmp1, &mut w.tmp2);
+        let (r, au) = (&mut w.tmp1, &mut w.tmp2);
         let (u_slice, rest) = w.q.split_at_mut(1);
         let (v_slice, rest) = rest.split_at_mut(1);
         let (wv_slice, rest) = rest.split_at_mut(1);
@@ -180,16 +180,16 @@ impl LinearSolver for TfqmrSolver {
                     }
                 }
                 for i in 0..n {
-                    Au[i] = u[i] + qv[i];
+                    au[i] = u[i] + qv[i];
                 }
-                let tmp_in = Au.to_vec();
-                a.matvec(&tmp_in, Au);
+                let tmp_in = au.to_vec();
+                a.matvec(&tmp_in, au);
                 if let Some(pc) = pc {
-                    let tmp2 = Au.to_vec();
-                    pc.apply(pc_side, &tmp2, Au)?;
+                    let tmp2 = au.to_vec();
+                    pc.apply(pc_side, &tmp2, au)?;
                 }
                 for i in 0..n {
-                    r[i] -= alpha * Au[i];
+                    r[i] -= alpha * au[i];
                 }
 
                 {
@@ -225,15 +225,15 @@ impl LinearSolver for TfqmrSolver {
                                 ConvergedReason::ConvergedRtol | ConvergedReason::ConvergedAtol
                             ))
                     {
-                        a.matvec(x, Au);
+                        a.matvec(x, au);
                         for i in 0..n {
-                            Au[i] = b[i] - Au[i];
+                            au[i] = b[i] - au[i];
                         }
                         if let Some(pc) = pc {
-                            let tmp = Au.to_vec();
-                            pc.apply(pc_side, &tmp, Au)?;
+                            let tmp = au.to_vec();
+                            pc.apply(pc_side, &tmp, au)?;
                         }
-                        true_res = norm2(Au);
+                        true_res = norm2(au);
                         stats.final_residual = true_res;
                     } else {
                         stats.final_residual = dpest;
@@ -272,15 +272,15 @@ impl LinearSolver for TfqmrSolver {
             dpold = norm2(r);
 
             if self.resid_recalc_every == 1 {
-                a.matvec(x, Au);
+                a.matvec(x, au);
                 for i in 0..n {
-                    Au[i] = b[i] - Au[i];
+                    au[i] = b[i] - au[i];
                 }
                 if let Some(pc) = pc {
-                    let tmp = Au.clone();
-                    pc.apply(pc_side, &tmp, Au)?;
+                    let tmp = au.clone();
+                    pc.apply(pc_side, &tmp, au)?;
                 }
-                true_res = norm2(Au);
+                true_res = norm2(au);
                 stats.final_residual = true_res;
                 let (reason, s2) = self.conv.check(true_res, res0, 2 * k);
                 stats = s2;


### PR DESCRIPTION
## Summary
- silence unused parameter warnings in preconditioner builders
- remove or scope unused variables across solvers and SuperLU bindings
- clean up unused fields and methods to allow compilation with `-D warnings`

## Testing
- `cargo check`


------
https://chatgpt.com/codex/tasks/task_e_68aab752f1dc8329afd9ccbe360c1b45