### PR TITLE
Fix lints and strengthen test coverage

### DIFF
--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -687,6 +687,39 @@ mod tests {
                 (global_sq.sqrt()).into()
             }
         }
+        struct Dummy;
+
+        impl TestMatVec<Vec<f64>> for Dummy {
+            fn matvec(&self, _x: &Vec<f64>, _y: &mut Vec<f64>) {}
+        }
+
+        impl TestMatTransVec<Vec<f64>> for Dummy {
+            fn mattransvec(&self, _x: &Vec<f64>, _y: &mut Vec<f64>) {}
+        }
+
+        impl TestInnerProduct<Vec<f64>> for Dummy {
+            type Scalar = f64;
+            fn dot(
+                &self,
+                _x: &Vec<f64>,
+                _y: &Vec<f64>,
+                _comm: &impl crate::parallel::Comm,
+            ) -> Self::Scalar {
+                0.0
+            }
+        }
+
+        fn _use_traits<T: TestMatVec<Vec<f64>> + TestMatTransVec<Vec<f64>> + TestInnerProduct<Vec<f64>>>() {}
+        _use_traits::<Dummy>();
+
+        let dummy = Dummy;
+        let comm = crate::parallel::NoComm;
+        let v = vec![0.0; 1];
+        let mut y = vec![0.0; 1];
+        dummy.matvec(&v, &mut y);
+        dummy.mattransvec(&v, &mut y);
+        let _ = dummy.dot(&v, &v, &comm);
+        let _ = dummy.norm(&v, &comm);
 
         // All method signatures should compile
         assert!(true);

--- a/src/preconditioner/ilu.rs
+++ b/src/preconditioner/ilu.rs
@@ -1493,7 +1493,7 @@ mod tests {
 
     #[test]
     fn test_ilu_variants() {
-        let matrix = faer::Mat::from_fn(3, 3, |i, j| {
+        let _matrix = faer::Mat::from_fn(3, 3, |i, j| {
             if i == j {
                 4.0
             } else if (i as i32 - j as i32).abs() == 1 {

--- a/src/solver/superlu_dist.rs
+++ b/src/solver/superlu_dist.rs
@@ -4892,7 +4892,7 @@ mod tests {
 
     #[test]
     fn test_refinement_convergence_criteria() {
-        let mut engine = RefinementEngine::with_defaults();
+        let engine = RefinementEngine::with_defaults();
 
         // Test absolute tolerance convergence
         assert!(engine.check_convergence(1e-13, 1e-6, 1));

--- a/src/solver/tests/gmres_left_right.rs
+++ b/src/solver/tests/gmres_left_right.rs
@@ -47,6 +47,8 @@ mod tests_gmres_lr {
         ksp_left.rtol = 1e-10;
         let mut x_left = [0.0; 3];
         let stats_left = ksp_left.solve(&b, &mut x_left)?;
+        assert!(stats_left.iterations > 0);
+        assert!(stats_left.final_residual < 1e-4, "left solver failed to converge");
 
         // --- RIGHT preconditioning
         let mut ksp_right = KspContext::new();
@@ -57,6 +59,8 @@ mod tests_gmres_lr {
         ksp_right.rtol = 1e-10;
         let mut x_right = [0.0; 3];
         let stats_right = ksp_right.solve(&b, &mut x_right)?;
+        assert!(stats_right.iterations > 0);
+        assert!(stats_right.final_residual < 1e-4, "right solver failed to converge");
 
         // True residuals are small and comparable
         let res_l = true_residual_norm(amat.as_ref(), &x_left, &b);

--- a/src/utils/matrix_market.rs
+++ b/src/utils/matrix_market.rs
@@ -477,7 +477,6 @@ pub fn write_vector_market<P: AsRef<Path>>(file_path: P, vector: &[f64]) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::matrix::sparse::SparseMatrix;
     use std::fs;
 
     const MATRIX_FILE: &str = "examples/e05r0000/e05r0000.mtx";


### PR DESCRIPTION
## Summary
- remove unused import from matrix market tests
- clean up unused variables and mutability in tests
- exercise mock traits to avoid dead code warnings

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68ab3f93088c8329922faf5473ed8cc5