### PR TITLE
Attach communicators to linear operators

### DIFF
--- a/examples/mpi_amg_gmres_demo.rs
+++ b/examples/mpi_amg_gmres_demo.rs
@@ -26,8 +26,8 @@
 
 use kryst::config::options::parse_all_options;
 use kryst::context::ksp_context::KspContext;
+use kryst::matrix::op::{CsrOp, wrap_with_comm};
 use kryst::matrix::sparse::SparseMatrix;
-use kryst::matrix::op::CsrOp;
 use kryst::parallel::{Comm, UniverseComm};
 use kryst::utils::matrix_market::{read_matrix_market, write_vector_market};
 use std::env;
@@ -195,9 +195,10 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // Attach operator and set up KSP (communicator is not kept inside KSP)
-    let op_arc: Arc<dyn kryst::matrix::op::LinOp<S = f64>> = Arc::new(csr_op);
-    ksp.set_operators(op_arc, None);
+    // Attach operator and set up KSP, attaching the communicator
+    let op_arc: Arc<dyn kryst::matrix::op::LinOp<S = f64>> =
+        wrap_with_comm(Arc::new(csr_op), comm.clone());
+    ksp.set_operators_with_comm(op_arc, None, comm.clone());
     ksp.setup()?;
 
     let setup_time = start_setup.elapsed();
@@ -342,7 +343,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     // All-reduce to get global norms
     let global_residual_sq = comm.all_reduce_f64(local_residual_sq);
-    let global_rhs_sq     = comm.all_reduce_f64(local_rhs_sq);
+    let global_rhs_sq = comm.all_reduce_f64(local_rhs_sq);
 
     let residual_norm = global_residual_sq.sqrt();
     let rhs_norm = global_rhs_sq.sqrt();

--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -25,7 +25,7 @@
 use crate::config::options::{KspOptions, PcOptions};
 use crate::context::pc_context::{DeferredPcInfo, PcFactory, PcType};
 use crate::error::KError;
-use crate::matrix::op::{LinOp, StructureId, ValuesId};
+use crate::matrix::op::{LinOp, StructureId, ValuesId, wrap_with_comm};
 use crate::parallel::Comm;
 use crate::preconditioner::{PcReusePolicy, PcSide, Preconditioner};
 use crate::solver::{
@@ -351,6 +351,17 @@ impl KspContext {
         self.pmat = Some(pmat);
         self.invalidate_setup();
         self
+    }
+
+    pub fn set_operators_with_comm(
+        &mut self,
+        amat: Arc<dyn LinOp<S = f64>>,
+        pmat: Option<Arc<dyn LinOp<S = f64>>>,
+        comm: crate::parallel::UniverseComm,
+    ) -> &mut Self {
+        let a_wrapped = wrap_with_comm(amat, comm.clone());
+        let p_wrapped = pmat.map(|p| wrap_with_comm(p, comm.clone()));
+        self.set_operators(a_wrapped, p_wrapped)
     }
 
     pub fn set_pc_reuse_policy(&mut self, policy: PcReusePolicy) -> &mut Self {

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -280,3 +280,62 @@ impl LinOp for CsrMatrix<f64> {
         ValuesId(0)
     }
 }
+/// Wrap any LinOp with a communicator without changing its behavior.
+pub struct WithCommOp<T: LinOp + ?Sized> {
+    inner: Arc<T>,
+    comm: UniverseComm,
+}
+
+impl<T: LinOp + ?Sized> WithCommOp<T> {
+    pub fn new(inner: Arc<T>, comm: UniverseComm) -> Self {
+        Self { inner, comm }
+    }
+    pub fn inner(&self) -> &T {
+        &self.inner
+    }
+}
+
+impl<T: LinOp + ?Sized> LinOp for WithCommOp<T> {
+    type S = T::S;
+
+    #[inline]
+    fn dims(&self) -> (usize, usize) {
+        self.inner.dims()
+    }
+    #[inline]
+    fn matvec(&self, x: &[Self::S], y: &mut [Self::S]) {
+        self.inner.matvec(x, y)
+    }
+    #[inline]
+    fn supports_transpose(&self) -> bool {
+        self.inner.supports_transpose()
+    }
+    #[inline]
+    fn t_matvec(&self, x: &[Self::S], y: &mut [Self::S]) {
+        self.inner.t_matvec(x, y)
+    }
+    #[inline]
+    fn as_any(&self) -> &dyn Any {
+        self.inner.as_any()
+    }
+    #[inline]
+    fn structure_id(&self) -> StructureId {
+        self.inner.structure_id()
+    }
+    #[inline]
+    fn values_id(&self) -> ValuesId {
+        self.inner.values_id()
+    }
+    #[inline]
+    fn comm(&self) -> UniverseComm {
+        self.comm.clone()
+    }
+}
+
+/// Ergonomic helper for call sites
+pub fn wrap_with_comm<T>(op: Arc<T>, comm: UniverseComm) -> Arc<dyn LinOp<S = T::S>>
+where
+    T: LinOp + ?Sized + 'static,
+{
+    Arc::new(WithCommOp::new(op, comm)) as Arc<dyn LinOp<S = T::S>>
+}

--- a/tests/with_comm_op.rs
+++ b/tests/with_comm_op.rs
@@ -1,0 +1,41 @@
+use std::sync::Arc;
+
+use faer::Mat;
+use kryst::context::ksp_context::{KspContext, SolverType};
+use kryst::matrix::op::{LinOp, wrap_with_comm};
+use kryst::parallel::{NoComm, UniverseComm};
+
+#[test]
+#[should_panic]
+fn mismatch_comm_panics() {
+    let a = Mat::<f64>::from_fn(4, 4, |i, j| if i == j { 1.0 } else { 0.0 });
+    let p = a.clone();
+    let a_op: Arc<dyn LinOp<S = f64>> = wrap_with_comm(Arc::new(a), UniverseComm::NoComm(NoComm));
+
+    #[cfg(feature = "mpi")]
+    let p_comm = UniverseComm::Mpi(std::sync::Arc::new(
+        kryst::parallel::MpiComm::try_new().unwrap(),
+    ));
+    #[cfg(all(not(feature = "mpi"), feature = "rayon"))]
+    let p_comm = UniverseComm::Rayon(kryst::parallel::RayonComm::new());
+    #[cfg(not(any(feature = "mpi", feature = "rayon")))]
+    let p_comm = UniverseComm::Serial;
+
+    let p_op: Arc<dyn LinOp<S = f64>> = wrap_with_comm(Arc::new(p), p_comm);
+    let mut ksp = KspContext::new();
+    ksp.set_operators(a_op, Some(p_op));
+}
+
+#[test]
+fn residual_uses_comm_serial() {
+    let a = Mat::<f64>::from_fn(3, 3, |i, j| if i == j { 2.0 } else { 0.0 });
+    let b = vec![1.0; 3];
+    let mut x = vec![0.0; 3];
+
+    let a_op = wrap_with_comm(Arc::new(a), UniverseComm::NoComm(NoComm));
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Gmres).unwrap();
+    ksp.set_operators(a_op, None);
+    let stats = ksp.solve(&b, &mut x).unwrap();
+    assert!(stats.final_residual.is_finite());
+}


### PR DESCRIPTION
## Summary
- wrap linear operators in `WithCommOp` to carry a `UniverseComm`
- add `KspContext::set_operators_with_comm` helper
- update MPI example to attach communicators
- test communicator equality and residual calculation

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68abe67993648329bc6ed3ba0a59e4c6