### PR TITLE
Allow LinOp-based PC construction

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -394,24 +394,10 @@ impl KspContext {
 
         if self.pc.is_none() {
             if let Some(specs) = self.pending_chain.take() {
-                let m = pmat
-                    .as_any()
-                    .downcast_ref::<faer::Mat<f64>>()
-                    .ok_or_else(|| {
-                        KError::InvalidInput(
-                            "expected faer::Mat<f64> for chain construction".into(),
-                        )
-                    })?;
-                let chain = PcFactory::construct_deferred_pc_chain(specs, m)?;
+                let chain = PcFactory::construct_deferred_pc_chain(specs, pmat.as_ref())?;
                 self.pc = Some(chain);
             } else if let Some(spec) = self.pending_pc.take() {
-                let m = pmat
-                    .as_any()
-                    .downcast_ref::<faer::Mat<f64>>()
-                    .ok_or_else(|| {
-                        KError::InvalidInput("expected faer::Mat<f64> for PC construction".into())
-                    })?;
-                let pc = PcFactory::construct_deferred_preconditioner(spec, m)?;
+                let pc = PcFactory::construct_deferred_preconditioner(spec, pmat.as_ref())?;
                 self.pc = Some(pc);
             }
         }

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -2,7 +2,6 @@ use crate::config::options::PcOptions;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};
-use faer::Mat;
 use std::str::FromStr;
 
 /// Supported preconditioner types.
@@ -310,8 +309,9 @@ impl PcFactory {
 
     pub fn construct_deferred_preconditioner(
         info: DeferredPcInfo,
-        _matrix: &Mat<f64>,
+        _op: &dyn LinOp<S = f64>,
     ) -> Result<Box<dyn Preconditioner>, KError> {
+        // The concrete operator format is deferred to the preconditioner itself.
         match info.pc_type {
             PcType::Amg => Err(KError::NotImplemented("AMG not yet implemented".into())),
             PcType::Asm => Err(KError::NotImplemented("ASM not yet implemented".into())),
@@ -344,13 +344,13 @@ impl PcFactory {
 
     pub fn construct_deferred_pc_chain(
         specs: Vec<DeferredPcInfo>,
-        matrix: &Mat<f64>,
+        op: &dyn LinOp<S = f64>,
     ) -> Result<Box<dyn Preconditioner>, KError> {
         use crate::preconditioner::chain::PcChain;
 
         let mut stages: Vec<Box<dyn Preconditioner>> = Vec::with_capacity(specs.len());
         for spec in specs {
-            let stage = Self::construct_deferred_preconditioner(spec, matrix)?;
+            let stage = Self::construct_deferred_preconditioner(spec, op)?;
             stages.push(stage);
         }
         Ok(Box::new(PcChain::new(stages)))
@@ -358,11 +358,11 @@ impl PcFactory {
 
     pub fn create_pc_chain(
         chain: &str,
-        matrix: &Mat<f64>,
+        op: &dyn LinOp<S = f64>,
         opts: Option<PcOptions>,
     ) -> Result<Box<dyn Preconditioner>, KError> {
         let specs = Self::create_pc_chain_from_str(chain, opts.as_ref())?;
-        Self::construct_deferred_pc_chain(specs, matrix)
+        Self::construct_deferred_pc_chain(specs, op)
     }
 
     pub fn create_deferred_pc_chain_from_options(

--- a/src/matrix/convert.rs
+++ b/src/matrix/convert.rs
@@ -27,3 +27,25 @@ pub fn to_csr_cached(
         "to_csr_cached: unsupported LinOp type".into(),
     ))
 }
+
+/// Obtain a CSR matrix from a [`LinOp`], converting and caching if necessary.
+#[inline]
+pub fn csr_from_linop(
+    op: &dyn LinOp<S = f64>,
+    drop_tol: f64,
+) -> Result<Arc<CsrMatrix<f64>>, KError> {
+    to_csr_cached(op, drop_tol)
+}
+
+/// Obtain a dense matrix from a [`LinOp`], converting formats as needed.
+pub fn dense_from_linop(op: &dyn LinOp<S = f64>) -> Result<Mat<f64>, KError> {
+    if let Some(mat) = op.as_any().downcast_ref::<Mat<f64>>() {
+        return Ok(mat.clone());
+    }
+    if let Some(csr) = op.as_any().downcast_ref::<CsrMatrix<f64>>() {
+        return Ok(csr.to_dense());
+    }
+    Err(KError::InvalidInput(
+        "Unsupported operator type for Dense conversion".into(),
+    ))
+}

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -10,6 +10,6 @@ pub mod op_shell;
 pub mod sparse;
 pub mod utils;
 
-pub use convert::{to_csr_cached, try_as_csr};
+pub use convert::{csr_from_linop, dense_from_linop, to_csr_cached, try_as_csr};
 pub use op::{ChangeIds, CsrOp, DenseOp, LinOp, StructureId, ValuesId};
 pub use op_shell::MatShell;

--- a/tests/ksp_csr_setup.rs
+++ b/tests/ksp_csr_setup.rs
@@ -1,0 +1,30 @@
+use std::sync::Arc;
+
+use kryst::context::ksp_context::{KspContext, SolverType};
+use kryst::context::pc_context::PcType;
+use kryst::matrix::op::LinOp;
+use kryst::matrix::sparse::CsrMatrix;
+
+#[test]
+fn ksp_setup_accepts_csr_without_dense_downcast() {
+    // Build a simple 3x3 tridiagonal matrix in CSR format
+    let csr = CsrMatrix::from_csr(
+        3,
+        3,
+        vec![0, 2, 4, 5],
+        vec![0, 1, 0, 2, 1],
+        vec![2.0, -1.0, -1.0, -1.0, 2.0],
+    );
+    let a: Arc<dyn LinOp<S = f64>> = Arc::new(csr);
+
+    // Configure KSP with a Jacobi preconditioner and GMRES solver
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Gmres)
+        .unwrap()
+        .set_pc_type(PcType::Jacobi, None)
+        .unwrap()
+        .set_operators(a.clone(), None);
+
+    // setup should succeed without requiring a dense matrix downcast
+    ksp.setup().unwrap();
+}


### PR DESCRIPTION
## Summary
- build preconditioners and PC chains from any `LinOp` instead of `faer::Mat`
- drop dense downcasts in `KspContext::setup`
- add utilities to convert `LinOp` inputs to CSR or dense matrices
- test KSP setup on CSR matrix without dense conversion

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68abeaeaa10c832993f73c383b25e8e7