### PR TITLE
Fix MPI initialization and collective semantics

### DIFF
--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -1,9 +1,7 @@
 #[cfg(feature = "mpi")]
 use mpi::datatype::Equivalence;
 #[cfg(feature = "mpi")]
-use mpi::topology::{Color, Communicator};
-#[cfg(feature = "mpi")]
-use mpi::traits::*;
+use mpi::raw::AsRaw;
 #[cfg(any(feature = "mpi", feature = "rayon"))]
 use std::sync::Arc;
 
@@ -294,24 +292,9 @@ impl Comm for UniverseComm {
         match self {
             UniverseComm::NoComm(comm) => comm.split(color, key),
             #[cfg(feature = "mpi")]
-            UniverseComm::Mpi(comm) => {
-                // Split the MPI communicator and return a new UniverseComm
-                let sub = comm
-                    .world
-                    .split_by_color_with_key(Color::with_value(color), key)
-                    .expect("Failed to split communicator");
-                let sub_rank = sub.rank() as usize;
-                let sub_size = sub.size() as usize;
-                let new_comm = MpiComm {
-                    _universe: mpi::initialize().unwrap(), // Workaround for universe sharing
-                    world: sub,
-                    rank: sub_rank,
-                    size: sub_size,
-                };
-                UniverseComm::Mpi(Arc::new(new_comm))
-            }
+            UniverseComm::Mpi(comm) => comm.split(color, key),
             #[cfg(feature = "rayon")]
-            UniverseComm::Rayon(_comm) => UniverseComm::Rayon(RayonComm::new()),
+            UniverseComm::Rayon(comm) => comm.split(color, key),
             #[cfg(not(any(feature = "mpi", feature = "rayon")))]
             UniverseComm::Serial => UniverseComm::Serial,
         }

--- a/src/parallel/mpi_comm.rs
+++ b/src/parallel/mpi_comm.rs
@@ -14,14 +14,14 @@
 
 use mpi::topology::SimpleCommunicator;
 use mpi::traits::*;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 
 /// MPI communicator wrapper for distributed parallelism.
 ///
-/// Holds the MPI universe, world communicator, the rank of the current process, and the total number of processes.
+/// Holds the MPI world communicator, the rank of the current process, and the total
+/// number of processes. MPI itself is initialized exactly once for the entire
+/// program via a global [`OnceLock`].
 pub struct MpiComm {
-    /// The MPI universe - must be kept alive for the entire duration
-    pub _universe: mpi::environment::Universe,
     /// The MPI world communicator (all processes in the job).
     pub world: SimpleCommunicator,
     /// The rank (ID) of this process within the communicator.
@@ -33,43 +33,25 @@ pub struct MpiComm {
 unsafe impl Send for MpiComm {}
 unsafe impl Sync for MpiComm {}
 
+// --- One-time MPI universe holder ---
+static MPI_UNIVERSE: OnceLock<mpi::environment::Universe> = OnceLock::new();
+
+fn universe() -> &'static mpi::environment::Universe {
+    MPI_UNIVERSE.get_or_init(|| mpi::initialize().expect("MPI initialization failed"))
+}
+
 impl MpiComm {
-    /// Initializes MPI and constructs a new `MpiComm` instance.
-    ///
-    /// # Panics
-    /// Panics if MPI initialization fails.
+    /// Initializes MPI once and constructs a new [`MpiComm`].
     pub fn new() -> Self {
-        let universe = mpi::initialize().unwrap();
-        let world = universe.world();
+        let world = universe().world().duplicate();
         let rank = world.rank() as usize;
         let size = world.size() as usize;
-        MpiComm {
-            _universe: universe,
-            world,
-            rank,
-            size,
-        }
+        MpiComm { world, rank, size }
     }
 
-    /// Attempts to initialize MPI and construct a new `MpiComm` instance.
-    ///
-    /// Returns `None` if MPI initialization fails (e.g., MPI not available or test environment).
-    /// This provides a graceful fallback for environments where MPI may not be properly configured.
+    /// Best-effort constructor that returns `None` if initialization fails.
     pub fn try_new() -> Option<Self> {
-        // Use std::panic::catch_unwind to handle potential panics during MPI initialization
-        std::panic::catch_unwind(|| {
-            let universe = mpi::initialize().unwrap();
-            let world = universe.world();
-            let rank = world.rank() as usize;
-            let size = world.size() as usize;
-            MpiComm {
-                _universe: universe,
-                world,
-                rank,
-                size,
-            }
-        })
-        .ok()
+        std::panic::catch_unwind(|| Self::new()).ok()
     }
 }
 
@@ -101,10 +83,12 @@ impl super::Comm for MpiComm {
         out: &mut [T],
         root: usize,
     ) {
-        // Only the root process provides the global array; others provide an empty slice.
-        self.world
-            .process_at_rank(root as i32)
-            .scatter_into_root(global, out);
+        let proc = self.world.process_at_rank(root as i32);
+        if self.rank == root {
+            proc.scatter_into_root(global, out);
+        } else {
+            proc.scatter_into(out);
+        }
     }
 
     /// Gathers arrays from all processes to the root process (gather operation).
@@ -118,17 +102,14 @@ impl super::Comm for MpiComm {
         out: &mut Vec<T>,
         root: usize,
     ) {
-        // Only the root process allocates the receive buffer; others use an empty Vec.
-        let mut recvbuf = if self.rank == root {
-            vec![local[0].clone(); local.len() * self.size]
-        } else {
-            Vec::new()
-        };
-        self.world
-            .process_at_rank(root as i32)
-            .gather_into_root(local, &mut recvbuf);
+        let proc = self.world.process_at_rank(root as i32);
         if self.rank == root {
-            *out = recvbuf;
+            let mut recv = vec![local[0].clone(); local.len() * self.size];
+            proc.gather_into_root(local, &mut recv);
+            *out = recv;
+        } else {
+            proc.gather_into(local);
+            out.clear();
         }
     }
 
@@ -151,13 +132,18 @@ impl super::Comm for MpiComm {
     }
 
     /// Split this communicator into sub‐colors
-    fn split(&self, _color: i32, _key: i32) -> super::UniverseComm {
-        // Placeholder: returns a duplicate of the current communicator
+    fn split(&self, color: i32, key: i32) -> super::UniverseComm {
+        use mpi::topology::Color;
+        let sub = self
+            .world
+            .split_by_color_with_key(Color::with_value(color), key)
+            .expect("MPI split failed");
+        let rank = sub.rank() as usize;
+        let size = sub.size() as usize;
         super::UniverseComm::Mpi(Arc::new(MpiComm {
-            _universe: mpi::initialize().unwrap(), // This is a workaround
-            world: self.world.duplicate(),
-            rank: self.rank,
-            size: self.size,
+            world: sub,
+            rank,
+            size,
         }))
     }
 

--- a/tests/mpi_collectives.rs
+++ b/tests/mpi_collectives.rs
@@ -1,0 +1,43 @@
+#[cfg(feature = "mpi")]
+use kryst::parallel::{Comm, MpiComm, UniverseComm};
+#[cfg(feature = "mpi")]
+use std::sync::Arc;
+
+#[cfg(feature = "mpi")]
+#[test]
+fn split_roundtrips() {
+    let comm = UniverseComm::Mpi(Arc::new(MpiComm::new()));
+    let color = (comm.rank() % 2) as i32;
+    let key = comm.rank() as i32;
+    let sub = comm.split(color, key);
+    assert!(sub.size() >= 1);
+}
+
+#[cfg(feature = "mpi")]
+#[test]
+fn scatter_gather_smoke() {
+    let comm = MpiComm::new();
+    let rank = comm.rank();
+    let size = comm.size();
+    let root = 0usize;
+    let n = 2usize;
+    let mut recv = vec![0i32; n];
+
+    if rank == root {
+        let global: Vec<i32> = (0..n * size).map(|x| x as i32).collect();
+        comm.scatter(&global, &mut recv, root);
+    } else {
+        let empty: Vec<i32> = Vec::new();
+        comm.scatter(&empty, &mut recv, root);
+    }
+
+    let mut gathered = Vec::new();
+    comm.gather(&recv, &mut gathered, root);
+
+    if rank == root {
+        let global: Vec<i32> = (0..n * size).map(|x| x as i32).collect();
+        assert_eq!(gathered, global);
+    } else {
+        assert!(gathered.is_empty());
+    }
+}


### PR DESCRIPTION
## Summary
- centralize MPI initialization with a global `OnceLock` and derive sub-communicators without re-initializing
- correct `scatter`/`gather` to use root vs non-root semantics
- delegate `UniverseComm::split` to underlying comm implementation and add MPI collective tests

## Testing
- `cargo test --test mpi_collectives`

------
https://chatgpt.com/codex/tasks/task_e_68accb05820083298a4a060b7be84a31