### PR TITLE
Centralize rayon pool and guard CSR threading

### DIFF
--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -1,4 +1,4 @@
-use crate::parallel::{NoComm, UniverseComm};
+use crate::parallel::{Comm, NoComm, UniverseComm};
 use faer::traits::ComplexField;
 use std::any::Any;
 use std::sync::Arc;
@@ -85,13 +85,19 @@ use faer::Mat;
 pub struct DenseOp {
     mat: Arc<Mat<f64>>,
     ids: ChangeIds,
+    comm: UniverseComm,
 }
 impl DenseOp {
     pub fn new(mat: Arc<Mat<f64>>) -> Self {
         let ids = ChangeIds::default();
         ids.bump_structure();
         ids.bump_values();
-        Self { mat, ids }
+        Self { mat, ids, comm: UniverseComm::NoComm(NoComm) }
+    }
+    /// Attach a communicator to this operator.
+    pub fn with_comm(mut self, comm: UniverseComm) -> Self {
+        self.comm = comm;
+        self
     }
     pub fn mark_structure_changed(&self) {
         self.ids.bump_structure();
@@ -134,18 +140,22 @@ impl LinOp for DenseOp {
     fn values_id(&self) -> ValuesId {
         self.ids.values_id()
     }
+    fn comm(&self) -> UniverseComm {
+        self.comm.clone()
+    }
 }
 
 pub struct CsrOp {
     csr: Arc<CsrMatrix<f64>>,
     ids: ChangeIds,
+    comm: UniverseComm,
 }
 impl CsrOp {
     pub fn new(csr: Arc<CsrMatrix<f64>>) -> Self {
         let ids = ChangeIds::default();
         ids.bump_structure();
         ids.bump_values();
-        Self { csr, ids }
+        Self { csr, ids, comm: UniverseComm::NoComm(NoComm) }
     }
     pub fn mark_structure_changed(&self) {
         self.ids.bump_structure();
@@ -156,6 +166,11 @@ impl CsrOp {
     pub fn inner(&self) -> &CsrMatrix<f64> {
         &self.csr
     }
+    /// Attach a communicator to this operator.
+    pub fn with_comm(mut self, comm: UniverseComm) -> Self {
+        self.comm = comm;
+        self
+    }
 }
 impl LinOp for CsrOp {
     type S = f64;
@@ -163,6 +178,18 @@ impl LinOp for CsrOp {
         (self.csr.nrows(), self.csr.ncols())
     }
     fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        #[cfg(feature = "rayon")]
+        {
+            let local_only = self.comm.size() == 1;
+            let threads = crate::parallel::threads::current_rayon_threads();
+            let big_enough = self.csr.nrows()
+                >= crate::parallel::threads::env_usize("KRYST_PAR_CUTOFF", 4096);
+
+            if local_only && threads > 1 && big_enough {
+                return self.csr.spmv_parallel(x, y);
+            }
+        }
+
         self.csr.spmv(x, y);
     }
     fn supports_transpose(&self) -> bool {
@@ -190,6 +217,9 @@ impl LinOp for CsrOp {
     }
     fn values_id(&self) -> ValuesId {
         self.ids.values_id()
+    }
+    fn comm(&self) -> UniverseComm {
+        self.comm.clone()
     }
 }
 

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -121,6 +121,8 @@ pub mod mpi_comm;
 #[cfg(feature = "mpi")]
 pub use mpi_comm::MpiComm;
 
+pub mod threads;
+
 #[cfg(feature = "rayon")]
 pub mod rayon_comm;
 #[cfg(feature = "rayon")]

--- a/src/parallel/mpi_comm.rs
+++ b/src/parallel/mpi_comm.rs
@@ -46,6 +46,12 @@ impl MpiComm {
         let world = universe().world().duplicate();
         let rank = world.rank() as usize;
         let size = world.size() as usize;
+
+        #[cfg(feature = "rayon")]
+        {
+            crate::parallel::threads::init_global_rayon_pool(size);
+        }
+
         MpiComm { world, rank, size }
     }
 

--- a/src/parallel/rayon_comm.rs
+++ b/src/parallel/rayon_comm.rs
@@ -20,7 +20,7 @@ use rayon::prelude::*;
 /// Implements the `Comm` trait for shared-memory parallelism. All collective operations
 /// are no-ops or local, as there is no inter-process communication.
 #[derive(Clone)]
-pub struct RayonComm;
+    pub struct RayonComm;
 
 impl RayonComm {
     /// Creates a new `RayonComm` and initializes the global Rayon thread pool
@@ -28,10 +28,10 @@ impl RayonComm {
     ///
     /// If the global thread pool is already initialized, this is a no-op.
     pub fn new() -> Self {
-        rayon::ThreadPoolBuilder::new()
-            .num_threads(num_cpus::get())
-            .build_global()
-            .ok();
+        #[cfg(feature = "rayon")]
+        {
+            crate::parallel::threads::init_global_rayon_pool(1);
+        }
         RayonComm
     }
 }
@@ -47,7 +47,7 @@ impl super::Comm for RayonComm {
 
     /// Returns the number of parallel workers (number of CPU cores).
     fn size(&self) -> usize {
-        num_cpus::get()
+        crate::parallel::threads::current_rayon_threads()
     }
 
     /// Synchronization barrier (no-op in shared memory, but uses a Rayon scope for API compatibility).

--- a/src/parallel/threads.rs
+++ b/src/parallel/threads.rs
@@ -1,0 +1,86 @@
+use std::sync::OnceLock;
+
+#[cfg(feature = "rayon")]
+use rayon::ThreadPoolBuilder;
+
+/// Helper to read an environment variable as usize.
+/// Falls back to `default` if the variable is not set or invalid.
+pub fn env_usize(key: &str, default: usize) -> usize {
+    std::env::var(key)
+        .ok()
+        .and_then(|s| s.parse::<usize>().ok())
+        .unwrap_or(default)
+}
+
+/// One-time computed number of Rayon worker threads we actually use.
+static EFFECTIVE_THREADS: OnceLock<usize> = OnceLock::new();
+
+/// Decide and initialize the global Rayon thread pool exactly once.
+/// - `mpi_size`: number of MPI ranks in the current communicator (>= 1)
+/// - If env `KRYST_THREADS` is set, it overrides the global CPU count.
+/// - If not set, we fall back to `RAYON_NUM_THREADS`, then `num_cpus::get()`.
+/// - Per-rank threads = floor(total / mpi_size), clamped to >= 1.
+/// Returns the number of threads actually used for Rayon.
+pub fn init_global_rayon_pool(mpi_size: usize) -> usize {
+    #[cfg(not(feature = "rayon"))]
+    {
+        let _ = mpi_size; // silence warning
+        return 1;
+    }
+
+    #[cfg(feature = "rayon")]
+    {
+        *EFFECTIVE_THREADS.get_or_init(|| {
+            let total = std::env::var("KRYST_THREADS")
+                .ok()
+                .and_then(|s| s.parse::<usize>().ok())
+                .or_else(|| {
+                    std::env::var("RAYON_NUM_THREADS")
+                        .ok()
+                        .and_then(|s| s.parse().ok())
+                })
+                .unwrap_or_else(num_cpus::get);
+
+            let threads = std::cmp::max(1, total / std::cmp::max(1, mpi_size));
+            // Build the global pool once. If someone built it earlier, this is a no-op.
+            let _ = ThreadPoolBuilder::new().num_threads(threads).build_global();
+            threads
+        })
+    }
+}
+
+/// Returns how many Rayon threads we are running with (after init).
+pub fn current_rayon_threads() -> usize {
+    #[cfg(feature = "rayon")]
+    {
+        // If no pool yet, Rayon falls back to a default; prefer our recorded number if any.
+        EFFECTIVE_THREADS
+            .get()
+            .copied()
+            .unwrap_or_else(rayon::current_num_threads)
+    }
+    #[cfg(not(feature = "rayon"))]
+    {
+        1
+    }
+}
+
+/// A light "guard" for clarity: constructing this ensures the pool is initialized.
+/// Note: The global pool cannot be destroyed; this is just an explicit init point.
+pub struct ThreadPoolGuard {
+    threads: usize,
+}
+
+impl ThreadPoolGuard {
+    /// Initialize the global pool for a communicator of size `mpi_size`.
+    pub fn new_per_rank(mpi_size: usize) -> Self {
+        let threads = init_global_rayon_pool(mpi_size);
+        Self { threads }
+    }
+
+    /// Number of threads being used.
+    pub fn threads(&self) -> usize {
+        self.threads
+    }
+}
+


### PR DESCRIPTION
## Summary
- add threads module to initialize a global per-rank Rayon pool with env overrides
- call the pool init from MPI and Rayon communicators and report effective thread count
- let DenseOp/CsrOp carry communicators and enable CSR matvec parallelism only when safe

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68acd0fba3c48329bdbd5202c984ff91