### PR TITLE
feat: track matrix value ids for reuse

### DIFF
--- a/src/context/ksp_context.rs
+++ b/src/context/ksp_context.rs
@@ -9,6 +9,12 @@
 //!    - Else if values id changed and numeric reuse allowed → [`update_numeric`]
 //!    - Else unchanged.
 //!
+//! For efficient reuse across nonlinear iterations or time steps, wrap matrices in
+//! [`DenseOp`](crate::matrix::op::DenseOp) or [`CsrOp`](crate::matrix::op::CsrOp) and call
+//! [`mark_values_changed`](crate::matrix::op::DenseOp::mark_values_changed) or
+//! [`mark_structure_changed`](crate::matrix::op::DenseOp::mark_structure_changed) after
+//! in-place modifications. This ensures cache keys and reuse decisions reflect updates.
+//!
 //! ## Side policy
 //! [`pc_side`](struct.KspContext.html#structfield.pc_side) is passed to solvers; PCs **do not** decide left vs right placement.
 //!
@@ -431,15 +437,42 @@ impl KspContext {
                     self.last_pc_vid = Some(vid);
                 }
                 Some(_old_sid) => {
-                    if self.last_pc_vid != Some(vid)
-                        && self.pc_reuse.allow_numeric()
-                        && pc.supports_numeric_update()
-                    {
-                        pc.update_numeric(pmat.as_ref())?;
-                        self.last_pc_vid = Some(vid);
-                    } else if self.last_pc_vid != Some(vid) {
-                        pc.update_symbolic(pmat.as_ref())?;
-                        self.last_pc_vid = Some(vid);
+                    let vid_known = vid.0 != 0;
+                    let values_changed = self.last_pc_vid != Some(vid);
+                    match self.pc_reuse {
+                        PcReusePolicy::Never => {
+                            if !vid_known || values_changed {
+                                pc.update_symbolic(pmat.as_ref())?;
+                                self.last_pc_vid = Some(vid);
+                            }
+                        }
+                        PcReusePolicy::ReuseNumeric => {
+                            if pc.supports_numeric_update() {
+                                if !vid_known {
+                                    log::debug!("ValuesId unknown; conservatively refreshing numeric data. Wrap your matrix in DenseOp/CsrOp and call mark_values_changed() to enable exact reuse.");
+                                }
+                                pc.update_numeric(pmat.as_ref())?;
+                                self.last_pc_vid = Some(vid);
+                            } else if !vid_known || values_changed {
+                                pc.update_symbolic(pmat.as_ref())?;
+                                self.last_pc_vid = Some(vid);
+                            }
+                        }
+                        PcReusePolicy::Auto => {
+                            if (!vid_known || values_changed)
+                                && pc.supports_numeric_update()
+                                && self.pc_reuse.allow_numeric()
+                            {
+                                if !vid_known {
+                                    log::debug!("ValuesId unknown; conservatively refreshing numeric data. Wrap your matrix in DenseOp/CsrOp and call mark_values_changed() to enable exact reuse.");
+                                }
+                                pc.update_numeric(pmat.as_ref())?;
+                                self.last_pc_vid = Some(vid);
+                            } else if values_changed {
+                                pc.update_symbolic(pmat.as_ref())?;
+                                self.last_pc_vid = Some(vid);
+                            }
+                        }
                     }
                 }
             }
@@ -646,7 +679,6 @@ impl KspContext {
     }
 }
 
-#[cfg(test)]
 impl KspContext {
     /// Test-only: view current workspace (e.g., to inspect GMRES V/Z basis sizes).
     pub fn debug_workspace(&self) -> Option<&Workspace> {

--- a/src/matrix/format.rs
+++ b/src/matrix/format.rs
@@ -38,6 +38,7 @@ pub trait AsFormat {
 pub(crate) struct CsrKey {
     pub base_ptr: usize,
     pub structure_id: u64,
+    pub values_id: u64,
     pub drop_tol_bits: u64,
 }
 
@@ -45,6 +46,7 @@ impl PartialEq for CsrKey {
     fn eq(&self, other: &Self) -> bool {
         self.base_ptr == other.base_ptr
             && self.structure_id == other.structure_id
+            && self.values_id == other.values_id
             && self.drop_tol_bits == other.drop_tol_bits
     }
 }
@@ -53,6 +55,7 @@ impl Hash for CsrKey {
     fn hash<H: Hasher>(&self, state: &mut H) {
         self.base_ptr.hash(state);
         self.structure_id.hash(state);
+        self.values_id.hash(state);
         self.drop_tol_bits.hash(state);
     }
 }
@@ -61,10 +64,11 @@ impl Hash for CsrKey {
 pub(crate) static CSR_CACHE: Lazy<Mutex<HashMap<CsrKey, Weak<CsrMatrix<f64>>>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));
 
-pub(crate) fn key_from_ptr(ptr: usize, structure_id: u64, drop_tol: f64) -> CsrKey {
+pub(crate) fn key_from_ptr(ptr: usize, structure_id: u64, values_id: u64, drop_tol: f64) -> CsrKey {
     CsrKey {
         base_ptr: ptr,
         structure_id,
+        values_id,
         drop_tol_bits: drop_tol.to_bits(),
     }
 }

--- a/src/matrix/format_impls.rs
+++ b/src/matrix/format_impls.rs
@@ -5,7 +5,7 @@ use faer::Mat;
 use crate::matrix::{
     csc::CscMatrix,
     format::{AsFormat, CSC_CACHE, CSR_CACHE, csc_key_from_ptr, key_from_ptr},
-    op::LinOp,
+    op::{DenseOp, LinOp},
     sparse::CsrMatrix,
 };
 
@@ -31,7 +31,8 @@ impl AsFormat for Mat<f64> {
     fn to_csr_cached(&self, drop_tol: f64) -> Arc<CsrMatrix<f64>> {
         let base_ptr = self as *const Mat<f64> as usize;
         let structure_id = LinOp::structure_id(self).0;
-        let key = key_from_ptr(base_ptr, structure_id, drop_tol);
+        let values_id = LinOp::values_id(self).0;
+        let key = key_from_ptr(base_ptr, structure_id, values_id, drop_tol);
         if let Some(existing) = {
             let cache = CSR_CACHE.lock().unwrap();
             cache.get(&key).and_then(|w| w.upgrade())
@@ -60,6 +61,49 @@ impl AsFormat for Mat<f64> {
             return existing;
         }
         let csc = CscMatrix::from_dense(self, drop_tol);
+        let arc = Arc::new(csc);
+        let mut cache = CSC_CACHE.lock().unwrap();
+        cache.insert(key, Arc::downgrade(&arc));
+        arc
+    }
+}
+
+impl AsFormat for DenseOp {
+    fn to_csr_cached(&self, drop_tol: f64) -> Arc<CsrMatrix<f64>> {
+        let inner = self.inner();
+        let base_ptr = inner as *const Mat<f64> as usize;
+        let sid = self.structure_id().0;
+        let vid = self.values_id().0;
+        let key = key_from_ptr(base_ptr, sid, vid, drop_tol);
+        if let Some(existing) = {
+            let cache = CSR_CACHE.lock().unwrap();
+            cache.get(&key).and_then(|w| w.upgrade())
+        } {
+            return existing;
+        }
+        let csr = CsrMatrix::from_dense(inner, drop_tol);
+        let arc = Arc::new(csr);
+        let mut cache = CSR_CACHE.lock().unwrap();
+        cache.insert(key, Arc::downgrade(&arc));
+        arc
+    }
+
+    fn as_csc(&self) -> Option<&CscMatrix<f64>> {
+        None
+    }
+
+    fn to_csc_cached(&self, drop_tol: f64) -> Arc<CscMatrix<f64>> {
+        let inner = self.inner();
+        let base_ptr = inner as *const Mat<f64> as usize;
+        let sid = self.structure_id().0;
+        let key = csc_key_from_ptr(base_ptr, sid, drop_tol);
+        if let Some(existing) = {
+            let cache = CSC_CACHE.lock().unwrap();
+            cache.get(&key).and_then(|w| w.upgrade())
+        } {
+            return existing;
+        }
+        let csc = CscMatrix::from_dense(inner, drop_tol);
         let arc = Arc::new(csc);
         let mut cache = CSC_CACHE.lock().unwrap();
         cache.insert(key, Arc::downgrade(&arc));

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -88,6 +88,9 @@ pub struct DenseOp {
     comm: UniverseComm,
 }
 impl DenseOp {
+    /// Wrap a dense matrix so changes can be tracked via [`mark_structure_changed`] and
+    /// [`mark_values_changed`]. This enables correct caching and preconditioner reuse across
+    /// nonlinear or time-stepping updates.
     pub fn new(mat: Arc<Mat<f64>>) -> Self {
         let ids = ChangeIds::default();
         ids.bump_structure();

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -234,6 +234,14 @@ impl Preconditioner for LegacyOpPreconditioner {
     fn apply_mut(&mut self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
         self.apply(side, x, y)
     }
+
+    fn supports_numeric_update(&self) -> bool {
+        true
+    }
+
+    fn update_numeric(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        self.setup(a)
+    }
 }
 
 #[cfg(not(feature = "legacy-pc-bridge"))]

--- a/tests/reuse_tests.rs
+++ b/tests/reuse_tests.rs
@@ -1,9 +1,58 @@
 use kryst::context::ksp_context::{KspContext, SolverType};
 use kryst::context::pc_context::PcType;
-use kryst::matrix::CsrOp;
+use kryst::matrix::op::{DenseOp, LinOp};
+use kryst::matrix::format::AsFormat;
+use kryst::matrix::{CsrOp, convert::csr_from_linop};
 use kryst::matrix::sparse::CsrMatrix;
-use kryst::preconditioner::PcReusePolicy;
-use std::sync::Arc;
+use kryst::preconditioner::{PcReusePolicy, PcSide, Preconditioner};
+use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
+use faer::Mat;
+use kryst::error::KError;
+
+struct CountPc {
+    numeric: Arc<AtomicUsize>,
+    symbolic: Arc<AtomicUsize>,
+}
+impl CountPc {
+    fn new() -> (Self, Arc<AtomicUsize>, Arc<AtomicUsize>) {
+        let n = Arc::new(AtomicUsize::new(0));
+        let s = Arc::new(AtomicUsize::new(0));
+        (Self { numeric: n.clone(), symbolic: s.clone() }, n, s)
+    }
+}
+impl Preconditioner for CountPc {
+    fn setup(&mut self, _a: &dyn LinOp<S = f64>) -> Result<(), KError> { Ok(()) }
+    fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> { y.copy_from_slice(x); Ok(()) }
+    fn supports_numeric_update(&self) -> bool { true }
+    fn update_numeric(&mut self, _a: &dyn LinOp<S = f64>) -> Result<(), KError> { self.numeric.fetch_add(1, Ordering::SeqCst); Ok(()) }
+    fn update_symbolic(&mut self, _a: &dyn LinOp<S = f64>) -> Result<(), KError> { self.symbolic.fetch_add(1, Ordering::SeqCst); Ok(()) }
+}
+
+#[derive(Default)]
+struct PatternCheckPc {
+    row_ptr: Vec<usize>,
+    col_idx: Vec<usize>,
+}
+impl Preconditioner for PatternCheckPc {
+    fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        let csr = csr_from_linop(a, 0.0)?;
+        self.row_ptr = csr.row_ptr().to_vec();
+        self.col_idx = csr.col_idx().to_vec();
+        Ok(())
+    }
+    fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> { y.copy_from_slice(x); Ok(()) }
+    fn supports_numeric_update(&self) -> bool { true }
+    fn update_numeric(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        let csr = csr_from_linop(a, 0.0)?;
+        if self.row_ptr != csr.row_ptr() || self.col_idx != csr.col_idx() {
+            return Err(KError::Unsupported("pattern changed; need update_symbolic"));
+        }
+        Ok(())
+    }
+    fn update_symbolic(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        self.setup(a)
+    }
+}
 
 #[test]
 fn pc_rebuilds_on_structure_change() {
@@ -63,4 +112,76 @@ fn jacobi_numeric_update_without_rebuild() {
     ksp.setup().unwrap();
     assert_eq!(sid0, ksp.last_pc_sid());
     assert_ne!(vid0, ksp.last_pc_vid());
+}
+
+#[test]
+fn denseop_cache_invalidation() {
+    let mat = Arc::new(Mat::from_fn(2, 2, |i, j| if i == j { 1.0 } else { 0.0 }));
+    let op = DenseOp::new(mat);
+    let csr1 = op.to_csr_cached(0.0);
+    let p1 = Arc::as_ptr(&csr1);
+    op.mark_values_changed();
+    let csr2 = op.to_csr_cached(0.0);
+    let p2 = Arc::as_ptr(&csr2);
+    assert_ne!(p1, p2);
+}
+
+#[test]
+fn unknown_vid_triggers_numeric_refresh() {
+    let (pc, numeric, _) = CountPc::new();
+    let a = Arc::new(Mat::from_fn(2, 2, |i, j| if i == j { 1.0 } else { 0.0 }));
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Gmres).unwrap();
+    ksp.set_pc_box_for_tests(Box::new(pc));
+    ksp.set_operators(a.clone(), None);
+    ksp.setup().unwrap();
+    ksp.setup().unwrap();
+    assert_eq!(numeric.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn pattern_mismatch_in_numeric_update() {
+    let mut pc = PatternCheckPc::default();
+    let a1 = Mat::from_fn(2, 2, |i, j| if i == j { 1.0 } else { 0.0 });
+    pc.setup(&a1).unwrap();
+    let a2 = Mat::from_fn(2, 2, |i, j| if i == j { 1.0 } else if i == 0 && j == 1 { 0.5 } else { 0.0 });
+    let err = pc.update_numeric(&a2).unwrap_err();
+    match err {
+        KError::Unsupported(msg) => assert!(msg.contains("pattern changed")),
+        other => panic!("unexpected error: {:?}", other),
+    }
+}
+
+#[test]
+fn values_id_known_triggers_single_numeric_update() {
+    let (pc, numeric, _) = CountPc::new();
+    let mat = Arc::new(Mat::from_fn(2, 2, |i, j| if i == j { 1.0 } else { 0.0 }));
+    let op = Arc::new(DenseOp::new(mat.clone()));
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Gmres).unwrap();
+    ksp.set_pc_box_for_tests(Box::new(pc));
+    ksp.set_operators(op.clone(), None);
+    ksp.setup().unwrap();
+    // trigger numeric refresh
+    op.mark_values_changed();
+    ksp.setup().unwrap();
+    ksp.setup().unwrap();
+    assert_eq!(numeric.load(Ordering::SeqCst), 1);
+}
+
+#[test]
+fn policy_never_forces_symbolic_update() {
+    let (pc, numeric, symbolic) = CountPc::new();
+    let mat = Arc::new(Mat::from_fn(2, 2, |i, j| if i == j { 1.0 } else { 0.0 }));
+    let op = Arc::new(DenseOp::new(mat.clone()));
+    let mut ksp = KspContext::new();
+    ksp.set_type(SolverType::Gmres).unwrap();
+    ksp.set_pc_box_for_tests(Box::new(pc));
+    ksp.set_pc_reuse_policy(PcReusePolicy::Never);
+    ksp.set_operators(op.clone(), None);
+    ksp.setup().unwrap();
+    op.mark_values_changed();
+    ksp.setup().unwrap();
+    assert_eq!(numeric.load(Ordering::SeqCst), 0);
+    assert_eq!(symbolic.load(Ordering::SeqCst), 1);
 }


### PR DESCRIPTION
## Summary
- cache dense->CSR conversions using structure and value IDs
- add DenseOp format conversion with bumpable IDs
- refresh preconditioners when values change or IDs are unknown
- expose test hook for custom preconditioners and add reuse tests

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68acdc34186083298ee79bf626c34c47