### PR TITLE
Fix cfg placement and minor warnings

### DIFF
--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -1,8 +1,8 @@
 use crate::config::options::PcOptions;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
-use crate::preconditioner::{PcSide, Preconditioner};
 use crate::preconditioner::approxinv_csr::ApproxInvKind;
+use crate::preconditioner::{PcSide, Preconditioner};
 use std::str::FromStr;
 
 /// Supported preconditioner types.
@@ -107,11 +107,11 @@ pub enum PcConfig {
         eig_hi: f64,
     },
     Asm {
-    overlap: usize,
-    subdomain_hint: Option<usize>,
-    block_solver: Option<String>,
-    mode: Option<String>,
-    weighting: Option<String>,
+        overlap: usize,
+        subdomain_hint: Option<usize>,
+        block_solver: Option<String>,
+        mode: Option<String>,
+        weighting: Option<String>,
     },
     Amg {
         levels: Option<usize>,
@@ -239,10 +239,20 @@ impl PcConfig {
 
             ApproxInverse => {
                 // Interpret options for CSR-based SPAI/FSAI
-                let kind = match o.approxinv_kind.as_deref().unwrap_or("fsai").to_lowercase().as_str() {
+                let kind = match o
+                    .approxinv_kind
+                    .as_deref()
+                    .unwrap_or("fsai")
+                    .to_lowercase()
+                    .as_str()
+                {
                     "fsai" => ApproxInvKind::FSAI,
                     "spai" => ApproxInvKind::SPAI,
-                    other => return Err(KError::InvalidInput(format!("unknown pc_approxinv_kind: {other}"))),
+                    other => {
+                        return Err(KError::InvalidInput(format!(
+                            "unknown pc_approxinv_kind: {other}"
+                        )))
+                    }
                 };
                 let levels = o.approxinv_levels.unwrap_or(1);
                 let max_per_col = o.approxinv_max_per_col.unwrap_or(20);
@@ -250,7 +260,15 @@ impl PcConfig {
                 let reg = o.approxinv_reg.unwrap_or(1e-12);
                 let max_cond = o.approxinv_max_cond.unwrap_or(1e12);
                 let parallel = o.approxinv_parallel.unwrap_or(cfg!(feature = "rayon"));
-                PcConfig::ApproxInv { kind, levels, max_per_col, drop_tol, reg, max_cond, parallel }
+                PcConfig::ApproxInv {
+                    kind,
+                    levels,
+                    max_per_col,
+                    drop_tol,
+                    reg,
+                    max_cond,
+                    parallel,
+                }
             }
 
             Lu => PcConfig::Lu,
@@ -329,7 +347,9 @@ impl PcFactory {
             let msg = format!(
                 "Direct PC {:?} is not the last stage (index {}, chain len {}). \
                  Subsequent stages will likely be redundant or ignored.",
-                s.pc_type, i, specs.len()
+                s.pc_type,
+                i,
+                specs.len()
             );
             if strict {
                 return Err(KError::InvalidInput(msg));
@@ -410,9 +430,25 @@ impl PcFactory {
                 weighting,
             } => b::build_asm(overlap, subdomain_hint, block_solver, mode, weighting),
             PcConfig::Amg { levels, smoother } => b::build_amg(levels, smoother),
-            PcConfig::ApproxInv { kind, levels, max_per_col, drop_tol, reg, max_cond, parallel } => {
+            PcConfig::ApproxInv {
+                kind,
+                levels,
+                max_per_col,
+                drop_tol,
+                reg,
+                max_cond,
+                parallel,
+            } => {
                 use crate::preconditioner::approxinv_csr::{ApproxInvParams, FsaiCsr, SpaiCsr};
-                let params = ApproxInvParams { kind, levels, max_per_col, drop_tol, reg, max_cond, parallel };
+                let params = ApproxInvParams {
+                    kind,
+                    levels,
+                    max_per_col,
+                    drop_tol,
+                    reg,
+                    max_cond,
+                    parallel,
+                };
                 match kind {
                     ApproxInvKind::FSAI => Ok(Box::new(FsaiCsr::new_with_params(params))),
                     ApproxInvKind::SPAI => Ok(Box::new(SpaiCsr::new_with_params(params))),
@@ -544,7 +580,6 @@ pub type PC = ();
 mod tests {
     use super::*;
     use crate::preconditioner::Preconditioner;
-    use std::str::FromStr;
 
     #[cfg(feature = "dense-direct")]
     #[test]
@@ -612,7 +647,8 @@ mod tests {
                 pc_type: Some("asm".into()),
                 asm_block_solver: Some("csr".into()),
                 ..Default::default()
-            }).unwrap()
+            })
+            .unwrap()
         });
         fn _is_pc(_: &Box<dyn Preconditioner>) {}
         _is_pc(&pc);

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -125,18 +125,10 @@ impl Comm for NoComm {
         UniverseComm::NoComm(NoComm)
     }
 
-    fn irecv_from<'a>(&'a self, _buf: &'a mut [f64], _src: i32) -> Self::Request<'a> {
-        ()
-    }
-    fn isend_to<'a>(&'a self, _buf: &'a [f64], _dest: i32) -> Self::Request<'a> {
-        ()
-    }
-    fn irecv_from_u64<'a>(&'a self, _buf: &'a mut [u64], _src: i32) -> Self::Request<'a> {
-        ()
-    }
-    fn isend_to_u64<'a>(&'a self, _buf: &'a [u64], _dest: i32) -> Self::Request<'a> {
-        ()
-    }
+    fn irecv_from<'a>(&'a self, _buf: &'a mut [f64], _src: i32) -> Self::Request<'a> {}
+    fn isend_to<'a>(&'a self, _buf: &'a [f64], _dest: i32) -> Self::Request<'a> {}
+    fn irecv_from_u64<'a>(&'a self, _buf: &'a mut [u64], _src: i32) -> Self::Request<'a> {}
+    fn isend_to_u64<'a>(&'a self, _buf: &'a [u64], _dest: i32) -> Self::Request<'a> {}
     fn wait_all<'a>(&self, _reqs: &mut [Self::Request<'a>]) {}
 }
 
@@ -348,7 +340,10 @@ impl Comm for UniverseComm {
                     )
                 };
                 debug_assert_eq!(rc, 0);
-                AnyRequest::Mpi(MpiRequest { handle: req, _marker: std::marker::PhantomData })
+                AnyRequest::Mpi(MpiRequest {
+                    handle: req,
+                    _marker: std::marker::PhantomData,
+                })
             }
             #[cfg(feature = "rayon")]
             UniverseComm::Rayon(_comm) => AnyRequest::None,
@@ -378,7 +373,10 @@ impl Comm for UniverseComm {
                     )
                 };
                 debug_assert_eq!(rc, 0);
-                AnyRequest::Mpi(MpiRequest { handle: req, _marker: std::marker::PhantomData })
+                AnyRequest::Mpi(MpiRequest {
+                    handle: req,
+                    _marker: std::marker::PhantomData,
+                })
             }
             #[cfg(feature = "rayon")]
             UniverseComm::Rayon(_comm) => AnyRequest::None,
@@ -409,7 +407,10 @@ impl Comm for UniverseComm {
                     )
                 };
                 debug_assert_eq!(rc, 0);
-                AnyRequest::Mpi(MpiRequest { handle: req, _marker: std::marker::PhantomData })
+                AnyRequest::Mpi(MpiRequest {
+                    handle: req,
+                    _marker: std::marker::PhantomData,
+                })
             }
             #[cfg(feature = "rayon")]
             UniverseComm::Rayon(_comm) => AnyRequest::None,
@@ -439,7 +440,10 @@ impl Comm for UniverseComm {
                     )
                 };
                 debug_assert_eq!(rc, 0);
-                AnyRequest::Mpi(MpiRequest { handle: req, _marker: std::marker::PhantomData })
+                AnyRequest::Mpi(MpiRequest {
+                    handle: req,
+                    _marker: std::marker::PhantomData,
+                })
             }
             #[cfg(feature = "rayon")]
             UniverseComm::Rayon(_comm) => AnyRequest::None,

--- a/src/parallel/rayon_comm.rs
+++ b/src/parallel/rayon_comm.rs
@@ -20,7 +20,7 @@ use rayon::prelude::*;
 /// Implements the `Comm` trait for shared-memory parallelism. All collective operations
 /// are no-ops or local, as there is no inter-process communication.
 #[derive(Clone)]
-    pub struct RayonComm;
+pub struct RayonComm;
 
 impl RayonComm {
     /// Creates a new `RayonComm` and initializes the global Rayon thread pool
@@ -118,17 +118,9 @@ impl super::Comm for RayonComm {
         });
     }
 
-    fn irecv_from<'a>(&'a self, _buf: &'a mut [f64], _src: i32) -> Self::Request<'a> {
-        ()
-    }
-    fn isend_to<'a>(&'a self, _buf: &'a [f64], _dest: i32) -> Self::Request<'a> {
-        ()
-    }
-    fn irecv_from_u64<'a>(&'a self, _buf: &'a mut [u64], _src: i32) -> Self::Request<'a> {
-        ()
-    }
-    fn isend_to_u64<'a>(&'a self, _buf: &'a [u64], _dest: i32) -> Self::Request<'a> {
-        ()
-    }
+    fn irecv_from<'a>(&'a self, _buf: &'a mut [f64], _src: i32) -> Self::Request<'a> {}
+    fn isend_to<'a>(&'a self, _buf: &'a [f64], _dest: i32) -> Self::Request<'a> {}
+    fn irecv_from_u64<'a>(&'a self, _buf: &'a mut [u64], _src: i32) -> Self::Request<'a> {}
+    fn isend_to_u64<'a>(&'a self, _buf: &'a [u64], _dest: i32) -> Self::Request<'a> {}
     fn wait_all<'a>(&self, _reqs: &mut [Self::Request<'a>]) {}
 }

--- a/src/preconditioner/direct/lu_pc.rs
+++ b/src/preconditioner/direct/lu_pc.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "dense-direct")]
+
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};
@@ -43,4 +45,3 @@ impl Preconditioner for LuPc {
         crate::matrix::format::FormatHint::Dense
     }
 }
-#![cfg(feature = "dense-direct")]

--- a/src/preconditioner/direct/qr_pc.rs
+++ b/src/preconditioner/direct/qr_pc.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "dense-direct")]
+
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};
@@ -43,4 +45,3 @@ impl Preconditioner for QrPc {
         crate::matrix::format::FormatHint::Dense
     }
 }
-#![cfg(feature = "dense-direct")]

--- a/src/preconditioner/tests/direct_apply.rs
+++ b/src/preconditioner/tests/direct_apply.rs
@@ -1,12 +1,12 @@
 #[cfg(feature = "dense-direct")]
 use crate::error::KError;
-use crate::matrix::op::LinOp;
 use crate::matrix::op::CsrOp;
+use crate::matrix::op::LinOp;
 use crate::matrix::sparse::CsrMatrix;
 use crate::preconditioner::builders as b;
 #[cfg(feature = "dense-direct")]
 use crate::preconditioner::direct::{LuPc, QrPc};
-use crate::preconditioner::{PcSide, Preconditioner};
+use crate::preconditioner::PcSide;
 use std::sync::Arc;
 
 #[cfg(feature = "dense-direct")]
@@ -41,8 +41,13 @@ fn builders_sor_and_chebyshev_object_safe() {
     let op = CsrOp::new(Arc::new(csr));
 
     // SOR
-    let mut sor = b::build_sor(1.0, 1, crate::preconditioner::sor::MatSorType::APPLY_LOWER, false)
-        .expect("build_sor should succeed");
+    let mut sor = b::build_sor(
+        1.0,
+        1,
+        crate::preconditioner::sor::MatSorType::APPLY_LOWER,
+        false,
+    )
+    .expect("build_sor should succeed");
     sor.setup(&op as &dyn LinOp<S = f64>).unwrap();
     let x = vec![1.0; 5];
     let mut y = vec![0.0; 5];

--- a/src/solver/dense_lu.rs
+++ b/src/solver/dense_lu.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "dense-direct")]
+
 use crate::error::KError;
 use faer::linalg::solvers::{FullPivLu, SolveCore};
 use faer::{Conj, Mat, MatMut};
@@ -21,4 +23,3 @@ pub fn solve(a: &Mat<f64>, b: &[f64], x: &mut [f64]) -> Result<(), KError> {
     lu.solve_in_place_with_conj(Conj::No, x_mat);
     Ok(())
 }
-#![cfg(feature = "dense-direct")]

--- a/src/solver/dense_qr.rs
+++ b/src/solver/dense_qr.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "dense-direct")]
+
 use crate::error::KError;
 use faer::linalg::solvers::{Qr, SolveCore};
 use faer::{Conj, Mat, MatMut};
@@ -16,4 +18,3 @@ pub fn solve(a: &Mat<f64>, b: &[f64], x: &mut [f64]) -> Result<(), KError> {
     qr.solve_in_place_with_conj(Conj::No, x_mat);
     Ok(())
 }
-#![cfg(feature = "dense-direct")]

--- a/src/solver/direct_lu.rs
+++ b/src/solver/direct_lu.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "dense-direct")]
+
 //! Direct dense solvers using Faer: LU and QR factorizations.
 //!
 //! This module provides wrappers for direct dense linear solvers using the Faer library.
@@ -336,4 +338,3 @@ mod tests {
         );
     }
 }
-#![cfg(feature = "dense-direct")]

--- a/src/solver/minres.rs
+++ b/src/solver/minres.rs
@@ -425,8 +425,11 @@ where
         stats.final_residual = true_res;
 
         // If reason not yet final, normalize it based on true residual vs initial baseline
-        if matches!(stats.reason, crate::utils::convergence::ConvergedReason::Continued) {
-            let (reason2, mut s2) = self.conv.check(true_res, beta1, stats.iterations);
+        if matches!(
+            stats.reason,
+            crate::utils::convergence::ConvergedReason::Continued
+        ) {
+            let (_reason2, mut s2) = self.conv.check(true_res, beta1, stats.iterations);
             s2.final_residual = true_res;
             return Ok(s2);
         }
@@ -445,7 +448,9 @@ where
 impl crate::solver::LinearSolver for MinresSolver<f64> {
     type Error = KError;
 
-    fn as_any_mut(&mut self) -> &mut dyn std::any::Any { self }
+    fn as_any_mut(&mut self) -> &mut dyn std::any::Any {
+        self
+    }
 
     fn setup_workspace(&mut self, _work: &mut crate::context::ksp_context::Workspace) {}
 


### PR DESCRIPTION
## Summary
- move `dense-direct` cfg attributes to module headers
- simplify no-op communication functions
- drop unused imports and variables

## Testing
- `rustfmt src/preconditioner/direct/lu_pc.rs src/preconditioner/direct/qr_pc.rs src/solver/direct_lu.rs src/solver/dense_lu.rs src/solver/dense_qr.rs src/parallel/mod.rs src/parallel/rayon_comm.rs src/context/pc_context.rs src/preconditioner/tests/direct_apply.rs src/solver/minres.rs`
- `cargo clippy --all-targets -- -D warnings` *(fails: missing fields and borrow errors)*

------
https://chatgpt.com/codex/tasks/task_e_68b3fa04d15883299f74aecdcf285d1a