### PR TITLE
Fix borrow issues and clean up clippy warnings

### DIFF
--- a/src/preconditioner/builders.rs
+++ b/src/preconditioner/builders.rs
@@ -3,9 +3,6 @@ use crate::preconditioner::{Preconditioner, jacobi::Jacobi, sor::MatSorType};
 #[cfg(feature = "dense-direct")]
 use crate::preconditioner::direct::{LuPc, QrPc};
 
-#[cfg(feature = "legacy-pc-bridge")]
-use crate::preconditioner::{ilup::Ilup, ilut::Ilut, LegacyOpPreconditioner};
-
 use crate::preconditioner::sor::SorPc;
 use crate::preconditioner::chebyshev::ChebyshevPc;
 

--- a/src/preconditioner/direct/lu_pc.rs
+++ b/src/preconditioner/direct/lu_pc.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "dense-direct")]
-
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};

--- a/src/preconditioner/direct/qr_pc.rs
+++ b/src/preconditioner/direct/qr_pc.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "dense-direct")]
-
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::preconditioner::{PcSide, Preconditioner};

--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -709,8 +709,8 @@ impl Preconditioner for IluCsr {
         let sid = op.structure_id();
         let vid = op.values_id();
 
-        let structure_changed = self.last_sid.map_or(true, |s| s != sid);
-        let values_changed = self.last_vid.map_or(true, |v| v != vid);
+        let structure_changed = self.last_sid != Some(sid);
+        let values_changed = self.last_vid != Some(vid);
 
         if structure_changed || !self.cfg.numeric_update_fixed {
             self.factor_symbolic_and_numeric(&a)?;

--- a/src/solver/dense_lu.rs
+++ b/src/solver/dense_lu.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "dense-direct")]
-
 use crate::error::KError;
 use faer::linalg::solvers::{FullPivLu, SolveCore};
 use faer::{Conj, Mat, MatMut};

--- a/src/solver/dense_qr.rs
+++ b/src/solver/dense_qr.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "dense-direct")]
-
 use crate::error::KError;
 use faer::linalg::solvers::{Qr, SolveCore};
 use faer::{Conj, Mat, MatMut};

--- a/src/solver/direct_lu.rs
+++ b/src/solver/direct_lu.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "dense-direct")]
-
 //! Direct dense solvers using Faer: LU and QR factorizations.
 //!
 //! This module provides wrappers for direct dense linear solvers using the Faer library.

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -27,10 +27,6 @@ pub struct FgmresSolver {
     pub haptol: f64,
     /// If true, size basis/H for maxits; otherwise per-restart sizing.
     pub preallocate: bool,
-    /// Optional hook called once per outer iteration block (after backsolve) to allow user to tweak PC.
-    #[deprecated(note = "Use Preconditioner::on_restart(iter, res) instead")]
-    pub modify_pc_on_restart:
-        Option<Box<dyn FnMut(usize, f64) -> Result<(), KError> + Send + Sync>>,
     /// Whether to treat near-zero residual as a happy breakdown
     pub happy_breakdown: bool,
 }
@@ -46,7 +42,6 @@ impl FgmresSolver {
             orthog: Orthog::Classical,
             haptol: 1e-12,
             preallocate: false,
-            modify_pc_on_restart: None,
             happy_breakdown: true,
         }
     }
@@ -164,6 +159,8 @@ impl FgmresSolver {
                 sn: vec![0.0; block_m],
                 g: vec![0.0; block_m + 1],
                 z: vec![vec![0.0; n]; block_m],
+                q_mem: Vec::new(),
+                z_mem: Vec::new(),
             };
             &mut owned_ws
         };
@@ -370,10 +367,6 @@ impl FgmresSolver {
                 }
             } else {
                 v0.fill(0.0);
-            }
-            // Allow both legacy hook and the new Preconditioner::on_restart to adjust PC
-            if let Some(hook) = self.modify_pc_on_restart.as_mut() {
-                hook(total_iters, beta0)?;
             }
             if let Some(pc_) = pc.as_deref_mut() {
                 pc_.on_restart(total_iters, beta0)?;

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -238,11 +238,12 @@ impl LinearSolver for GmresSolver {
         let beta = match pc_side {
             PcSide::Left => {
                 self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                let beta = Self::nrm2(&ws.tmp2);
+                let tmp2 = ws.tmp2.clone();
+                let beta = Self::nrm2(&tmp2);
                 let v0 = ws.vcol_mut(n, 0);
                 if beta > 0.0 {
-                    for i in 0..n {
-                        v0[i] = ws.tmp2[i] / beta;
+                    for (v, &t) in v0.iter_mut().zip(&tmp2) {
+                        *v = t / beta;
                     }
                 } else {
                     v0.fill(0.0);
@@ -250,11 +251,12 @@ impl LinearSolver for GmresSolver {
                 beta
             }
             PcSide::Right => {
-                let beta = Self::nrm2(&ws.tmp1);
+                let tmp1 = ws.tmp1.clone();
+                let beta = Self::nrm2(&tmp1);
                 let v0 = ws.vcol_mut(n, 0);
                 if beta > 0.0 {
-                    for i in 0..n {
-                        v0[i] = ws.tmp1[i] / beta;
+                    for (v, &t) in v0.iter_mut().zip(&tmp1) {
+                        *v = t / beta;
                     }
                 } else {
                     v0.fill(0.0);
@@ -296,42 +298,50 @@ impl LinearSolver for GmresSolver {
             for k in 0..self.restart {
                 match pc_side {
                     PcSide::Left => {
-                        a.matvec(ws.vcol(n, k), &mut ws.tmp1);
+                        let vk = ws.vcol(n, k).to_vec();
+                        a.matvec(&vk, &mut ws.tmp1);
                         self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
                         for i in 0..=k {
-                            let hij = Self::dot(&ws.tmp2, ws.vcol(n, i));
+                            let vi = ws.vcol(n, i).to_vec();
+                            let hij = Self::dot(&ws.tmp2, &vi);
                             ws.h[i][k] = hij;
-                            Self::axpy(&mut ws.tmp2, hij, ws.vcol(n, i));
+                            Self::axpy(&mut ws.tmp2, hij, &vi);
                         }
-                        let hkp1k = Self::nrm2(&ws.tmp2);
+                        let tmp2 = ws.tmp2.clone();
+                        let hkp1k = Self::nrm2(&tmp2);
                         ws.h[k + 1][k] = hkp1k;
                         let vnext = ws.vcol_mut(n, k + 1);
                         if hkp1k > 0.0 {
-                            for i in 0..n {
-                                vnext[i] = ws.tmp2[i] / hkp1k;
+                            for (v, &t) in vnext.iter_mut().zip(&tmp2) {
+                                *v = t / hkp1k;
                             }
                         } else {
                             vnext.fill(0.0);
                         }
                     }
                     PcSide::Right => {
-                        self.apply_precond(pc, PcSide::Right, ws.vcol(n, k), &mut ws.tmp2)?;
+                        let vk = ws.vcol(n, k).to_vec();
+                        self.apply_precond(pc, PcSide::Right, &vk, &mut ws.tmp2)?;
                         {
+                            let tmp = ws.tmp2.clone();
                             let zk = ws.zcol_mut(n, k);
-                            zk.copy_from_slice(&ws.tmp2);
+                            zk.copy_from_slice(&tmp);
                         }
-                        a.matvec(ws.zcol(n, k), &mut ws.tmp1);
+                        let zk = ws.zcol(n, k).to_vec();
+                        a.matvec(&zk, &mut ws.tmp1);
                         for i in 0..=k {
-                            let hij = Self::dot(&ws.tmp1, ws.vcol(n, i));
+                            let vi = ws.vcol(n, i).to_vec();
+                            let hij = Self::dot(&ws.tmp1, &vi);
                             ws.h[i][k] = hij;
-                            Self::axpy(&mut ws.tmp1, hij, ws.vcol(n, i));
+                            Self::axpy(&mut ws.tmp1, hij, &vi);
                         }
-                        let hkp1k = Self::nrm2(&ws.tmp1);
+                        let tmp1 = ws.tmp1.clone();
+                        let hkp1k = Self::nrm2(&tmp1);
                         ws.h[k + 1][k] = hkp1k;
                         let vnext = ws.vcol_mut(n, k + 1);
                         if hkp1k > 0.0 {
-                            for i in 0..n {
-                                vnext[i] = ws.tmp1[i] / hkp1k;
+                            for (v, &t) in vnext.iter_mut().zip(&tmp1) {
+                                *v = t / hkp1k;
                             }
                         } else {
                             vnext.fill(0.0);
@@ -409,11 +419,12 @@ impl LinearSolver for GmresSolver {
             match pc_side {
                 PcSide::Left => {
                     self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                    let beta = Self::nrm2(&ws.tmp2);
+                    let tmp2 = ws.tmp2.clone();
+                    let beta = Self::nrm2(&tmp2);
                     let v0 = ws.vcol_mut(n, 0);
                     if beta > 0.0 {
-                        for i in 0..n {
-                            v0[i] = ws.tmp2[i] / beta;
+                        for (v, &t) in v0.iter_mut().zip(&tmp2) {
+                            *v = t / beta;
                         }
                     } else {
                         v0.fill(0.0);
@@ -421,11 +432,12 @@ impl LinearSolver for GmresSolver {
                     ws.g[0] = beta;
                 }
                 PcSide::Right => {
-                    let beta = Self::nrm2(&ws.tmp1);
+                    let tmp1 = ws.tmp1.clone();
+                    let beta = Self::nrm2(&tmp1);
                     let v0 = ws.vcol_mut(n, 0);
                     if beta > 0.0 {
-                        for i in 0..n {
-                            v0[i] = ws.tmp1[i] / beta;
+                        for (v, &t) in v0.iter_mut().zip(&tmp1) {
+                            *v = t / beta;
                         }
                     } else {
                         v0.fill(0.0);

--- a/src/solver/pca_gmres.rs
+++ b/src/solver/pca_gmres.rs
@@ -186,6 +186,8 @@ impl LinearSolver for PcaGmresSolver {
                 sn: vec![0.0; m_restart],
                 g: vec![0.0; m_restart + 1],
                 z: Vec::new(),
+                q_mem: Vec::new(),
+                z_mem: Vec::new(),
             };
             &mut owned
         };


### PR DESCRIPTION
## Summary
- Fix GMRES solver borrow conflicts using temporary clones
- Remove deprecated hook and add missing workspace buffers to FGMRES and PCA-GMRES
- Drop redundant dense-direct attributes and tidy builders and ILU change detection

## Testing
- `cargo clippy -q`


------
https://chatgpt.com/codex/tasks/task_e_68b3fbca509883298d377c1f6ffc5236