### PR TITLE
refactor: isolate pca gmres storage and semantics

### DIFF
--- a/src/solver/pca_gmres.rs
+++ b/src/solver/pca_gmres.rs
@@ -1,6 +1,5 @@
-//! PCA-GMRES (baseline) over &dyn LinOp<f64> with left/right/no preconditioning.
-//! Block size and pipeline depth are accepted but currently executed with s=1,
-//! while keeping the data layout and hooks to enable CA/pipelining next.
+//! PCA-GMRES (baseline) over &dyn LinOp<f64> with left/right/no preconditioning,
+//! using disjoint slabs for V and Z, with semantics enforced by `pc_mode`.
 
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
@@ -47,7 +46,7 @@ impl PcaGmresSolver {
                 dtol: 1e3,
                 max_iters: maxits,
             },
-            pc_mode: PcaPcMode::Left, // matches former default
+            pc_mode: PcaPcMode::Left, // default matches historical behavior
             modified_gs: true,
             haptol: 1e-12,
         }
@@ -62,34 +61,43 @@ impl PcaGmresSolver {
         x.iter().map(|v| v * v).sum::<f64>().sqrt()
     }
 
+    /// Workspace policy:
+    ///   - V basis in `w.q[0..=m]`
+    ///   - Z basis in `w.z[0..m-1]` (only used for Right PC)
     fn ensure_workspace(&self, w: &mut Workspace, n: usize) {
         let m = self.restart;
-        // Need: q for basis vectors. For RIGHT PC we also store Z (preconditioned directions).
-        // We re-use q as: V: [0..=m], Z: [m+1 .. m+m] (m slots)
-        let need_q = if matches!(self.pc_mode, PcaPcMode::Right) {
-            2 * m + 1
-        } else {
-            m + 1
-        };
-        if w.q.len() < need_q {
-            w.q.resize(need_q, Vec::new());
+
+        // V basis
+        if w.q.len() < m + 1 {
+            w.q.resize(m + 1, Vec::new());
         }
-        for q in &mut w.q {
-            if q.len() != n {
-                q.resize(n, 0.0);
+        for v in &mut w.q[..m + 1] {
+            if v.len() != n {
+                v.resize(n, 0.0);
             }
         }
 
-        // H: (m+1) x m
+        // Z basis (right preconditioning only, but always size for simplicity)
+        if w.z.len() < m {
+            w.z.resize(m, Vec::new());
+        }
+        for z in &mut w.z[..m] {
+            if z.len() != n {
+                z.resize(n, 0.0);
+            }
+        }
+
+        // Hessenberg
         if w.h.len() < m + 1 {
             w.h.resize(m + 1, Vec::new());
         }
-        for r in &mut w.h {
-            if r.len() < m {
-                r.resize(m, 0.0);
+        for row in &mut w.h[..m + 1] {
+            if row.len() != m {
+                row.resize(m, 0.0);
             }
         }
 
+        // Scalars and temporaries
         if w.tmp1.len() != n {
             w.tmp1.resize(n, 0.0);
         }
@@ -107,11 +115,71 @@ impl PcaGmresSolver {
         }
     }
 
+    /// Map pc_mode to the *expected* PcSide for Arnoldi semantics.
+    /// (None doesn't care; we return Left for convenience.)
+    fn expected_side(&self) -> PcSide {
+        match self.pc_mode {
+            PcaPcMode::None | PcaPcMode::Left => PcSide::Left,
+            PcaPcMode::Right => PcSide::Right,
+        }
+    }
+
+    /// Apply (immutable) preconditioner or act as identity when None.
+    #[inline]
+    fn apply_pc(
+        pc: Option<&dyn Preconditioner>,
+        side: PcSide,
+        x: &[f64],
+        y: &mut [f64],
+    ) -> Result<(), KError> {
+        if let Some(p) = pc {
+            p.apply(side, x, y)
+        } else {
+            y.copy_from_slice(x);
+            Ok(())
+        }
+    }
+
+    /// Classical (optionally modified) Gram–Schmidt: project `w` on `V[0..k]`,
+    /// write the column into `H[0..=k][k]`, return `||w||`.
+    /// This is the hook to fuse reductions and, later, hoist k steps for CA/pipelining.
+    fn project_and_normalize(
+        &self,
+        v_basis: &[Vec<f64>],
+        k: usize,
+        w: &mut [f64],
+        h: &mut [Vec<f64>],
+    ) -> f64 {
+        // First pass
+        for i in 0..=k {
+            let hij = Self::dot(w, &v_basis[i]);
+            h[i][k] = hij;
+            for (wi, &vi) in w.iter_mut().zip(&v_basis[i]) {
+                *wi -= hij * vi;
+            }
+        }
+        if self.modified_gs {
+            // Re-orthogonalize for robustness
+            for i in 0..=k {
+                let corr = Self::dot(w, &v_basis[i]);
+                if corr.abs() > 1e-12 {
+                    h[i][k] += corr;
+                    for (wi, &vi) in w.iter_mut().zip(&v_basis[i]) {
+                        *wi -= corr * vi;
+                    }
+                }
+            }
+        }
+        Self::nrm2(w)
+    }
+
+    #[inline]
     fn apply_givens(hij: &mut f64, hij1: &mut f64, c: f64, s: f64) {
         let t = c * (*hij) + s * (*hij1);
         *hij1 = -s * (*hij) + c * (*hij1);
         *hij = t;
     }
+    #[inline]
     fn givens(a: f64, b: f64) -> (f64, f64) {
         if b == 0.0 {
             (1.0, 0.0)
@@ -130,10 +198,13 @@ impl LinearSolver for PcaGmresSolver {
     }
 
     fn setup_workspace(&mut self, w: &mut Workspace) {
-        // Shapes fixed at solve-time once n is known; reserve outlines now.
+        // Outline only; concrete sizes are set in solve()
         let m = self.restart;
         if w.q.len() < m + 1 {
             w.q.resize(m + 1, Vec::new());
+        }
+        if w.z.len() < m {
+            w.z.resize(m, Vec::new());
         }
         if w.h.len() < m + 1 {
             w.h.resize(m + 1, Vec::new());
@@ -155,12 +226,12 @@ impl LinearSolver for PcaGmresSolver {
         pc: Option<&mut dyn Preconditioner>,
         b: &[f64],
         x: &mut [f64],
-        _pc_side: PcSide,
+        pc_side_arg: PcSide,
         _comm: &UniverseComm,
         monitors: Option<&[Box<dyn Fn(usize, f64) + Send + Sync>]>,
         work: Option<&mut Workspace>,
     ) -> Result<SolveStats<f64>, Self::Error> {
-        let pc: Option<&dyn Preconditioner> = pc.as_deref();
+        let pc_in: Option<&dyn Preconditioner> = pc.as_deref();
         let (m, n) = a.dims();
         if m != n || b.len() != n || x.len() != n {
             return Err(KError::InvalidInput(
@@ -168,9 +239,25 @@ impl LinearSolver for PcaGmresSolver {
             ));
         }
 
-        // Baseline executes with block_size = 1, pipeline_depth = 1,
-        // while keeping memory layout and hooks for later CA/pipelining.
-        let m_restart = self.restart;
+        // Determine the *effective* mode (degrade to None if pc is absent).
+        let has_pc = pc_in.is_some();
+        let mode = if has_pc {
+            self.pc_mode
+        } else {
+            PcaPcMode::None
+        };
+        let expected_side = match mode {
+            PcaPcMode::None | PcaPcMode::Left => PcSide::Left,
+            PcaPcMode::Right => PcSide::Right,
+        };
+
+        // Enforce semantics: if a preconditioner is active, side must match the mode.
+        if has_pc && pc_side_arg != expected_side {
+            return Err(KError::InvalidInput(format!(
+                "PCA-GMRES: pc_mode={:?} expects pc_side={:?}, got {:?}",
+                self.pc_mode, expected_side, pc_side_arg
+            )));
+        }
 
         // Workspace
         let mut owned;
@@ -182,32 +269,63 @@ impl LinearSolver for PcaGmresSolver {
         };
         self.ensure_workspace(ws, n);
 
-        // Memory layout in ws.q:
-        //   V-basis: q[0..=m]
-        //   Z-basis (RIGHT PC only): q[m+1 .. m+m] (length m)
-        let v_off = 0usize;
-        let z_off = m_restart + 1;
-
         // r = b - A x
         a.matvec(x, &mut ws.tmp1);
         for i in 0..n {
             ws.tmp1[i] = b[i] - ws.tmp1[i];
         }
-        let mut beta0 = Self::nrm2(&ws.tmp1);
-        let bnorm = Self::nrm2(b).max(1e-32);
-        let thr = self.conv.atol.max(self.conv.rtol * bnorm);
 
-        // Initialize v0
-        if beta0 > 0.0 {
-            let v0 = &mut ws.q[v_off + 0][..];
-            for i in 0..n {
-                v0[i] = ws.tmp1[i] / beta0;
+        // Initialize v0 and g[0] according to mode
+        let beta0 = match mode {
+            PcaPcMode::None => {
+                let beta = Self::nrm2(&ws.tmp1);
+                if beta > 0.0 {
+                    let v0 = &mut ws.q[0][..];
+                    for i in 0..n {
+                        v0[i] = ws.tmp1[i] / beta;
+                    }
+                } else {
+                    ws.q[0].fill(0.0);
+                }
+                beta
             }
-        } else {
-            ws.q[v_off + 0].fill(0.0);
-        }
+            PcaPcMode::Left => {
+                // v0 = M^{-1} r / ||M^{-1}r||
+                Self::apply_pc(pc_in, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
+                let beta = Self::nrm2(&ws.tmp2);
+                if beta > 0.0 {
+                    let v0 = &mut ws.q[0][..];
+                    for i in 0..n {
+                        v0[i] = ws.tmp2[i] / beta;
+                    }
+                } else {
+                    ws.q[0].fill(0.0);
+                }
+                beta
+            }
+            PcaPcMode::Right => {
+                // v0 = r / ||r||  (Arnoldi on A M^{-1})
+                let beta = Self::nrm2(&ws.tmp1);
+                if beta > 0.0 {
+                    let v0 = &mut ws.q[0][..];
+                    for i in 0..n {
+                        v0[i] = ws.tmp1[i] / beta;
+                    }
+                } else {
+                    ws.q[0].fill(0.0);
+                }
+                beta
+            }
+        };
+
+        ws.h.iter_mut().for_each(|row| row.fill(0.0));
+        ws.cs.fill(0.0);
+        ws.sn.fill(0.0);
         ws.g.fill(0.0);
         ws.g[0] = beta0;
+
+        let bnorm = Self::nrm2(b).max(1e-32);
+        let thr = self.conv.atol.max(self.conv.rtol * bnorm);
 
         let mut total_iters = 0usize;
         let mut res = beta0;
@@ -233,95 +351,68 @@ impl LinearSolver for PcaGmresSolver {
         }
 
         'outer: while total_iters < self.conv.max_iters {
-            // Arnoldi up to m_restart steps
+            let max_k = self.restart.min(self.conv.max_iters - total_iters);
             let mut arnoldi_steps = 0usize;
-            for j in 0..m_restart.min(self.conv.max_iters - total_iters) {
-                // w = A * (direction)
-                match self.pc_mode {
+
+            for k in 0..max_k {
+                // w = Arnoldi matvec depending on mode
+                match mode {
                     PcaPcMode::None => {
-                        a.matvec(&ws.q[v_off + j], &mut ws.tmp2);
+                        // w = A v_k
+                        a.matvec(&ws.q[k], &mut ws.tmp1);
                     }
                     PcaPcMode::Left => {
-                        // w = M^{-1} A v_j
-                        a.matvec(&ws.q[v_off + j], &mut ws.tmp1);
-                        if let Some(p) = pc {
-                            p.apply(PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                        } else {
-                            ws.tmp2.copy_from_slice(&ws.tmp1);
-                        }
+                        // w = M^{-1} A v_k
+                        a.matvec(&ws.q[k], &mut ws.tmp1);
+                        Self::apply_pc(pc_in, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
+                        ws.tmp1.copy_from_slice(&ws.tmp2);
                     }
                     PcaPcMode::Right => {
-                        // z_j = M^{-1} v_j; w = A z_j
-                        if let Some(p) = pc {
-                            let (v_part, z_part) = ws.q.split_at_mut(z_off);
-                            let vj = &v_part[v_off + j];
-                            let zj = &mut z_part[j][..];
-                            p.apply(PcSide::Right, vj, zj)?;
-                            a.matvec(zj, &mut ws.tmp2);
-                        } else {
-                            // no PC: treat as None path
-                            a.matvec(&ws.q[v_off + j], &mut ws.tmp2);
-                        }
+                        // z_k = M^{-1} v_k; w = A z_k
+                        let zk = &mut ws.z[k][..];
+                        Self::apply_pc(pc_in, PcSide::Right, &ws.q[k], zk)?;
+                        a.matvec(zk, &mut ws.tmp1);
                     }
                 }
 
-                // Classical GS + optional re-orthogonalization
-                for i in 0..=j {
-                    let hij = Self::dot(&ws.tmp2, &ws.q[v_off + i]);
-                    ws.h[i][j] = hij;
-                    for (w, &vi) in ws.tmp2.iter_mut().zip(&ws.q[v_off + i]) {
-                        *w -= hij * vi;
-                    }
-                }
-                if self.modified_gs {
-                    for i in 0..=j {
-                        let corr = Self::dot(&ws.tmp2, &ws.q[v_off + i]);
-                        if corr.abs() > 1e-12 {
-                            ws.h[i][j] += corr;
-                            for (w, &vi) in ws.tmp2.iter_mut().zip(&ws.q[v_off + i]) {
-                                *w -= corr * vi;
-                            }
-                        }
-                    }
-                }
-                // h[j+1, j] = ||w||
-                let hij1 = Self::nrm2(&ws.tmp2);
-                ws.h[j + 1][j] = hij1;
+                // Orthonormalize against V
+                let hnorm = self.project_and_normalize(&ws.q, k, &mut ws.tmp1, &mut ws.h);
+                ws.h[k + 1][k] = hnorm;
 
-                // v_{j+1}
-                let vnext = &mut ws.q[v_off + (j + 1)][..];
-                if hij1 > 0.0 {
+                // v_{k+1}
+                let vnext = &mut ws.q[k + 1][..];
+                if hnorm > 0.0 {
                     for i in 0..n {
-                        vnext[i] = ws.tmp2[i] / hij1;
+                        vnext[i] = ws.tmp1[i] / hnorm;
                     }
                 } else {
                     vnext.fill(0.0);
                 }
 
-                // Apply previous Givens
-                for i in 0..j {
+                // Apply stored Givens
+                for i in 0..k {
                     let (top, rest) = ws.h.split_at_mut(i + 1);
-                    let row_i = &mut top[i];
-                    let row_ip1 = &mut rest[0];
-                    Self::apply_givens(&mut row_i[j], &mut row_ip1[j], ws.cs[i], ws.sn[i]);
+                    let hij = &mut top[i][k];
+                    let hij1 = &mut rest[0][k];
+                    Self::apply_givens(hij, hij1, ws.cs[i], ws.sn[i]);
                 }
-                // New Givens to zero h[j+1, j]
-                let (top, rest) = ws.h.split_at_mut(j + 1);
-                let row_j = &mut top[j];
-                let row_j1 = &mut rest[0];
-                let (c, s) = Self::givens(row_j[j], row_j1[j]);
-                ws.cs[j] = c;
-                ws.sn[j] = s;
-                Self::apply_givens(&mut row_j[j], &mut row_j1[j], c, s);
+                // New Givens
+                let (top, rest) = ws.h.split_at_mut(k + 1);
+                let hjk = &mut top[k][k];
+                let hj1k = &mut rest[0][k];
+                let (c, s) = Self::givens(*hjk, *hj1k);
+                ws.cs[k] = c;
+                ws.sn[k] = s;
+                Self::apply_givens(hjk, hj1k, c, s);
 
                 // Update RHS g
-                let t = c * ws.g[j] + s * ws.g[j + 1];
-                ws.g[j + 1] = -s * ws.g[j] + c * ws.g[j + 1];
-                ws.g[j] = t;
+                let t = c * ws.g[k] + s * ws.g[k + 1];
+                ws.g[k + 1] = -s * ws.g[k] + c * ws.g[k + 1];
+                ws.g[k] = t;
 
-                res = ws.g[j + 1].abs();
+                res = ws.g[k + 1].abs(); // estimate; equals true ||r|| for Right/None, precond ||M^{-1}r|| for Left
                 total_iters += 1;
-                arnoldi_steps = j + 1;
+                arnoldi_steps = k + 1;
 
                 if let Some(mons) = monitors {
                     for m in mons {
@@ -336,9 +427,12 @@ impl LinearSolver for PcaGmresSolver {
                 ) {
                     break;
                 }
+                if total_iters >= self.conv.max_iters {
+                    break;
+                }
             }
 
-            // Back-substitute y
+            // Back-substitute
             let k = arnoldi_steps;
             let mut y = vec![0.0; k];
             for i in (0..k).rev() {
@@ -349,21 +443,19 @@ impl LinearSolver for PcaGmresSolver {
                 y[i] = sum / ws.h[i][i];
             }
 
-            // Update x
-            match self.pc_mode {
-                PcaPcMode::Right if pc.is_some() => {
-                    // x += Σ y_i * z_i
+            // Update x with V or Z depending on mode
+            match mode {
+                PcaPcMode::Right => {
                     for i in 0..k {
-                        let zi = &ws.q[z_off + i][..];
+                        let zi = &ws.z[i][..];
                         for (xj, &zij) in x.iter_mut().zip(zi) {
                             *xj += y[i] * zij;
                         }
                     }
                 }
-                _ => {
-                    // x += Σ y_i * v_i
+                PcaPcMode::None | PcaPcMode::Left => {
                     for i in 0..k {
-                        let vi = &ws.q[v_off + i][..];
+                        let vi = &ws.q[i][..];
                         for (xj, &vij) in x.iter_mut().zip(vi) {
                             *xj += y[i] * vij;
                         }
@@ -371,45 +463,104 @@ impl LinearSolver for PcaGmresSolver {
                 }
             }
 
-            // Restart: r = b - A x
+            // Restart: r = b - A x, rebuild v0 based on mode
             a.matvec(x, &mut ws.tmp1);
             for i in 0..n {
                 ws.tmp1[i] = b[i] - ws.tmp1[i];
             }
-            beta0 = Self::nrm2(&ws.tmp1);
-            ws.g.fill(0.0);
-            ws.g[0] = beta0;
-            let v0 = &mut ws.q[v_off + 0][..];
-            if beta0 > 0.0 {
-                for i in 0..n {
-                    v0[i] = ws.tmp1[i] / beta0;
+            let beta0_new = match mode {
+                PcaPcMode::None => {
+                    let beta = Self::nrm2(&ws.tmp1);
+                    let v0 = &mut ws.q[0][..];
+                    if beta > 0.0 {
+                        for i in 0..n {
+                            v0[i] = ws.tmp1[i] / beta;
+                        }
+                    } else {
+                        v0.fill(0.0);
+                    }
+                    beta
                 }
-            } else {
-                v0.fill(0.0);
-            }
+                PcaPcMode::Left => {
+                    Self::apply_pc(pc_in, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
+                    let beta = Self::nrm2(&ws.tmp2);
+                    let v0 = &mut ws.q[0][..];
+                    if beta > 0.0 {
+                        for i in 0..n {
+                            v0[i] = ws.tmp2[i] / beta;
+                        }
+                    } else {
+                        v0.fill(0.0);
+                    }
+                    beta
+                }
+                PcaPcMode::Right => {
+                    let beta = Self::nrm2(&ws.tmp1);
+                    let v0 = &mut ws.q[0][..];
+                    if beta > 0.0 {
+                        for i in 0..n {
+                            v0[i] = ws.tmp1[i] / beta;
+                        }
+                    } else {
+                        v0.fill(0.0);
+                    }
+                    beta
+                }
+            };
+
+            // Reset Hessenberg and RHS for next cycle
+            ws.h.iter_mut().for_each(|row| row.fill(0.0));
+            ws.cs.fill(0.0);
+            ws.sn.fill(0.0);
+            ws.g.fill(0.0);
+            ws.g[0] = beta0_new;
 
             if total_iters >= self.conv.max_iters {
                 break 'outer;
             }
-            if beta0 <= thr {
-                stats.reason = if beta0 <= self.conv.atol {
+            if beta0_new <= thr {
+                stats.reason = if beta0_new <= self.conv.atol {
                     ConvergedReason::ConvergedAtol
                 } else {
                     ConvergedReason::ConvergedRtol
                 };
-                stats.final_residual = beta0;
+                stats.final_residual = beta0_new;
                 break 'outer;
             }
         }
 
-        if matches!(stats.reason, ConvergedReason::Continued) {
-            stats.final_residual = res;
-            stats.reason = if res <= thr {
-                ConvergedReason::ConvergedRtol
+        // Report *true* residual at the end for consistency
+        a.matvec(x, &mut ws.tmp1);
+        for i in 0..n {
+            ws.tmp1[i] = b[i] - ws.tmp1[i];
+        }
+        let true_res = Self::nrm2(&ws.tmp1);
+        let (_r, mut s) = self.conv.check(true_res, bnorm, total_iters);
+        s.iterations = total_iters;
+        s.final_residual = true_res;
+        if matches!(s.reason, ConvergedReason::Continued) {
+            s.reason = if true_res <= thr {
+                if true_res <= self.conv.atol {
+                    ConvergedReason::ConvergedAtol
+                } else {
+                    ConvergedReason::ConvergedRtol
+                }
             } else {
                 ConvergedReason::DivergedMaxIts
             };
         }
-        Ok(stats)
+        Ok(s)
+    }
+}
+
+impl PcaGmresSolver {
+    pub fn set_restart(&mut self, restart: usize) {
+        self.restart = restart.max(1);
+    }
+    pub fn set_pc_mode(&mut self, mode: PcaPcMode) {
+        self.pc_mode = mode;
+    }
+    pub fn set_reorthog(&mut self, flag: bool) {
+        self.modified_gs = flag;
     }
 }


### PR DESCRIPTION
## Summary
- refactor PCA-GMRES workspace to keep V and Z in separate buffers
- use `pc_mode` and enforced `pc_side` to guard preconditioner semantics
- factor Gram-Schmidt into `project_and_normalize` for future CA/pipelining

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b4cccb7a948329b28d07a0703d9183