### PR TITLE
Add CSR SpMV tests and microbench

### DIFF
--- a/benches/spmv.rs
+++ b/benches/spmv.rs
@@ -1,37 +1,52 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use kryst::matrix::{spmv, sparse::CsrMatrix};
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion, Throughput};
+use kryst::matrix::{sparse::CsrMatrix, spmv::spmv_csr_parallel};
+use rand::{Rng, SeedableRng};
 
-fn csr_poisson_1d(n: usize) -> CsrMatrix<f64> {
-    let mut row_ptr = Vec::with_capacity(n + 1);
-    let mut col_idx = Vec::new();
-    let mut vals = Vec::new();
-    row_ptr.push(0);
-    for i in 0..n {
-        if i > 0 {
-            col_idx.push(i - 1);
-            vals.push(-1.0);
-        }
-        col_idx.push(i);
-        vals.push(2.0);
-        if i + 1 < n {
-            col_idx.push(i + 1);
-            vals.push(-1.0);
-        }
-        row_ptr.push(col_idx.len());
+fn build_random_csr(m: usize, n: usize, nnz_per_row: usize) -> CsrMatrix<f64> {
+    let mut rp = Vec::with_capacity(m + 1);
+    rp.push(0);
+    let mut cj = Vec::with_capacity(m * nnz_per_row);
+    let mut vv = Vec::with_capacity(m * nnz_per_row);
+    let mut rng = rand::rngs::StdRng::seed_from_u64(123);
+    for _ in 0..m {
+        let mut cols: Vec<usize> = (0..n)
+            .map(|_| rng.gen_range(0..n))
+            .take(nnz_per_row)
+            .collect();
+        cols.sort_unstable();
+        cols.dedup();
+        let k0 = cj.len();
+        cj.extend(cols.iter().copied());
+        let added = cj.len() - k0;
+        vv.extend((0..added).map(|_| rng.r#gen::<f64>()));
+        rp.push(cj.len());
     }
-    CsrMatrix::from_csr(n, n, row_ptr, col_idx, vals)
+    CsrMatrix::from_csr(m, n, rp, cj, vv)
 }
 
 fn bench_spmv(c: &mut Criterion) {
-    let n = 1_000;
-    let a = csr_poisson_1d(n);
+    let (m, n, nnz_r) = (200_000, 200_000, 20);
+    let a = build_random_csr(m, n, nnz_r);
     let x = vec![1.0; n];
-    let mut y = vec![0.0; n];
-    c.bench_function("spmv_csr_parallel", |b| {
+    let mut y = vec![0.0; m];
+
+    let mut group = c.benchmark_group("spmv_csr");
+    group.sample_size(10);
+    group.throughput(Throughput::Elements(a.nnz() as u64));
+
+    group.bench_function(BenchmarkId::new("naive_serial", a.nnz()), |b| {
         b.iter(|| {
-            spmv::spmv_csr_parallel(&a, black_box(&x), &mut y).unwrap();
+            a.spmv_scaled(1.0, &x, 0.0, &mut y).unwrap();
         });
     });
+
+    group.bench_function(BenchmarkId::new("parallel", a.nnz()), |b| {
+        b.iter(|| {
+            spmv_csr_parallel(&a, &x, &mut y).unwrap();
+        });
+    });
+
+    group.finish();
 }
 
 criterion_group!(benches, bench_spmv);

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -1,9 +1,9 @@
-use crate::parallel::{Comm, NoComm, UniverseComm};
 use crate::error::KError;
+use crate::parallel::{Comm, NoComm, UniverseComm};
 use faer::traits::ComplexField;
 use std::any::Any;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
 pub struct StructureId(pub u64);
@@ -106,7 +106,11 @@ impl DenseOp {
         let ids = ChangeIds::default();
         ids.bump_structure();
         ids.bump_values();
-        Self { mat, ids, comm: UniverseComm::NoComm(NoComm) }
+        Self {
+            mat,
+            ids,
+            comm: UniverseComm::NoComm(NoComm),
+        }
     }
     /// Attach a communicator to this operator.
     pub fn with_comm(mut self, comm: UniverseComm) -> Self {
@@ -290,7 +294,7 @@ impl LinOp for CsrOp {
     fn t_matvec(&self, x: &[f64], y: &mut [f64]) {
         #[cfg(feature = "transpose-cache")]
         {
-            if let Some(csc) = self.ensure_csc_for_t() {
+            if let Some(csc) = self.ensure_csc_view() {
                 let _ = crate::matrix::spmv::t_spmv_csr_parallel(
                     self.csr.as_ref(),
                     crate::matrix::spmv::TBackend::Csc(&csc),
@@ -323,7 +327,7 @@ impl LinOp for CsrOp {
 
 #[cfg(feature = "transpose-cache")]
 impl CsrOp {
-    fn ensure_csc_for_t(&self) -> Option<Arc<CscMatrix<f64>>> {
+    pub fn ensure_csc_view(&self) -> Option<Arc<CscMatrix<f64>>> {
         use crate::matrix::format::AsFormat;
         let vid = self.values_id();
         {

--- a/src/matrix/spmv/mod.rs
+++ b/src/matrix/spmv/mod.rs
@@ -40,13 +40,19 @@ unsafe fn fallback_lane_dot(vals: &[f64], cols: &[usize], x: &[f64]) -> f64 {
     acc
 }
 
-#[cfg(not(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "avx2")))]
+#[cfg(not(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx2"
+)))]
 #[inline]
 unsafe fn lane_dot_gather_unchecked(vals: &[f64], cols: &[usize], x: &[f64]) -> f64 {
     unsafe { fallback_lane_dot(vals, cols, x) }
 }
 
-#[cfg(all(any(target_arch = "x86", target_arch = "x86_64"), target_feature = "avx2"))]
+#[cfg(all(
+    any(target_arch = "x86", target_arch = "x86_64"),
+    target_feature = "avx2"
+))]
 #[inline]
 unsafe fn lane_dot_gather_unchecked(vals: &[f64], cols: &[usize], x: &[f64]) -> f64 {
     // placeholder for AVX2 gather implementation
@@ -60,11 +66,7 @@ pub enum TBackend<'a> {
 }
 
 #[cfg(feature = "rayon")]
-fn t_spmv_csr_parallel_csc(
-    csc: &CscMatrix<f64>,
-    x: &[f64],
-    y: &mut [f64],
-) -> Result<(), KError> {
+fn t_spmv_csr_parallel_csc(csc: &CscMatrix<f64>, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
     if x.len() != csc.nrows() || y.len() != csc.ncols() {
         return Err(KError::InvalidInput("t_spmv: dimension mismatch".into()));
     }
@@ -84,11 +86,7 @@ fn t_spmv_csr_parallel_csc(
 }
 
 #[cfg(not(feature = "rayon"))]
-fn t_spmv_csr_parallel_csc(
-    csc: &CscMatrix<f64>,
-    x: &[f64],
-    y: &mut [f64],
-) -> Result<(), KError> {
+fn t_spmv_csr_parallel_csc(csc: &CscMatrix<f64>, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
     if x.len() != csc.nrows() || y.len() != csc.ncols() {
         return Err(KError::InvalidInput("t_spmv: dimension mismatch".into()));
     }
@@ -97,11 +95,7 @@ fn t_spmv_csr_parallel_csc(
 }
 
 #[cfg(feature = "rayon")]
-fn t_spmv_csr_parallel_gather(
-    a: &CsrMatrix<f64>,
-    x: &[f64],
-    y: &mut [f64],
-) -> Result<(), KError> {
+fn t_spmv_csr_parallel_gather(a: &CsrMatrix<f64>, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
     let (m, n) = (a.nrows(), a.ncols());
     if x.len() != m || y.len() != n {
         return Err(KError::InvalidInput("t_spmv: dimension mismatch".into()));
@@ -143,11 +137,7 @@ fn t_spmv_csr_parallel_gather(
 }
 
 #[cfg(not(feature = "rayon"))]
-fn t_spmv_csr_parallel_gather(
-    a: &CsrMatrix<f64>,
-    x: &[f64],
-    y: &mut [f64],
-) -> Result<(), KError> {
+fn t_spmv_csr_parallel_gather(a: &CsrMatrix<f64>, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
     if x.len() != a.nrows() || y.len() != a.ncols() {
         return Err(KError::InvalidInput("t_spmv: dimension mismatch".into()));
     }
@@ -201,9 +191,10 @@ pub fn spmm_csr_block(
     let cj = a.col_idx();
     let vv = a.values();
 
+    let mut acc = vec![0.0f64; s];
     for i in 0..m {
+        acc.fill(0.0);
         let (rs, re) = (rp[i], rp[i + 1]);
-        let mut acc = vec![0.0f64; s];
         for p in rs..re {
             let j = cj[p];
             let aij = vv[p];
@@ -217,3 +208,6 @@ pub fn spmm_csr_block(
     }
     Ok(())
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/matrix/spmv/tests.rs
+++ b/src/matrix/spmv/tests.rs
@@ -1,0 +1,63 @@
+use crate::matrix::{
+    csc::CscMatrix,
+    sparse::{CsrMatrix, SparseMatrix},
+    spmv::{spmm_csr_block, spmv_csr_parallel, t_spmv_csr_parallel, TBackend},
+};
+
+#[test]
+fn spmv_matches_reference_small() {
+    // A = [[1,2,0],[0,3,4]]
+    let a = CsrMatrix::from_csr(
+        2,
+        3,
+        vec![0, 2, 4],
+        vec![0, 1, 1, 2],
+        vec![1.0, 2.0, 3.0, 4.0],
+    );
+    let x = vec![1.0, 1.0, 1.0];
+    let mut y_ref = vec![0.0; 2];
+    a.spmv(&x, &mut y_ref); // reference
+    let mut y = vec![0.0; 2];
+    spmv_csr_parallel(&a, &x, &mut y).unwrap();
+    assert_eq!(y, y_ref); // bitwise parity on this case
+}
+
+#[test]
+fn tspmv_matches_csc_path() {
+    // Rectangular: 3x2 then test A^T * x (size 2)
+    let a = CsrMatrix::from_csr(3, 2, vec![0, 1, 3, 3], vec![0, 0, 1], vec![5.0, 7.0, 9.0]);
+    let x = vec![1.0, 2.0, 3.0];
+    let mut y_csr = vec![0.0; 2];
+    t_spmv_csr_parallel(&a, TBackend::CsrGather, &x, &mut y_csr).unwrap();
+
+    let csc = CscMatrix::from_csc(3, 2, vec![0, 2, 3], vec![0, 1, 1], vec![5.0, 7.0, 9.0]);
+    let mut y_csc = vec![0.0; 2];
+    t_spmv_csr_parallel(&a, TBackend::Csc(&csc), &x, &mut y_csc).unwrap();
+
+    assert_eq!(y_csr, y_csc);
+}
+
+#[test]
+fn spmm_block_s_two_rhs() {
+    // A: 2x3 as above
+    let a = CsrMatrix::from_csr(
+        2,
+        3,
+        vec![0, 2, 4],
+        vec![0, 1, 1, 2],
+        vec![1.0, 2.0, 3.0, 4.0],
+    );
+    let x0 = vec![1.0, 1.0, 1.0];
+    let x1 = vec![2.0, 0.5, 0.0];
+    let mut y0 = vec![0.0; 2];
+    let mut y1 = vec![0.0; 2];
+
+    spmm_csr_block(&a, 2, &[&x0, &x1], &mut [&mut y0, &mut y1]).unwrap();
+
+    let mut r0 = vec![0.0; 2];
+    let mut r1 = vec![0.0; 2];
+    a.spmv(&x0, &mut r0);
+    a.spmv(&x1, &mut r1);
+    assert_eq!(y0, r0);
+    assert_eq!(y1, r1);
+}


### PR DESCRIPTION
## Summary
- add unit tests covering CSR SpMV, transpose path, and block SpMM
- expose cached CSC view in `CsrOp` and avoid per-row allocation in `spmm_csr_block`
- add criterion benchmark comparing serial and parallel CSR SpMV

## Testing
- `cargo test --lib spmv_matches_reference_small --quiet`
- `cargo test --lib tspmv_matches_csc_path --quiet`
- `cargo test --lib spmm_block_s_two_rhs --quiet`
- `cargo bench --bench spmv --no-run`

------
https://chatgpt.com/codex/tasks/task_e_68b50b0df1e88329993e3b3355a455a9