### PR TITLE
test: add workspace reuse test

### DIFF
--- a/src/solver/tests/gmres_workspace_reuse.rs
+++ b/src/solver/tests/gmres_workspace_reuse.rs
@@ -1,0 +1,58 @@
+#[cfg(test)]
+mod tests_gmres_workspace_reuse {
+    use crate::context::ksp_context::Workspace;
+    use crate::error::KError;
+    use crate::parallel::{NoComm, UniverseComm};
+    use crate::preconditioner::PcSide;
+    use crate::solver::{LinearSolver, gmres::GmresSolver};
+    use faer::Mat;
+
+    #[test]
+    fn workspace_buffers_reused_between_solves() -> Result<(), KError> {
+        let a = Mat::from_fn(2, 2, |i, j| if i == j { 4.0 } else { 1.0 });
+        let b = [1.0, 2.0];
+        let mut x = [0.0f64; 2];
+
+        let mut solver = GmresSolver::new(2, 1e-12, 10);
+        let mut ws = Workspace::default();
+        let comm = UniverseComm::NoComm(NoComm);
+
+        // First solve to allocate workspace
+        solver.solve(
+            &a,
+            None,
+            &b,
+            &mut x,
+            PcSide::Left,
+            &comm,
+            None,
+            Some(&mut ws),
+        )?;
+        let v_ptr = ws.v_mem.as_ptr();
+        let h_ptr = ws.h_mem.as_ptr();
+        let v_cap = ws.v_mem.capacity();
+        let h_cap = ws.h_mem.capacity();
+
+        // Solve again and ensure buffers are reused
+        x = [0.0, 0.0];
+        solver.solve(
+            &a,
+            None,
+            &b,
+            &mut x,
+            PcSide::Left,
+            &comm,
+            None,
+            Some(&mut ws),
+        )?;
+        assert_eq!(v_ptr, ws.v_mem.as_ptr());
+        assert_eq!(h_ptr, ws.h_mem.as_ptr());
+        assert!(ws.v_mem.capacity() >= v_cap);
+        assert!(ws.h_mem.capacity() >= h_cap);
+        let n = b.len();
+        let m = solver.restart;
+        assert_eq!(ws.v_mem.len(), (m + 1) * n);
+        assert_eq!(ws.h_mem.len(), (m + 1) * m);
+        Ok(())
+    }
+}

--- a/src/solver/tests/mod.rs
+++ b/src/solver/tests/mod.rs
@@ -1,3 +1,4 @@
 mod cg_side;
 mod gmres_left_right;
 mod gmres_right_z_basis;
+mod gmres_workspace_reuse;


### PR DESCRIPTION
## Summary
- test workspace reuse across GMRES solves to ensure buffers aren't reallocated

## Testing
- `cargo test workspace_buffers_reused_between_solves -- --test-threads=1` *(fails: cannot borrow `ws.tmp2` as immutable because it is also borrowed as mutable)*

------
https://chatgpt.com/codex/tasks/task_e_68b523d8c32c8329afe787a456db33a8