### PR TITLE
Refactor GMRES/FGMRES workspace borrowing

### DIFF
--- a/src/context/ksp_context/workspace.rs
+++ b/src/context/ksp_context/workspace.rs
@@ -67,6 +67,9 @@ impl Workspace {
     #[inline]
     pub fn has_z(&self) -> bool { self.need_z }
 
+    #[inline]
+    pub fn ld_h(&self) -> usize { self.m + 1 }
+
     /// Ensure capacity for a (F)GMRES run. Idempotent and allocation-friendly.
     pub fn acquire_gmres(&mut self, spec: GmresSpec) {
         // Remember shape for indexers
@@ -157,6 +160,123 @@ impl Workspace {
         let (_, lo_slice) = lo_part.split_at_mut(lo_off);
         let (hi_slice, _) = rest.split_at_mut(n);
         if a < b { (&mut lo_slice[..n], hi_slice) } else { (hi_slice, &mut lo_slice[..n]) }
+    }
+
+    // --- Composite view helpers -------------------------------------------------
+    #[inline]
+    pub fn v_and_z_mut(&mut self, j: usize) -> (&[f64], &mut [f64]) {
+        debug_assert!(self.need_z && j < self.m);
+        let n = self.n;
+        let off = j * n;
+        let vj: &[f64] = &self.v_mem[off..off + n];
+        let zj: &mut [f64] = &mut self.z_mem[off..off + n];
+        (vj, zj)
+    }
+
+    #[inline]
+    pub fn tmp1_and_z_mut(&mut self, j: usize) -> (&[f64], &mut [f64]) {
+        debug_assert!(self.need_z && j < self.m);
+        let n = self.n;
+        let tmp: &[f64] = &self.tmp1[..n];
+        let z: &mut [f64] = &mut self.z_mem[j * n..(j + 1) * n];
+        (tmp, z)
+    }
+
+    #[inline]
+    pub fn tmp2_and_z_mut(&mut self, j: usize) -> (&[f64], &mut [f64]) {
+        debug_assert!(self.need_z && j < self.m);
+        let n = self.n;
+        let tmp: &[f64] = &self.tmp2[..n];
+        let z: &mut [f64] = &mut self.z_mem[j * n..(j + 1) * n];
+        (tmp, z)
+    }
+
+    #[inline]
+    pub fn z_and_tmp2_mut(&mut self, j: usize) -> (&[f64], &mut [f64]) {
+        debug_assert!(self.need_z && j < self.m);
+        let n = self.n;
+        let z: &[f64] = &self.z_mem[j * n..(j + 1) * n];
+        let tmp: &mut [f64] = &mut self.tmp2[..n];
+        (z, tmp)
+    }
+
+    // --- Copy helpers -----------------------------------------------------------
+    #[inline]
+    pub fn copy_tmp2_into_vcol(&mut self, j: usize) {
+        let n = self.n;
+        let dst = &mut self.v_mem[j * n..(j + 1) * n];
+        let src = &self.tmp2[..n];
+        dst.copy_from_slice(src);
+    }
+
+    #[inline]
+    pub fn copy_tmp1_into_vcol(&mut self, j: usize) {
+        let n = self.n;
+        let dst = &mut self.v_mem[j * n..(j + 1) * n];
+        let src = &self.tmp1[..n];
+        dst.copy_from_slice(src);
+    }
+
+    #[inline]
+    pub fn copy_vcol_into_zcol(&mut self, j: usize) {
+        debug_assert!(self.need_z && j < self.m);
+        let n = self.n;
+        let src = &self.v_mem[j * n..(j + 1) * n];
+        let dst = &mut self.z_mem[j * n..(j + 1) * n];
+        dst.copy_from_slice(src);
+    }
+
+    #[inline]
+    pub fn copy_vcol_into_tmp1(&mut self, j: usize) {
+        let n = self.n;
+        let src = &self.v_mem[j * n..(j + 1) * n];
+        self.tmp1[..n].copy_from_slice(src);
+    }
+
+    // --- Hessenberg helpers -----------------------------------------------------
+    #[inline]
+    pub fn h2_mut(&mut self, i: usize, j: usize) -> (&mut f64, &mut f64) {
+        debug_assert!(i + 1 <= self.m && j < self.m);
+        let ld = self.ld_h();
+        let base = j * ld + i;
+        let (left, right) = self.h_mem.split_at_mut(base + 1);
+        let hij = &mut left[base];
+        let hij1 = &mut right[0];
+        (hij, hij1)
+    }
+
+    #[inline]
+    pub fn apply_prev_givens_to_col(&mut self, j: usize, upto: usize) {
+        for i in 0..upto {
+            let c = self.cs[i];
+            let s = self.sn[i];
+            let (hij, hij1) = self.h2_mut(i, j);
+            let t = c * *hij + s * *hij1;
+            *hij1 = -s * *hij + c * *hij1;
+            *hij = t;
+        }
+    }
+
+    #[inline]
+    pub fn apply_final_givens_and_update_g(&mut self, j: usize) {
+        let ld = self.ld_h();
+        let hkk = self.h_mem[j * ld + j];
+        let hk1k = self.h_mem[j * ld + j + 1];
+        let (c, s) = if hk1k == 0.0 {
+            (1.0, 0.0)
+        } else {
+            let r = (hkk * hkk + hk1k * hk1k).sqrt();
+            (hkk / r, hk1k / r)
+        };
+        self.cs[j] = c;
+        self.sn[j] = s;
+        let (hjj, hj1j) = self.h2_mut(j, j);
+        let t = c * *hjj + s * *hj1j;
+        *hj1j = -s * *hjj + c * *hj1j;
+        *hjj = t;
+        let t = c * self.g[j] + s * self.g[j + 1];
+        self.g[j + 1] = -s * self.g[j] + c * self.g[j + 1];
+        self.g[j] = t;
     }
 }
 

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -67,20 +67,8 @@ impl FgmresSolver {
         });
     }
 
-    fn apply_givens(hij: &mut f64, hij1: &mut f64, c: f64, s: f64) {
-        let t = c * (*hij) + s * (*hij1);
-        *hij1 = -s * (*hij) + c * (*hij1);
-        *hij = t;
-    }
-
-    fn givens(a: f64, b: f64) -> (f64, f64) {
-        if b == 0.0 {
-            (1.0, 0.0)
-        } else {
-            let r = (a * a + b * b).sqrt();
-            (a / r, b / r)
-        }
-    }
+    // legacy helpers for in-place Givens rotations removed; Workspace now handles
+    // orthogonalization and updating of the Hessenberg system.
 
     pub fn solve_flexible(
         &mut self,
@@ -131,7 +119,7 @@ impl FgmresSolver {
             for i in 0..n {
                 ws.tmp2[i] = ws.tmp1[i] / beta0;
             }
-            ws.v_col(0).copy_from_slice(&ws.tmp2[..n]);
+            ws.copy_tmp2_into_vcol(0);
         } else {
             ws.v_col(0).fill(0.0);
         }
@@ -177,8 +165,7 @@ impl FgmresSolver {
 
             for j in 0..m_this {
                 {
-                    let vj = &ws.v_mem[j * n..(j + 1) * n];
-                    let zj = ws.z_col(j);
+                    let (vj, zj) = ws.v_and_z_mut(j);
                     if let Some(pc_) = pc.as_deref_mut() {
                         pc_.apply_mut(pc_side, vj, zj)?;
                     } else {
@@ -186,28 +173,36 @@ impl FgmresSolver {
                     }
                 }
                 {
-                    let zj = &ws.z_mem[j * n..(j + 1) * n];
-                    a.matvec(zj, &mut ws.tmp2);
+                    let (zj, tmp2) = ws.z_and_tmp2_mut(j);
+                    a.matvec(zj, tmp2);
                 }
 
                 for i in 0..=j {
-                    let vi = &ws.v_mem[i * n..(i + 1) * n];
-                    let hij = Self::dot(&ws.tmp2, vi, comm);
+                    let hij = {
+                        let vi = &ws.v_mem[i * n..(i + 1) * n];
+                        let hij = Self::dot(&ws.tmp2, vi, comm);
+                        for (w_i, &vi_val) in ws.tmp2.iter_mut().zip(vi) {
+                            *w_i -= hij * vi_val;
+                        }
+                        hij
+                    };
                     *ws.h_at_mut(i, j) = hij;
-                    for (w_i, &vi_val) in ws.tmp2.iter_mut().zip(vi) {
-                        *w_i -= hij * vi_val;
-                    }
                 }
 
                 if matches!(self.orthog, Orthog::Modified) {
                     for i in 0..=j {
-                        let vi = &ws.v_mem[i * n..(i + 1) * n];
-                        let corr = Self::dot(&ws.tmp2, vi, comm);
+                        let corr = {
+                            let vi = &ws.v_mem[i * n..(i + 1) * n];
+                            let corr = Self::dot(&ws.tmp2, vi, comm);
+                            if corr.abs() > 1e-12 {
+                                for (w_i, &vi_val) in ws.tmp2.iter_mut().zip(vi) {
+                                    *w_i -= corr * vi_val;
+                                }
+                            }
+                            corr
+                        };
                         if corr.abs() > 1e-12 {
                             *ws.h_at_mut(i, j) += corr;
-                            for (w_i, &vi_val) in ws.tmp2.iter_mut().zip(vi) {
-                                *w_i -= corr * vi_val;
-                            }
                         }
                     }
                 }
@@ -215,36 +210,17 @@ impl FgmresSolver {
                 let hij1 = Self::nrm2(&ws.tmp2, comm);
                 *ws.h_at_mut(j + 1, j) = hij1;
 
-                let vnext = ws.v_col(j + 1);
                 if hij1 > 0.0 {
                     for i in 0..n {
                         ws.tmp2[i] /= hij1;
                     }
-                    vnext.copy_from_slice(&ws.tmp2[..n]);
+                    ws.copy_tmp2_into_vcol(j + 1);
                 } else {
-                    vnext.fill(0.0);
+                    ws.v_col(j + 1).fill(0.0);
                 }
 
-                for i in 0..j {
-                    let hij = ws.h_at_mut(i, j);
-                    let hij1 = ws.h_at_mut(i + 1, j);
-                    Self::apply_givens(hij, hij1, ws.cs[i], ws.sn[i]);
-                }
-                let (c, s) = {
-                    let hjj = ws.h_at(j, j);
-                    let hj1j = ws.h_at(j + 1, j);
-                    Self::givens(hjj, hj1j)
-                };
-                ws.cs[j] = c;
-                ws.sn[j] = s;
-                {
-                    let hjj = ws.h_at_mut(j, j);
-                    let hj1j = ws.h_at_mut(j + 1, j);
-                    Self::apply_givens(hjj, hj1j, c, s);
-                }
-                let t = c * ws.g[j] + s * ws.g[j + 1];
-                ws.g[j + 1] = -s * ws.g[j] + c * ws.g[j + 1];
-                ws.g[j] = t;
+                ws.apply_prev_givens_to_col(j, j);
+                ws.apply_final_givens_and_update_g(j);
 
                 res = ws.g[j + 1].abs();
                 total_iters += 1;
@@ -321,7 +297,7 @@ impl FgmresSolver {
                 for i in 0..n {
                     ws.tmp2[i] = ws.tmp1[i] / beta0;
                 }
-                ws.v_col(0).copy_from_slice(&ws.tmp2[..n]);
+                ws.copy_tmp2_into_vcol(0);
             } else {
                 ws.v_col(0).fill(0.0);
             }

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -97,44 +97,6 @@ impl GmresSolver {
     }
 
 
-    // legacy vector-returning orthonormalize removed; slabs path writes in-place
-    fn apply_givens_and_update(
-        h: &mut [f64],
-        cs: &mut [f64],
-        sn: &mut [f64],
-        g: &mut [f64],
-        k: usize,
-    ) {
-        let ld = cs.len() + 1;
-        for i in 0..k {
-            let c = cs[i];
-            let s = sn[i];
-            let idx = k * ld + i;
-            let hij = h[idx];
-            let hij1 = h[idx + 1];
-            let t = c * hij + s * hij1;
-            h[idx + 1] = -s * hij + c * hij1;
-            h[idx] = t;
-        }
-
-        let idx = k * ld + k;
-        let hkk = h[idx];
-        let hk1k = h[idx + 1];
-        let (c, s) = if hk1k == 0.0 {
-            (1.0, 0.0)
-        } else {
-            let r = (hkk * hkk + hk1k * hk1k).sqrt();
-            (hkk / r, hk1k / r)
-        };
-        cs[k] = c;
-        sn[k] = s;
-        let t = c * hkk + s * hk1k;
-        h[idx + 1] = -s * hkk + c * hk1k;
-        h[idx] = t;
-        let t = c * g[k] + s * g[k + 1];
-        g[k + 1] = -s * g[k] + c * g[k + 1];
-        g[k] = t;
-    }
 
     fn backsolve(h: &[f64], g: &[f64], k: usize) -> Vec<f64> {
         let ld = g.len();
@@ -230,18 +192,12 @@ impl LinearSolver for GmresSolver {
         let beta = match pc_side {
             PcSide::Left => {
                 self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                let tmp2 = ws.tmp2.clone();
-                let beta = Self::nrm2(&tmp2);
+                let beta = Self::nrm2(&ws.tmp2);
                 if beta > 0.0 {
                     for i in 0..n { ws.tmp2[i] /= beta; }
-                }
-                {
-                    let v0 = ws.v_col(0);
-                    if beta > 0.0 {
-                        v0.copy_from_slice(&ws.tmp2[..n]);
-                    } else {
-                        v0.fill(0.0);
-                    }
+                    ws.copy_tmp2_into_vcol(0);
+                } else {
+                    ws.v_col(0).fill(0.0);
                 }
                 beta
             }
@@ -249,14 +205,9 @@ impl LinearSolver for GmresSolver {
                 let beta = Self::nrm2(&ws.tmp1);
                 if beta > 0.0 {
                     for i in 0..n { ws.tmp2[i] = ws.tmp1[i] / beta; }
-                }
-                {
-                    let v0 = ws.v_col(0);
-                    if beta > 0.0 {
-                        v0.copy_from_slice(&ws.tmp2[..n]);
-                    } else {
-                        v0.fill(0.0);
-                    }
+                    ws.copy_tmp2_into_vcol(0);
+                } else {
+                    ws.v_col(0).fill(0.0);
                 }
                 beta
             }
@@ -311,14 +262,9 @@ impl LinearSolver for GmresSolver {
                         *ws.h_at_mut(k + 1, k) = hnext;
                         if hnext > 0.0 {
                             for i in 0..n { ws.tmp2[i] /= hnext; }
-                        }
-                        {
-                            let vnext = ws.v_col(k + 1);
-                            if hnext > 0.0 {
-                                vnext.copy_from_slice(&ws.tmp2[..n]);
-                            } else {
-                                vnext.fill(0.0);
-                            }
+                            ws.copy_tmp2_into_vcol(k + 1);
+                        } else {
+                            ws.v_col(k + 1).fill(0.0);
                         }
                     }
                     PcSide::Right => {
@@ -342,20 +288,16 @@ impl LinearSolver for GmresSolver {
                         *ws.h_at_mut(k + 1, k) = hnext;
                         if hnext > 0.0 {
                             for i in 0..n { ws.tmp1[i] /= hnext; }
-                        }
-                        {
-                            let vnext = ws.v_col(k + 1);
-                            if hnext > 0.0 {
-                                vnext.copy_from_slice(&ws.tmp1[..n]);
-                            } else {
-                                vnext.fill(0.0);
-                            }
+                            ws.copy_tmp1_into_vcol(k + 1);
+                        } else {
+                            ws.v_col(k + 1).fill(0.0);
                         }
                     }
                     PcSide::Symmetric => unreachable!(),
                 }
 
-                Self::apply_givens_and_update(&mut ws.h_mem, &mut ws.cs, &mut ws.sn, &mut ws.g, k);
+                ws.apply_prev_givens_to_col(k, k);
+                ws.apply_final_givens_and_update_g(k);
 
                 res = ws.g[k + 1].abs();
                 total_iters += 1;
@@ -410,18 +352,12 @@ impl LinearSolver for GmresSolver {
             match pc_side {
                 PcSide::Left => {
                     self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                    let tmp2 = ws.tmp2.clone();
-                    let beta = Self::nrm2(&tmp2);
+                    let beta = Self::nrm2(&ws.tmp2);
                     if beta > 0.0 {
                         for i in 0..n { ws.tmp2[i] /= beta; }
-                    }
-                    {
-                        let v0 = ws.v_col(0);
-                        if beta > 0.0 {
-                            v0.copy_from_slice(&ws.tmp2[..n]);
-                        } else {
-                            v0.fill(0.0);
-                        }
+                        ws.copy_tmp2_into_vcol(0);
+                    } else {
+                        ws.v_col(0).fill(0.0);
                     }
                     ws.g[0] = beta;
                 }
@@ -429,14 +365,9 @@ impl LinearSolver for GmresSolver {
                     let beta = Self::nrm2(&ws.tmp1);
                     if beta > 0.0 {
                         for i in 0..n { ws.tmp2[i] = ws.tmp1[i] / beta; }
-                    }
-                    {
-                        let v0 = ws.v_col(0);
-                        if beta > 0.0 {
-                            v0.copy_from_slice(&ws.tmp2[..n]);
-                        } else {
-                            v0.fill(0.0);
-                        }
+                        ws.copy_tmp2_into_vcol(0);
+                    } else {
+                        ws.v_col(0).fill(0.0);
                     }
                     ws.g[0] = beta;
                 }


### PR DESCRIPTION
## Summary
- add workspace helpers for safe multi-slice borrows and in-place copies
- refactor GMRES/FGMRES to use workspace helpers and avoid clone-based borrow hacks
- centralize Givens rotations in workspace for Hessenberg updates

## Testing
- `cargo check`
- `cargo check -F "rayon,logging"`


------
https://chatgpt.com/codex/tasks/task_e_68b529c717ec8329b05559372c18522b