### PR TITLE
Add workspace allocation test and clean no-MPI build

### DIFF
--- a/src/matrix/spmv/mod.rs
+++ b/src/matrix/spmv/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::KError;
 use crate::matrix::{csc::CscMatrix, sparse::CsrMatrix};
+use crate::matrix::op::LinOp;
 
 /// y = A * x using CSR; parallel when `rayon` is enabled.
 #[cfg(feature = "rayon")]

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -4,12 +4,14 @@ use mpi::datatype::Equivalence;
 use mpi::raw::AsRaw;
 #[cfg(any(feature = "mpi", feature = "rayon"))]
 use std::sync::Arc;
+use std::marker::PhantomData;
 
-// Opaque request that can represent multiple backends.
+// Opaque request that can represent multiple backends. Use a `PhantomData`
+// to tie the lifetime when MPI support is disabled.
 pub enum AnyRequest<'a> {
-    None,
     #[cfg(feature = "mpi")]
     Mpi(MpiRequest<'a>),
+    None(PhantomData<&'a ()>),
 }
 
 #[cfg(feature = "mpi")]
@@ -320,7 +322,7 @@ impl Comm for UniverseComm {
 
     fn irecv_from<'a>(&'a self, buf: &'a mut [f64], src: i32) -> Self::Request<'a> {
         match self {
-            UniverseComm::NoComm(_comm) => AnyRequest::None,
+            UniverseComm::NoComm(_comm) => AnyRequest::None(PhantomData),
             #[cfg(feature = "mpi")]
             UniverseComm::Mpi(comm) => {
                 // Post a true nonblocking receive via raw MPI and keep the handle
@@ -346,14 +348,14 @@ impl Comm for UniverseComm {
                 })
             }
             #[cfg(feature = "rayon")]
-            UniverseComm::Rayon(_comm) => AnyRequest::None,
+            UniverseComm::Rayon(_comm) => AnyRequest::None(PhantomData),
             #[cfg(not(any(feature = "mpi", feature = "rayon")))]
-            UniverseComm::Serial => AnyRequest::None,
+            UniverseComm::Serial => AnyRequest::None(PhantomData),
         }
     }
     fn isend_to<'a>(&'a self, buf: &'a [f64], dest: i32) -> Self::Request<'a> {
         match self {
-            UniverseComm::NoComm(_comm) => AnyRequest::None,
+            UniverseComm::NoComm(_comm) => AnyRequest::None(PhantomData),
             #[cfg(feature = "mpi")]
             UniverseComm::Mpi(comm) => {
                 // Post a true nonblocking send via raw MPI and keep the handle
@@ -379,15 +381,15 @@ impl Comm for UniverseComm {
                 })
             }
             #[cfg(feature = "rayon")]
-            UniverseComm::Rayon(_comm) => AnyRequest::None,
+            UniverseComm::Rayon(_comm) => AnyRequest::None(PhantomData),
             #[cfg(not(any(feature = "mpi", feature = "rayon")))]
-            UniverseComm::Serial => AnyRequest::None,
+            UniverseComm::Serial => AnyRequest::None(PhantomData),
         }
     }
 
     fn irecv_from_u64<'a>(&'a self, buf: &'a mut [u64], src: i32) -> Self::Request<'a> {
         match self {
-            UniverseComm::NoComm(_comm) => AnyRequest::None,
+            UniverseComm::NoComm(_comm) => AnyRequest::None(PhantomData),
             #[cfg(feature = "mpi")]
             UniverseComm::Mpi(comm) => {
                 // Nonblocking receive of u64 via raw MPI
@@ -413,14 +415,14 @@ impl Comm for UniverseComm {
                 })
             }
             #[cfg(feature = "rayon")]
-            UniverseComm::Rayon(_comm) => AnyRequest::None,
+            UniverseComm::Rayon(_comm) => AnyRequest::None(PhantomData),
             #[cfg(not(any(feature = "mpi", feature = "rayon")))]
-            UniverseComm::Serial => AnyRequest::None,
+            UniverseComm::Serial => AnyRequest::None(PhantomData),
         }
     }
     fn isend_to_u64<'a>(&'a self, buf: &'a [u64], dest: i32) -> Self::Request<'a> {
         match self {
-            UniverseComm::NoComm(_comm) => AnyRequest::None,
+            UniverseComm::NoComm(_comm) => AnyRequest::None(PhantomData),
             #[cfg(feature = "mpi")]
             UniverseComm::Mpi(comm) => {
                 // Nonblocking send of u64 via raw MPI
@@ -446,9 +448,9 @@ impl Comm for UniverseComm {
                 })
             }
             #[cfg(feature = "rayon")]
-            UniverseComm::Rayon(_comm) => AnyRequest::None,
+            UniverseComm::Rayon(_comm) => AnyRequest::None(PhantomData),
             #[cfg(not(any(feature = "mpi", feature = "rayon")))]
-            UniverseComm::Serial => AnyRequest::None,
+            UniverseComm::Serial => AnyRequest::None(PhantomData),
         }
     }
     fn wait_all<'a>(&self, reqs: &mut [Self::Request<'a>]) {
@@ -465,7 +467,7 @@ impl Comm for UniverseComm {
         }
         // Clear handles so buffers can be reused immediately.
         for r in reqs.iter_mut() {
-            *r = AnyRequest::None;
+            *r = AnyRequest::None(PhantomData);
         }
     }
 }

--- a/tests/workspace_tests.rs
+++ b/tests/workspace_tests.rs
@@ -1,1 +1,58 @@
+use kryst::context::ksp_context::{Workspace, GmresSpec};
+use kryst::solver::{GmresSolver, LinearSolver};
+use kryst::matrix::op::LinOp;
+use kryst::preconditioner::PcSide;
+use kryst::parallel::UniverseComm;
+
+#[test]
+fn gmres_workspace_allocation_stable_and_sized() {
+    let n = 4;
+    let restart = 3;
+    // allocate workspace manually
+    let mut ws = Workspace::default();
+    ws.acquire_gmres(GmresSpec { n, m: restart, need_z: true, block_s: 0 });
+
+    let v_ptr = ws.v_mem.as_ptr();
+    let z_ptr = ws.z_mem.as_ptr();
+    let h_ptr = ws.h_mem.as_ptr();
+    let v_cap = ws.v_mem.capacity();
+    let z_cap = ws.z_mem.capacity();
+    let h_cap = ws.h_mem.capacity();
+
+    // Setup small identity system
+    let a = faer::Mat::<f64>::from_fn(n, n, |i, j| if i == j { 1.0 } else { 0.0 });
+    let amat = &a as &dyn LinOp<S = f64>;
+    let mut solver = GmresSolver::new(restart, 1e-6, 10);
+    let b: Vec<f64> = (0..n).map(|i| i as f64 + 1.0).collect();
+    let mut x = vec![0.0; n];
+
+    solver
+        .solve(
+            amat,
+            None,
+            &b,
+            &mut x,
+            PcSide::Right,
+            &UniverseComm::NoComm(kryst::parallel::NoComm),
+            None,
+            Some(&mut ws),
+        )
+        .unwrap();
+
+    // Pointers and capacities should be unchanged
+    assert_eq!(v_ptr, ws.v_mem.as_ptr());
+    assert_eq!(z_ptr, ws.z_mem.as_ptr());
+    assert_eq!(h_ptr, ws.h_mem.as_ptr());
+    assert!(ws.v_mem.capacity() >= v_cap);
+    assert!(ws.z_mem.capacity() >= z_cap);
+    assert!(ws.h_mem.capacity() >= h_cap);
+
+    // Lengths should match exact expectations
+    assert_eq!(ws.v_mem.len(), (restart + 1) * n);
+    assert_eq!(ws.z_mem.len(), restart * n);
+    assert_eq!(ws.h_mem.len(), (restart + 1) * restart);
+    assert_eq!(ws.g.len(), restart + 1);
+    assert_eq!(ws.cs.len(), restart);
+    assert_eq!(ws.sn.len(), restart);
+}
 


### PR DESCRIPTION
## Summary
- add a GMRES workspace test ensuring buffer reuse and correct sizing
- fix no-MPI builds by tying AnyRequest lifetime via PhantomData
- import LinOp for transpose SpMV helpers

## Testing
- `cargo test --no-default-features --features logging gmres_workspace_allocation_stable_and_sized`


------
https://chatgpt.com/codex/tasks/task_e_68b52ca8f2888329ad164ce7f51b34fd