### PR TITLE
Override NoComm sum2 reduction

### DIFF
--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -142,6 +142,12 @@ impl Comm for NoComm {
         local
     }
 
+    fn allreduce_sum2(&self, a: f64, b: f64) -> (f64, f64) {
+        (a, b)
+    }
+
+    fn allreduce_sum_slice(&self, _v: &mut [f64]) {}
+
     fn split(&self, _color: i32, _key: i32) -> UniverseComm {
         UniverseComm::NoComm(NoComm)
     }


### PR DESCRIPTION
## Summary
- Override `allreduce_sum2` and `allreduce_sum_slice` for the serial `NoComm` communicator to avoid redundant operations

## Testing
- `cargo test` *(fails: timed out due to long build process)*

------
https://chatgpt.com/codex/tasks/task_e_68b5d92fea808329b33ec08678a25a5c