### PR TITLE
Introduce fused two-scalar allreduce and verify CG/PCG sync counts

### DIFF
--- a/src/parallel/mpi_comm.rs
+++ b/src/parallel/mpi_comm.rs
@@ -138,6 +138,23 @@ impl super::Comm for MpiComm {
         self.all_reduce(local)
     }
 
+    fn allreduce_sum2(&self, a: f64, b: f64) -> (f64, f64) {
+        use mpi::collective::SystemOperation;
+        let send = [a, b];
+        let mut recv = [0.0f64; 2];
+        self.world
+            .all_reduce_into(&send, &mut recv, &SystemOperation::sum());
+        (recv[0], recv[1])
+    }
+
+    fn allreduce_sum_slice(&self, v: &mut [f64]) {
+        use mpi::collective::SystemOperation;
+        let mut out = vec![0.0f64; v.len()];
+        self.world
+            .all_reduce_into(v, &mut out[..], &SystemOperation::sum());
+        v.copy_from_slice(&out);
+    }
+
     /// Split this communicator into sub‐colors
     fn split(&self, color: i32, key: i32) -> super::UniverseComm {
         use mpi::topology::Color;

--- a/src/solver/cg.rs
+++ b/src/solver/cg.rs
@@ -236,101 +236,182 @@ impl CgSolver {
         }
 
         for k in 1..=self.conv.max_iters {
-            if self.single_reduction && k > 1 {
+            if self.single_reduction {
+                if k > 1 {
+                    let beta = rho / rho_prev;
+                    for i in 0..n {
+                        p[i] = z_prev[i] + beta * p[i];
+                    }
+                }
+            } else if k > 1 {
                 let beta = rho / rho_prev;
                 for i in 0..n {
-                    p[i] = z_prev[i] + beta * p[i];
+                    p[i] = z[i] + beta * p[i];
                 }
             }
 
             a.matvec(p, ap);
 
-            let (p_ap, rho_k) = if !self.single_reduction {
-                let p_ap = Self::dot(p, ap, comm);
-                (p_ap, rho)
-            } else if has_pending_rz {
-                let p_ap_local = Self::local_dot(p, ap);
-                let (p_ap_g, rho_g) = comm.allreduce_sum2(p_ap_local, pending_rz_local);
-                (p_ap_g, rho_g)
-            } else {
-                let p_ap_local = Self::local_dot(p, ap);
-                let p_ap_g = comm.allreduce_sum(p_ap_local);
-                (p_ap_g, rho)
-            };
-            if p_ap <= 0.0 || !p_ap.is_finite() {
-                return Err(KError::IndefiniteMatrix);
-            }
+            if self.single_reduction {
+                let (p_ap, rho_k) = if has_pending_rz {
+                    let p_ap_local = Self::local_dot(p, ap);
+                    let (p_ap_g, rho_g) = comm.allreduce_sum2(p_ap_local, pending_rz_local);
+                    (p_ap_g, rho_g)
+                } else {
+                    let p_ap_local = Self::local_dot(p, ap);
+                    let p_ap_g = comm.allreduce_sum(p_ap_local);
+                    (p_ap_g, rho)
+                };
+                if p_ap <= 0.0 || !p_ap.is_finite() {
+                    return Err(KError::IndefiniteMatrix);
+                }
 
-            let alpha = rho_k / p_ap;
+                let alpha = rho_k / p_ap;
 
-            if let Some(rmax) = self.trust_region {
-                let pnorm = Self::nrm2(p, comm);
-                if xnorm + alpha.abs() * pnorm > rmax {
-                    let step = (rmax - xnorm) / (pnorm + 1e-300);
-                    for i in 0..n {
-                        x[i] += step * p[i];
+                if let Some(rmax) = self.trust_region {
+                    let pnorm = Self::nrm2(p, comm);
+                    if xnorm + alpha.abs() * pnorm > rmax {
+                        let step = (rmax - xnorm) / (pnorm + 1e-300);
+                        for i in 0..n {
+                            x[i] += step * p[i];
+                        }
+                        stats.iterations = k;
+                        stats.reason = ConvergedReason::DivergedMaxIts;
+                        stats.final_residual = recompute_true_residual_norm(a, b, x, comm, tmp);
+                        return Ok(stats);
                     }
-                    stats.iterations = k;
-                    stats.reason = ConvergedReason::DivergedMaxIts;
-                    // ensure final_residual is true ||b - A x|| at exit
-                    stats.final_residual = recompute_true_residual_norm(a, b, x, comm, tmp);
-                    return Ok(stats);
                 }
-            }
 
-            for i in 0..n {
-                x[i] += alpha * p[i];
-            }
-            for i in 0..n {
-                r[i] -= alpha * ap[i];
-            }
-            if self.trust_region.is_some() {
-                xnorm = Self::nrm2(x, comm);
-            }
-
-            if let Some(m) = pc {
-                m.apply(pc_side, r, z)?;
-            } else {
-                z.copy_from_slice(r);
-            }
-
-            let rz_local_next = Self::local_dot(r, z);
-            if rz_local_next <= 0.0 || !rz_local_next.is_finite() {
-                return Err(KError::IndefinitePreconditioner);
-            }
-            pending_rz_local = rz_local_next;
-            has_pending_rz = true;
-
-            let rsq_new = if matches!(self.norm_type, CgNormType::Unpreconditioned) {
-                Some(Self::dot(r, r, comm))
-            } else {
-                None
-            };
-
-            let res_reported = match self.norm_type {
-                CgNormType::Preconditioned | CgNormType::Natural => rho_k.abs().sqrt(),
-                CgNormType::Unpreconditioned => rsq_new.unwrap().sqrt(),
-                CgNormType::None => 0.0,
-            };
-
-            if let Some(ms) = monitors {
-                for m in ms {
-                    m(k, res_reported);
+                for i in 0..n {
+                    x[i] += alpha * p[i];
                 }
-            }
+                for i in 0..n {
+                    r[i] -= alpha * ap[i];
+                }
+                if self.trust_region.is_some() {
+                    xnorm = Self::nrm2(x, comm);
+                }
 
-            let (reason, mut s) = self.conv.check(res_reported, res0_reported, k);
-            if !matches!(reason, ConvergedReason::Continued) {
-                let true_res = recompute_true_residual_norm(a, b, x, comm, tmp);
-                s.final_residual = true_res;
-                return Ok(s);
-            }
+                if let Some(m) = pc {
+                    m.apply(pc_side, r, z)?;
+                } else {
+                    z.copy_from_slice(r);
+                }
 
-            z_prev.swap_with_slice(z);
-            rho_prev = rho;
-            rho = rho_k;
-            stats.iterations = k;
-            stats.final_residual = res_reported;
+                let rz_local_next = Self::local_dot(r, z);
+                if rz_local_next <= 0.0 || !rz_local_next.is_finite() {
+                    return Err(KError::IndefinitePreconditioner);
+                }
+                pending_rz_local = rz_local_next;
+                has_pending_rz = true;
+
+                let rsq_new = if matches!(self.norm_type, CgNormType::Unpreconditioned) {
+                    Some(Self::dot(r, r, comm))
+                } else {
+                    None
+                };
+
+                let res_reported = match self.norm_type {
+                    CgNormType::Preconditioned | CgNormType::Natural => rho_k.abs().sqrt(),
+                    CgNormType::Unpreconditioned => rsq_new.unwrap().sqrt(),
+                    CgNormType::None => 0.0,
+                };
+
+                if let Some(ms) = monitors {
+                    for m in ms {
+                        m(k, res_reported);
+                    }
+                }
+
+                let (reason, mut s) = self.conv.check(res_reported, res0_reported, k);
+                if !matches!(reason, ConvergedReason::Continued) {
+                    let true_res = recompute_true_residual_norm(a, b, x, comm, tmp);
+                    s.final_residual = true_res;
+                    return Ok(s);
+                }
+
+                z_prev.swap_with_slice(z);
+                rho_prev = rho;
+                rho = rho_k;
+                stats.iterations = k;
+                stats.final_residual = res_reported;
+            } else {
+                let p_ap = Self::dot(p, ap, comm);
+                if p_ap <= 0.0 || !p_ap.is_finite() {
+                    return Err(KError::IndefiniteMatrix);
+                }
+
+                let alpha = rho / p_ap;
+
+                if let Some(rmax) = self.trust_region {
+                    let pnorm = Self::nrm2(p, comm);
+                    if xnorm + alpha.abs() * pnorm > rmax {
+                        let step = (rmax - xnorm) / (pnorm + 1e-300);
+                        for i in 0..n {
+                            x[i] += step * p[i];
+                        }
+                        stats.iterations = k;
+                        stats.reason = ConvergedReason::DivergedMaxIts;
+                        stats.final_residual = recompute_true_residual_norm(a, b, x, comm, tmp);
+                        return Ok(stats);
+                    }
+                }
+
+                for i in 0..n {
+                    x[i] += alpha * p[i];
+                }
+                for i in 0..n {
+                    r[i] -= alpha * ap[i];
+                }
+                if self.trust_region.is_some() {
+                    xnorm = Self::nrm2(x, comm);
+                }
+
+                if let Some(m) = pc {
+                    m.apply(pc_side, r, z)?;
+                } else {
+                    z.copy_from_slice(r);
+                }
+
+                let rho_new = Self::dot(r, z, comm);
+                if rho_new <= 0.0 || !rho_new.is_finite() {
+                    return Err(KError::IndefinitePreconditioner);
+                }
+
+                let rsq_new = if matches!(self.norm_type, CgNormType::Unpreconditioned) {
+                    Some(Self::dot(r, r, comm))
+                } else {
+                    None
+                };
+
+                let res_reported = match self.norm_type {
+                    CgNormType::Preconditioned | CgNormType::Natural => rho_new.abs().sqrt(),
+                    CgNormType::Unpreconditioned => rsq_new.unwrap().sqrt(),
+                    CgNormType::None => 0.0,
+                };
+
+                if let Some(ms) = monitors {
+                    for m in ms {
+                        m(k, res_reported);
+                    }
+                }
+
+                let (reason, mut s) = self.conv.check(res_reported, res0_reported, k);
+                if !matches!(reason, ConvergedReason::Continued) {
+                    let true_res = recompute_true_residual_norm(a, b, x, comm, tmp);
+                    s.final_residual = true_res;
+                    return Ok(s);
+                }
+
+                let beta = rho_new / rho;
+                for i in 0..n {
+                    p[i] = z[i] + beta * p[i];
+                }
+                rho_prev = rho;
+                rho = rho_new;
+                stats.iterations = k;
+                stats.final_residual = res_reported;
+            }
         }
 
         // Max-its reached: recompute true residual and return divergence

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -203,82 +203,146 @@ impl PcgSolver {
         for k in 1..=self.conv.max_iters {
             iters = k;
 
-            if self.single_reduction && k > 1 {
+            if self.single_reduction {
+                if k > 1 {
+                    let beta = rho / rho_prev;
+                    for i in 0..n {
+                        p[i] = z_prev[i] + beta * p[i];
+                    }
+                }
+            } else if k > 1 {
                 let beta = rho / rho_prev;
                 for i in 0..n {
-                    p[i] = z_prev[i] + beta * p[i];
+                    p[i] = z[i] + beta * p[i];
                 }
             }
 
             a.matvec(p, w);
 
-            let (pw, rho_k) = if !self.single_reduction {
-                let pw = Self::dot(p, w, comm);
-                (pw, rho)
-            } else if has_pending_rz {
-                let pw_local = Self::local_dot(p, w);
-                let (pw_g, rho_g) = comm.allreduce_sum2(pw_local, pending_rz_local);
-                (pw_g, rho_g)
-            } else {
-                let pw_local = Self::local_dot(p, w);
-                let pw_g = comm.allreduce_sum(pw_local);
-                (pw_g, rho)
-            };
-            if pw <= 0.0 || !pw.is_finite() {
-                let mut tmp = vec![0.0; n];
-                let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
-                return Ok(SolveStats { iterations: k - 1, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
-            }
-
-            let alpha = rho_k / pw;
-            for i in 0..n {
-                x[i] += alpha * p[i];
-                r[i] -= alpha * w[i];
-            }
-
-            if let Some(pc) = pc {
-                pc.apply(pc_side, r, z)?;
-            } else {
-                z.copy_from_slice(r);
-            }
-
-            let rz_local_next = Self::local_dot(r, z);
-            if rz_local_next < 0.0 || !rz_local_next.is_finite() {
-                let mut tmp = vec![0.0; n];
-                let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
-                return Ok(SolveStats { iterations: k, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
-            }
-            pending_rz_local = rz_local_next;
-            has_pending_rz = true;
-
-            res = match self.norm_type {
-                CgNormType::Preconditioned => rho_k.sqrt(),
-                CgNormType::Unpreconditioned => Self::nrm2(r, comm),
-                CgNormType::Natural => rho_k,
-                CgNormType::None => res,
-            };
-
-            if let Some(ms) = monitors {
-                for m in ms {
-                    m(k, res);
+            if self.single_reduction {
+                let (pw, rho_k) = if has_pending_rz {
+                    let pw_local = Self::local_dot(p, w);
+                    let (pw_g, rho_g) = comm.allreduce_sum2(pw_local, pending_rz_local);
+                    (pw_g, rho_g)
+                } else {
+                    let pw_local = Self::local_dot(p, w);
+                    let pw_g = comm.allreduce_sum(pw_local);
+                    (pw_g, rho)
+                };
+                if pw <= 0.0 || !pw.is_finite() {
+                    let mut tmp = vec![0.0; n];
+                    let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
+                    return Ok(SolveStats { iterations: k - 1, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
                 }
-            }
 
-            let res_check = match self.norm_type {
-                CgNormType::Preconditioned | CgNormType::Natural => rho_k.sqrt(),
-                CgNormType::Unpreconditioned | CgNormType::None => Self::nrm2(r, comm),
-            };
-            let (reason, mut s) = self.conv.check(res_check, bnorm, k);
-            if !matches!(reason, ConvergedReason::Continued) {
-                let mut tmp = vec![0.0; n];
-                let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
-                s.final_residual = true_res;
-                return Ok(SolveStats { iterations: k, final_residual: s.final_residual, reason: s.reason });
-            }
+                let alpha = rho_k / pw;
+                for i in 0..n {
+                    x[i] += alpha * p[i];
+                    r[i] -= alpha * w[i];
+                }
 
-            z_prev.swap_with_slice(z);
-            rho_prev = rho;
-            rho = rho_k;
+                if let Some(pc) = pc {
+                    pc.apply(pc_side, r, z)?;
+                } else {
+                    z.copy_from_slice(r);
+                }
+
+                let rz_local_next = Self::local_dot(r, z);
+                if rz_local_next < 0.0 || !rz_local_next.is_finite() {
+                    let mut tmp = vec![0.0; n];
+                    let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
+                    return Ok(SolveStats { iterations: k, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
+                }
+                pending_rz_local = rz_local_next;
+                has_pending_rz = true;
+
+                res = match self.norm_type {
+                    CgNormType::Preconditioned => rho_k.sqrt(),
+                    CgNormType::Unpreconditioned => Self::nrm2(r, comm),
+                    CgNormType::Natural => rho_k,
+                    CgNormType::None => res,
+                };
+
+                if let Some(ms) = monitors {
+                    for m in ms {
+                        m(k, res);
+                    }
+                }
+
+                let res_check = match self.norm_type {
+                    CgNormType::Preconditioned | CgNormType::Natural => rho_k.sqrt(),
+                    CgNormType::Unpreconditioned | CgNormType::None => Self::nrm2(r, comm),
+                };
+                let (reason, mut s) = self.conv.check(res_check, bnorm, k);
+                if !matches!(reason, ConvergedReason::Continued) {
+                    let mut tmp = vec![0.0; n];
+                    let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
+                    s.final_residual = true_res;
+                    return Ok(SolveStats { iterations: k, final_residual: s.final_residual, reason: s.reason });
+                }
+
+                z_prev.swap_with_slice(z);
+                rho_prev = rho;
+                rho = rho_k;
+            } else {
+                let pw = Self::dot(p, w, comm);
+                if pw <= 0.0 || !pw.is_finite() {
+                    let mut tmp = vec![0.0; n];
+                    let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
+                    return Ok(SolveStats { iterations: k - 1, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
+                }
+
+                let alpha = rho / pw;
+                for i in 0..n {
+                    x[i] += alpha * p[i];
+                    r[i] -= alpha * w[i];
+                }
+
+                if let Some(pc) = pc {
+                    pc.apply(pc_side, r, z)?;
+                } else {
+                    z.copy_from_slice(r);
+                }
+
+                let rho_new = Self::dot(r, z, comm);
+                if rho_new < 0.0 || !rho_new.is_finite() {
+                    let mut tmp = vec![0.0; n];
+                    let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
+                    return Ok(SolveStats { iterations: k, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
+                }
+
+                res = match self.norm_type {
+                    CgNormType::Preconditioned => rho_new.sqrt(),
+                    CgNormType::Unpreconditioned => Self::nrm2(r, comm),
+                    CgNormType::Natural => rho_new,
+                    CgNormType::None => res,
+                };
+
+                if let Some(ms) = monitors {
+                    for m in ms {
+                        m(k, res);
+                    }
+                }
+
+                let res_check = match self.norm_type {
+                    CgNormType::Preconditioned | CgNormType::Natural => rho_new.sqrt(),
+                    CgNormType::Unpreconditioned | CgNormType::None => Self::nrm2(r, comm),
+                };
+                let (reason, mut s) = self.conv.check(res_check, bnorm, k);
+                if !matches!(reason, ConvergedReason::Continued) {
+                    let mut tmp = vec![0.0; n];
+                    let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
+                    s.final_residual = true_res;
+                    return Ok(SolveStats { iterations: k, final_residual: s.final_residual, reason: s.reason });
+                }
+
+                let beta = rho_new / rho;
+                for i in 0..n {
+                    p[i] = z[i] + beta * p[i];
+                }
+                rho_prev = rho;
+                rho = rho_new;
+            }
         }
 
         let mut tmp = vec![0.0; n];

--- a/tests/cg_pcg_reduction_counts.rs
+++ b/tests/cg_pcg_reduction_counts.rs
@@ -62,3 +62,43 @@ fn pcg_reduction_counts() {
 
 }
 
+#[test]
+fn cg_classic_reduction_counts() {
+    let n = 5;
+    let a = build_spd(n);
+    let b = vec![1.0; n];
+    let mut x = vec![0.0; n];
+
+    let base = UniverseComm::NoComm(NoComm);
+    let comm = CountingComm::new(base.clone());
+    let mut solver = CgSolver::new(1e-12, 20);
+    solver.set_single_reduction(false);
+    let mut wk = Workspace::default();
+    solver.setup_workspace(&mut wk);
+    let stats = solver
+        .solve_with_comm(&a, None, &b, &mut x, PcSide::Left, &comm, None, Some(&mut wk))
+        .unwrap();
+    let expected = 1 + 2 * stats.iterations;
+    assert_eq!(comm.reduces.load(Ordering::Relaxed), expected);
+}
+
+#[test]
+fn pcg_classic_reduction_counts() {
+    let n = 5;
+    let a = build_spd(n);
+    let b = vec![1.0; n];
+    let mut x = vec![0.0; n];
+
+    let base = UniverseComm::NoComm(NoComm);
+    let comm = CountingComm::new(base.clone());
+    let mut solver = PcgSolver::new(1e-12, 20);
+    solver.set_single_reduction(false);
+    let mut wk = Workspace::default();
+    solver.setup_workspace(&mut wk);
+    let stats = solver
+        .solve_with_comm(&a, None, &b, &mut x, PcSide::Left, &comm, None, Some(&mut wk))
+        .unwrap();
+    let expected = 2 + 2 * stats.iterations;
+    assert_eq!(comm.reduces.load(Ordering::Relaxed), expected);
+}
+


### PR DESCRIPTION
## Summary
- Implement `allreduce_sum2` and slice reductions in MPI backend for true one-shot collectives
- Fix CG and PCG to support both classic two-reduction and new single-reduction paths
- Add regression tests asserting reduction counts for classic vs single-reduction modes

## Testing
- `cargo test --no-default-features --features logging --test cg_pcg_reduction_counts`

------
https://chatgpt.com/codex/tasks/task_e_68b5e70bf9c88329a4e6f1f82fac631e