### PR TITLE
Add numeric parity tests for single-reduction CG/PCG

### DIFF
--- a/tests/cg_pcg_reduction_counts.rs
+++ b/tests/cg_pcg_reduction_counts.rs
@@ -102,3 +102,77 @@ fn pcg_classic_reduction_counts() {
     assert_eq!(comm.reduces.load(Ordering::Relaxed), expected);
 }
 
+#[test]
+fn cg_single_reduction_numeric_parity() {
+    let n = 5;
+    let a = build_spd(n);
+    let b = vec![1.0; n];
+    let base = UniverseComm::NoComm(NoComm);
+
+    // Classic two-reduction CG
+    let mut x_classic = vec![0.0; n];
+    let mut solver_classic = CgSolver::new(1e-12, 20);
+    solver_classic.set_single_reduction(false);
+    let mut wk_classic = Workspace::default();
+    solver_classic.setup_workspace(&mut wk_classic);
+    let stats_classic = solver_classic
+        .solve_with_comm(&a, None, &b, &mut x_classic, PcSide::Left, &base, None, Some(&mut wk_classic))
+        .unwrap();
+
+    // Single-reduction CG
+    let mut x_single = vec![0.0; n];
+    let mut solver_single = CgSolver::new(1e-12, 20);
+    solver_single.set_single_reduction(true);
+    let mut wk_single = Workspace::default();
+    solver_single.setup_workspace(&mut wk_single);
+    let stats_single = solver_single
+        .solve_with_comm(&a, None, &b, &mut x_single, PcSide::Left, &base, None, Some(&mut wk_single))
+        .unwrap();
+
+    assert_eq!(stats_classic.iterations, stats_single.iterations);
+    assert!((stats_classic.final_residual - stats_single.final_residual).abs() < 1e-3);
+
+    let max_diff = x_classic
+        .iter()
+        .zip(x_single.iter())
+        .fold(0.0f64, |m, (a, b)| m.max((a - b).abs()));
+    assert!(max_diff < 1e-3);
+}
+
+#[test]
+fn pcg_single_reduction_numeric_parity() {
+    let n = 5;
+    let a = build_spd(n);
+    let b = vec![1.0; n];
+    let base = UniverseComm::NoComm(NoComm);
+
+    // Classic two-reduction PCG
+    let mut x_classic = vec![0.0; n];
+    let mut solver_classic = PcgSolver::new(1e-12, 20);
+    solver_classic.set_single_reduction(false);
+    let mut wk_classic = Workspace::default();
+    solver_classic.setup_workspace(&mut wk_classic);
+    let stats_classic = solver_classic
+        .solve_with_comm(&a, None, &b, &mut x_classic, PcSide::Left, &base, None, Some(&mut wk_classic))
+        .unwrap();
+
+    // Single-reduction PCG
+    let mut x_single = vec![0.0; n];
+    let mut solver_single = PcgSolver::new(1e-12, 20);
+    solver_single.set_single_reduction(true);
+    let mut wk_single = Workspace::default();
+    solver_single.setup_workspace(&mut wk_single);
+    let stats_single = solver_single
+        .solve_with_comm(&a, None, &b, &mut x_single, PcSide::Left, &base, None, Some(&mut wk_single))
+        .unwrap();
+
+    assert_eq!(stats_classic.iterations, stats_single.iterations);
+    assert!((stats_classic.final_residual - stats_single.final_residual).abs() < 1e-3);
+
+    let max_diff = x_classic
+        .iter()
+        .zip(x_single.iter())
+        .fold(0.0f64, |m, (a, b)| m.max((a - b).abs()));
+    assert!(max_diff < 1e-3);
+}
+


### PR DESCRIPTION
## Summary
- add unit tests checking that single-reduction CG and PCG match classic solver results within tolerance

## Testing
- `cargo test --no-default-features --features logging --test cg_pcg_reduction_counts`

------
https://chatgpt.com/codex/tasks/task_e_68b5e8b5d7ec8329bbb331ff3024fee7