### PR TITLE
Add trust-region convergence reason and align CG defaults

### DIFF
--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -99,6 +99,14 @@ impl PcReusePolicy {
 /// implementations that are true direct methods should override it. The default
 /// implementation returns a clear [`KError`], so existing preconditioners
 /// continue to work unchanged.
+///
+/// # SPD contract
+///
+/// Solvers such as Conjugate Gradient and MINRES **require** that left
+/// preconditioners behave like a symmetric positive definite operator so that
+/// `z = M^{-1} r` preserves symmetry.  These solvers check `rᵀz > 0` at runtime
+/// and may return [`KError::IndefinitePreconditioner`] if the contract is
+/// violated.
 pub trait Preconditioner: Send + Sync {
     /// Build any factorization/hierarchy once from the system matrix.
     fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError>;

--- a/src/solver/cg.rs
+++ b/src/solver/cg.rs
@@ -21,9 +21,15 @@ use log::trace;
 
 #[derive(Debug, Clone, Copy)]
 pub enum CgNormType {
+    /// Monitor the preconditioned residual `sqrt(rᵀz)` (default for left PCG)
     Preconditioned,
+    /// Monitor the unpreconditioned residual `||r||₂`
     Unpreconditioned,
+    /// Monitor the "natural" norm induced by the operator.  For SPD systems
+    /// with left preconditioning this is also `sqrt(rᵀz)` and is provided for
+    /// PETSc parity.
     Natural,
+    /// Do not compute or report a residual norm
     None,
 }
 
@@ -37,7 +43,7 @@ pub struct CgSolver {
 impl CgSolver {
     pub fn new(rtol: f64, maxits: usize) -> Self {
         Self {
-            conv: Convergence { rtol, atol: 1e-12, dtol: 1e3, max_iters: maxits },
+            conv: Convergence { rtol, atol: 1e-50, dtol: 1e5, max_iters: maxits },
             // Default monitors use preconditioned norm per policy
             norm_type: CgNormType::Preconditioned,
             single_reduction: false,
@@ -276,7 +282,7 @@ impl CgSolver {
                             x[i] += step * p[i];
                         }
                         stats.iterations = k;
-                        stats.reason = ConvergedReason::DivergedMaxIts;
+                        stats.reason = ConvergedReason::ConvergedTrustRegion;
                         stats.final_residual = recompute_true_residual_norm(a, b, x, comm, tmp);
                         return Ok(stats);
                     }
@@ -351,7 +357,7 @@ impl CgSolver {
                             x[i] += step * p[i];
                         }
                         stats.iterations = k;
-                        stats.reason = ConvergedReason::DivergedMaxIts;
+                        stats.reason = ConvergedReason::ConvergedTrustRegion;
                         stats.final_residual = recompute_true_residual_norm(a, b, x, comm, tmp);
                         return Ok(stats);
                     }

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -10,9 +10,14 @@ use std::any::Any;
 
 #[derive(Debug, Clone, Copy)]
 pub enum CgNormType {
+    /// Monitor the preconditioned residual `sqrt(rᵀz)` (default)
     Preconditioned,
+    /// Monitor the unpreconditioned residual `||r||₂`
     Unpreconditioned,
+    /// Monitor the natural norm induced by the operator (also `sqrt(rᵀz)` for
+    /// SPD systems). Included for compatibility with PETSc semantics.
     Natural,
+    /// Do not compute or report a residual norm
     None,
 }
 
@@ -24,7 +29,7 @@ pub struct PcgSolver {
 
 impl PcgSolver {
     pub fn new(rtol: f64, maxits: usize) -> Self {
-        Self { conv: Convergence { rtol, atol: 1e-12, dtol: 1e3, max_iters: maxits }, norm_type: CgNormType::Preconditioned, single_reduction: false }
+        Self { conv: Convergence { rtol, atol: 1e-50, dtol: 1e5, max_iters: maxits }, norm_type: CgNormType::Preconditioned, single_reduction: false }
     }
 
     /// Optional runtime update of solver tolerances

--- a/src/utils/convergence.rs
+++ b/src/utils/convergence.rs
@@ -25,6 +25,8 @@ pub enum ConvergedReason {
     ConvergedRtol,
     /// Converged due to absolute tolerance: ‖r‖ ≤ atol
     ConvergedAtol,
+    /// Converged because the step reached a trust-region bound
+    ConvergedTrustRegion,
     /// Diverged due to divergence tolerance: ‖r‖ ≥ dtol * ‖b‖
     DivergedDtol,
     /// Diverged due to maximum iterations reached

--- a/tests/cg_trust_region.rs
+++ b/tests/cg_trust_region.rs
@@ -1,0 +1,19 @@
+use kryst::preconditioner::PcSide;
+use kryst::context::ksp_context::Workspace;
+use kryst::solver::{CgSolver, LinearSolver};
+use kryst::parallel::UniverseComm;
+use kryst::utils::convergence::ConvergedReason;
+use faer::Mat;
+
+#[test]
+fn cg_hits_trust_region() {
+    let comm = UniverseComm::NoComm(kryst::parallel::NoComm);
+    let a = Mat::<f64>::from_fn(1, 1, |_i, _j| 2.0);
+    let b = vec![2.0];
+    let mut x = vec![0.0];
+    let mut solver = CgSolver::new(1e-8, 5).with_trust_region(0.5);
+    let mut ws = Workspace::new(1);
+    solver.setup_workspace(&mut ws);
+    let stats = solver.solve(&a, None, &b, &mut x, PcSide::Left, &comm, None, Some(&mut ws)).unwrap();
+    assert_eq!(stats.reason, ConvergedReason::ConvergedTrustRegion);
+}


### PR DESCRIPTION
## Summary
- add `ConvergedTrustRegion` result and surface trust-region stops
- document SPD contract for left preconditioners
- align CG solver defaults with PETSc-style tolerances and refine norm docs
- add regression test for trust-region termination

## Testing
- `cargo test` *(fails: solver::tests::gmres_right_z_basis::tests_gmres_z_basis::gmres_right_uses_z_basis_and_calls_pc_per_step)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f12d529083298db3968e4ba147b0