### PR TITLE
chore: address some clippy warnings

### DIFF
--- a/src/core/mat/shell.rs
+++ b/src/core/mat/shell.rs
@@ -35,6 +35,8 @@
 
 use crate::core::traits::{MatShape, MatTransVec, MatVec};
 use std::marker::PhantomData;
+
+type ShellFn<V> = dyn Fn(&V, &mut V) + Send + Sync;
 /// A "shell" matrix: user-supplied callbacks for A·x and Aᵀ·x
 ///
 /// `ShellMat` provides a matrix-free interface where matrix operations are defined
@@ -42,8 +44,8 @@ use std::marker::PhantomData;
 /// that don't need to be stored explicitly.
 pub struct ShellMat<V> {
     pub dim: usize,
-    mult: Box<dyn Fn(&V, &mut V) + Send + Sync>,
-    mult_trans: Box<dyn Fn(&V, &mut V) + Send + Sync>,
+    mult: Box<ShellFn<V>>,
+    mult_trans: Box<ShellFn<V>>,
     // Makes the dependency on V explicit without requiring V: Send/Sync.
     // Using `fn(&V)` (not `V`) avoids imposing Send/Sync bounds on V.
     _marker: PhantomData<fn(&V)>,

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -552,6 +552,12 @@ impl LocalAmgKernel {
     }
 }
 
+impl Default for LocalAmgKernel {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl AmgKernel for LocalAmgKernel {
     type Comm = crate::parallel::NoComm;
 
@@ -596,6 +602,12 @@ pub struct DistributedAmgKernel;
 impl DistributedAmgKernel {
     pub fn new() -> Self {
         Self
+    }
+}
+
+impl Default for DistributedAmgKernel {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/src/matrix/convert.rs
+++ b/src/matrix/convert.rs
@@ -43,7 +43,7 @@ fn unsupported_linop_err(op: &dyn LinOp<S = f64>, where_: &str, target: &str) ->
 }
 
 /// Try to borrow a CSR matrix if the operator is already CSR.
-pub fn try_as_csr<'a>(pmat: &'a dyn LinOp<S = f64>) -> Option<&'a CsrMatrix<f64>> {
+pub fn try_as_csr(pmat: &dyn LinOp<S = f64>) -> Option<&CsrMatrix<f64>> {
     pmat.as_any().downcast_ref::<CsrMatrix<f64>>()
 }
 
@@ -76,7 +76,7 @@ pub fn csr_from_linop(
 }
 
 /// Try to borrow a CSC matrix if the operator is already CSC.
-pub fn try_as_csc<'a>(pmat: &'a dyn LinOp<S = f64>) -> Option<&'a CscMatrix<f64>> {
+pub fn try_as_csc(pmat: &dyn LinOp<S = f64>) -> Option<&CscMatrix<f64>> {
     pmat.as_any().downcast_ref::<CscMatrix<f64>>()
 }
 

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -141,12 +141,12 @@ impl LinOp for DenseOp {
     fn t_matvec(&self, x: &[f64], y: &mut [f64]) {
         assert_eq!(x.len(), self.mat.nrows());
         assert_eq!(y.len(), self.mat.ncols());
-        for j in 0..self.mat.ncols() {
+        for (j, yj) in y.iter_mut().enumerate().take(self.mat.ncols()) {
             let mut sum = 0.0;
-            for i in 0..self.mat.nrows() {
-                sum += self.mat[(i, j)] * x[i];
+            for (i, xi) in x.iter().enumerate().take(self.mat.nrows()) {
+                sum += self.mat[(i, j)] * *xi;
             }
-            y[j] = sum;
+            *yj = sum;
         }
     }
     fn as_any(&self) -> &dyn Any {

--- a/src/parallel/mpi_comm.rs
+++ b/src/parallel/mpi_comm.rs
@@ -34,6 +34,12 @@ pub struct MpiComm {
 unsafe impl Send for MpiComm {}
 unsafe impl Sync for MpiComm {}
 
+impl Default for MpiComm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 // --- One-time MPI universe holder ---
 static MPI_UNIVERSE: OnceLock<mpi::environment::Universe> = OnceLock::new();
 
@@ -58,7 +64,7 @@ impl MpiComm {
 
     /// Best-effort constructor that returns `None` if initialization fails.
     pub fn try_new() -> Option<Self> {
-        std::panic::catch_unwind(|| Self::new()).ok()
+        std::panic::catch_unwind(Self::new).ok()
     }
 }
 
@@ -129,7 +135,7 @@ impl super::Comm for MpiComm {
         use mpi::collective::SystemOperation;
         let mut y = x;
         self.world
-            .all_reduce_into(&x, &mut y, &SystemOperation::sum());
+            .all_reduce_into(&x, &mut y, SystemOperation::sum());
         y
     }
 
@@ -143,7 +149,7 @@ impl super::Comm for MpiComm {
         let send = [a, b];
         let mut recv = [0.0f64; 2];
         self.world
-            .all_reduce_into(&send, &mut recv, &SystemOperation::sum());
+            .all_reduce_into(&send, &mut recv, SystemOperation::sum());
         (recv[0], recv[1])
     }
 
@@ -151,7 +157,7 @@ impl super::Comm for MpiComm {
         use mpi::collective::SystemOperation;
         let mut out = vec![0.0f64; v.len()];
         self.world
-            .all_reduce_into(v, &mut out[..], &SystemOperation::sum());
+            .all_reduce_into(v, &mut out[..], SystemOperation::sum());
         v.copy_from_slice(&out);
     }
 
@@ -203,7 +209,7 @@ impl super::Comm for MpiComm {
                 buf.as_mut_ptr() as *mut std::ffi::c_void,
                 count,
                 mpi::ffi::RSMPI_DOUBLE,
-                src as i32,
+                src,
                 0,
                 comm_raw,
                 &mut req,
@@ -222,7 +228,7 @@ impl super::Comm for MpiComm {
                 buf.as_ptr() as *const std::ffi::c_void,
                 count,
                 mpi::ffi::RSMPI_DOUBLE,
-                dest as i32,
+                dest,
                 0,
                 comm_raw,
                 &mut req,
@@ -241,7 +247,7 @@ impl super::Comm for MpiComm {
                 buf.as_mut_ptr() as *mut std::ffi::c_void,
                 count,
                 mpi::ffi::RSMPI_UINT64_T,
-                src as i32,
+                src,
                 0,
                 comm_raw,
                 &mut req,
@@ -260,7 +266,7 @@ impl super::Comm for MpiComm {
                 buf.as_ptr() as *const std::ffi::c_void,
                 count,
                 mpi::ffi::RSMPI_UINT64_T,
-                dest as i32,
+                dest,
                 0,
                 comm_raw,
                 &mut req,

--- a/src/parallel/rayon_comm.rs
+++ b/src/parallel/rayon_comm.rs
@@ -22,6 +22,12 @@ use rayon::prelude::*;
 #[derive(Clone)]
 pub struct RayonComm;
 
+impl Default for RayonComm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl RayonComm {
     /// Creates a new `RayonComm` and initializes the global Rayon thread pool
     /// to use all available CPU cores.

--- a/src/parallel/threads.rs
+++ b/src/parallel/threads.rs
@@ -52,6 +52,7 @@ static EFFECTIVE_THREADS: OnceLock<usize> = OnceLock::new();
 /// - If env `KRYST_THREADS` is set, it overrides the global CPU count.
 /// - If not set, we fall back to `RAYON_NUM_THREADS`, then `num_cpus::get()`.
 /// - Per-rank threads = floor(total / mpi_size), clamped to >= 1.
+///
 /// Returns the number of threads actually used for Rayon.
 pub fn init_global_rayon_pool(mpi_size: usize) -> usize {
     #[cfg(not(feature = "rayon"))]


### PR DESCRIPTION
## Summary
- add Default implementations and clean up MPI/Rayon communicators
- refactor shell matrix callbacks and simplify conversions
- tighten docs and eliminate several redundant loops

## Testing
- `cargo clippy -- -D warnings` *(fails: 165 errors remain)*
- `cargo test --quiet` *(no output, terminated)*

------
https://chatgpt.com/codex/tasks/task_e_68b5fe537634832996f6593abef1a3a2