### PR TITLE
Refactor: address clippy warnings

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -929,7 +929,7 @@ mod tests {
     use super::*;
     use crate::context::pc_context::PcType;
     use crate::preconditioner::PcSide;
-    use crate::matrix::op::{DenseOp, wrap_with_comm};
+    use crate::matrix::op::DenseOp;
     use faer::Mat;
     use std::sync::Arc;
 

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -1,5 +1,5 @@
 use crate::error::KError;
-use crate::parallel::{Comm, NoComm, UniverseComm};
+use crate::parallel::{NoComm, UniverseComm};
 use faer::traits::ComplexField;
 use std::any::Any;
 use std::sync::atomic::{AtomicU64, Ordering};

--- a/src/matrix/spmv/mod.rs
+++ b/src/matrix/spmv/mod.rs
@@ -1,5 +1,5 @@
 use crate::error::KError;
-use crate::matrix::{csc::CscMatrix, sparse::CsrMatrix};
+use crate::matrix::{csc::CscMatrix, op::LinOp, sparse::CsrMatrix};
 
 /// y = A * x using CSR; parallel when `rayon` is enabled.
 #[cfg(feature = "rayon")]
@@ -27,6 +27,7 @@ pub fn spmv_csr_parallel(a: &CsrMatrix<f64>, x: &[f64], y: &mut [f64]) -> Result
     a.spmv_scaled(1.0, x, 0.0, y)
 }
 
+#[cfg(feature = "rayon")]
 #[inline]
 unsafe fn fallback_lane_dot(vals: &[f64], cols: &[usize], x: &[f64]) -> f64 {
     debug_assert_eq!(vals.len(), cols.len());
@@ -40,6 +41,7 @@ unsafe fn fallback_lane_dot(vals: &[f64], cols: &[usize], x: &[f64]) -> f64 {
     acc
 }
 
+#[cfg(feature = "rayon")]
 #[cfg(not(all(
     any(target_arch = "x86", target_arch = "x86_64"),
     target_feature = "avx2"
@@ -49,6 +51,7 @@ unsafe fn lane_dot_gather_unchecked(vals: &[f64], cols: &[usize], x: &[f64]) -> 
     unsafe { fallback_lane_dot(vals, cols, x) }
 }
 
+#[cfg(feature = "rayon")]
 #[cfg(all(
     any(target_arch = "x86", target_arch = "x86_64"),
     target_feature = "avx2"

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -345,19 +345,19 @@ impl Comm for UniverseComm {
         }
     }
 
-    fn irecv_from<'a>(&'a self, buf: &'a mut [f64], src: i32) -> Self::Request<'a> {
+    fn irecv_from<'a>(&'a self, _buf: &'a mut [f64], _src: i32) -> Self::Request<'a> {
         match self {
             UniverseComm::NoComm(_comm) => AnyRequest::None(PhantomData),
             #[cfg(feature = "mpi")]
             UniverseComm::Mpi(comm) => {
                 // Post a true nonblocking receive via raw MPI and keep the handle
                 let mut req: mpi::ffi::MPI_Request = unsafe { std::mem::zeroed() };
-                let count = buf.len() as i32;
-                let src_rank = src as i32;
+                let count = _buf.len() as i32;
+                let src_rank = _src as i32;
                 let comm_raw = mpi::raw::AsRaw::as_raw(&comm.world);
                 let rc = unsafe {
                     mpi::ffi::MPI_Irecv(
-                        buf.as_mut_ptr() as *mut std::ffi::c_void,
+                        _buf.as_mut_ptr() as *mut std::ffi::c_void,
                         count,
                         mpi::ffi::RSMPI_DOUBLE,
                         src_rank,
@@ -378,19 +378,19 @@ impl Comm for UniverseComm {
             UniverseComm::Serial => AnyRequest::None(PhantomData),
         }
     }
-    fn isend_to<'a>(&'a self, buf: &'a [f64], dest: i32) -> Self::Request<'a> {
+    fn isend_to<'a>(&'a self, _buf: &'a [f64], _dest: i32) -> Self::Request<'a> {
         match self {
             UniverseComm::NoComm(_comm) => AnyRequest::None(PhantomData),
             #[cfg(feature = "mpi")]
             UniverseComm::Mpi(comm) => {
                 // Post a true nonblocking send via raw MPI and keep the handle
                 let mut req: mpi::ffi::MPI_Request = unsafe { std::mem::zeroed() };
-                let count = buf.len() as i32;
-                let dest_rank = dest as i32;
+                let count = _buf.len() as i32;
+                let dest_rank = _dest as i32;
                 let comm_raw = mpi::raw::AsRaw::as_raw(&comm.world);
                 let rc = unsafe {
                     mpi::ffi::MPI_Isend(
-                        buf.as_ptr() as *const std::ffi::c_void,
+                        _buf.as_ptr() as *const std::ffi::c_void,
                         count,
                         mpi::ffi::RSMPI_DOUBLE,
                         dest_rank,
@@ -412,19 +412,19 @@ impl Comm for UniverseComm {
         }
     }
 
-    fn irecv_from_u64<'a>(&'a self, buf: &'a mut [u64], src: i32) -> Self::Request<'a> {
+    fn irecv_from_u64<'a>(&'a self, _buf: &'a mut [u64], _src: i32) -> Self::Request<'a> {
         match self {
             UniverseComm::NoComm(_comm) => AnyRequest::None(PhantomData),
             #[cfg(feature = "mpi")]
             UniverseComm::Mpi(comm) => {
                 // Nonblocking receive of u64 via raw MPI
                 let mut req: mpi::ffi::MPI_Request = unsafe { std::mem::zeroed() };
-                let count = buf.len() as i32;
-                let src_rank = src as i32;
+                let count = _buf.len() as i32;
+                let src_rank = _src as i32;
                 let comm_raw = mpi::raw::AsRaw::as_raw(&comm.world);
                 let rc = unsafe {
                     mpi::ffi::MPI_Irecv(
-                        buf.as_mut_ptr() as *mut std::ffi::c_void,
+                        _buf.as_mut_ptr() as *mut std::ffi::c_void,
                         count,
                         mpi::ffi::RSMPI_UINT64_T,
                         src_rank,
@@ -445,19 +445,19 @@ impl Comm for UniverseComm {
             UniverseComm::Serial => AnyRequest::None(PhantomData),
         }
     }
-    fn isend_to_u64<'a>(&'a self, buf: &'a [u64], dest: i32) -> Self::Request<'a> {
+    fn isend_to_u64<'a>(&'a self, _buf: &'a [u64], _dest: i32) -> Self::Request<'a> {
         match self {
             UniverseComm::NoComm(_comm) => AnyRequest::None(PhantomData),
             #[cfg(feature = "mpi")]
             UniverseComm::Mpi(comm) => {
                 // Nonblocking send of u64 via raw MPI
                 let mut req: mpi::ffi::MPI_Request = unsafe { std::mem::zeroed() };
-                let count = buf.len() as i32;
-                let dest_rank = dest as i32;
+                let count = _buf.len() as i32;
+                let dest_rank = _dest as i32;
                 let comm_raw = mpi::raw::AsRaw::as_raw(&comm.world);
                 let rc = unsafe {
                     mpi::ffi::MPI_Isend(
-                        buf.as_ptr() as *const std::ffi::c_void,
+                        _buf.as_ptr() as *const std::ffi::c_void,
                         count,
                         mpi::ffi::RSMPI_UINT64_T,
                         dest_rank,

--- a/src/parallel/threads.rs
+++ b/src/parallel/threads.rs
@@ -27,6 +27,7 @@
 //!
 //! // Under MPI (e.g., 4 ranks), each rank gets floor(32/4) = 8 threads.
 //! ```
+#[cfg(feature = "rayon")]
 use std::sync::OnceLock;
 
 #[cfg(feature = "rayon")]
@@ -45,6 +46,7 @@ pub fn env_usize(key: &str, default: usize) -> usize {
 }
 
 /// One-time computed number of Rayon worker threads we actually use.
+#[cfg(feature = "rayon")]
 static EFFECTIVE_THREADS: OnceLock<usize> = OnceLock::new();
 
 /// Decide and initialize the global Rayon thread pool exactly once.

--- a/src/utils/coloring.rs
+++ b/src/utils/coloring.rs
@@ -9,10 +9,10 @@ where
     F: Fn(usize, usize) -> bool,
 {
     let mut adj = vec![Vec::new(); n];
-    for i in 0..n {
+    for (i, row) in adj.iter_mut().enumerate() {
         for j in 0..n {
             if i != j && (is_nz(i, j) || is_nz(j, i)) {
-                adj[i].push(j);
+                row.push(j);
             }
         }
     }
@@ -23,8 +23,8 @@ where
 pub fn distance2_neighbors(adj: &[Vec<usize>]) -> Vec<HashSet<usize>> {
     let n = adj.len();
     let mut dist2 = vec![HashSet::new(); n];
-    for i in 0..n {
-        for &j in &adj[i] {
+    for (i, neighbors) in adj.iter().enumerate() {
+        for &j in neighbors {
             dist2[i].insert(j);
             for &k in &adj[j] {
                 dist2[i].insert(k);
@@ -39,9 +39,9 @@ pub fn distance2_neighbors(adj: &[Vec<usize>]) -> Vec<HashSet<usize>> {
 pub fn greedy_distance2_coloring(dist2: &[HashSet<usize>]) -> Vec<usize> {
     let n = dist2.len();
     let mut color_of = vec![None; n];
-    for i in 0..n {
+    for (i, neighbors) in dist2.iter().enumerate() {
         let mut banned = HashSet::new();
-        for &k in &dist2[i] {
+        for &k in neighbors {
             if let Some(c) = color_of[k] {
                 banned.insert(c);
             }

--- a/src/utils/monitor.rs
+++ b/src/utils/monitor.rs
@@ -195,11 +195,11 @@ impl IterationMonitor {
             let rate_str = iter_data
                 .convergence_rate
                 .map(|r| format!("{:.6e}", r))
-                .unwrap_or_else(|| "".to_string());
+                .unwrap_or_default();
             let pc_time_str = iter_data
                 .pc_time
                 .map(|t| format!("{:.3}", t.as_secs_f64() * 1000.0))
-                .unwrap_or_else(|| "".to_string());
+                .unwrap_or_default();
 
             // Elapsed since solve start; default to 0.0s if not started
             let elapsed_s = self

--- a/src/utils/partition.rs
+++ b/src/utils/partition.rs
@@ -4,10 +4,10 @@
 /// Each part gets roughly `ceil(n / nparts)` rows.
 pub fn contiguous_partition(n: usize, nparts: usize) -> Vec<usize> {
     let p = nparts.max(1);
-    let chunk = (n + p - 1) / p;
+    let chunk = n.div_ceil(p);
     let mut owner_of = vec![0usize; n];
-    for i in 0..n {
-        owner_of[i] = (i / chunk).min(p - 1);
+    for (i, owner) in owner_of.iter_mut().enumerate() {
+        *owner = (i / chunk).min(p - 1);
     }
     owner_of
 }
@@ -20,14 +20,14 @@ pub fn greedy_nnz_balanced_partition(n: usize, nparts: usize, nnz_per_row: Optio
     let p = nparts.max(1);
     let mut owner_of = vec![0usize; n];
     let mut loads = vec![0usize; p];
-    for i in 0..n {
+    for (i, owner) in owner_of.iter_mut().enumerate() {
         let pid = loads
             .iter()
             .enumerate()
             .min_by_key(|(_, v)| **v)
             .map(|(i, _)| i)
             .unwrap();
-        owner_of[i] = pid;
+        *owner = pid;
         loads[pid] += nnz[i];
     }
     owner_of

--- a/tests/dist_csr.rs
+++ b/tests/dist_csr.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "mpi")]
 use std::sync::Arc;
 
 use kryst::LinOp;

--- a/tests/spmv_kernels.rs
+++ b/tests/spmv_kernels.rs
@@ -1,7 +1,5 @@
+#[cfg(feature = "rayon")]
 use kryst::matrix::{spmv, CsrMatrix};
-use kryst::matrix::format::AsFormat;
-use kryst::matrix::sparse::SparseMatrix;
-use kryst::LinOp;
 
 #[cfg(feature = "rayon")]
 #[test]


### PR DESCRIPTION
## Summary
- scope rayon-specific helpers and imports to limit unused code
- clean up logging and monitor utilities
- simplify partitioning and coloring helpers

## Testing
- `cargo clippy --no-default-features --features logging`
- `cargo check --no-default-features --features logging --tests`
- `cargo test --no-default-features --features logging --tests`

------
https://chatgpt.com/codex/tasks/task_e_68b602712df88329a96db687c7cff05b