### PR TITLE
pcg: add nonzero guess option and clarify natural norm

### DIFF
--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -3,8 +3,8 @@ use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::parallel::{Comm, UniverseComm};
 use crate::preconditioner::{PcSide, Preconditioner};
-use crate::solver::LinearSolver;
 use crate::solver::common::recompute_true_residual_norm;
+use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 use std::any::Any;
 
@@ -25,11 +25,28 @@ pub struct PcgSolver {
     pub(crate) conv: Convergence<f64>,
     norm_type: CgNormType,
     single_reduction: bool,
+    /// Whether the initial guess in `x` should be treated as nonzero.
+    ///
+    /// PETSc zeroes the initial guess by default unless told otherwise via
+    /// `KSPSetInitialGuessNonzero`. We follow the same policy; when this flag is
+    /// `false` and the provided `x` is numerically zero, the solver skips the
+    /// initial matvec and assumes a zero guess.
+    initial_guess_nonzero: bool,
 }
 
 impl PcgSolver {
     pub fn new(rtol: f64, maxits: usize) -> Self {
-        Self { conv: Convergence { rtol, atol: 1e-50, dtol: 1e5, max_iters: maxits }, norm_type: CgNormType::Preconditioned, single_reduction: false }
+        Self {
+            conv: Convergence {
+                rtol,
+                atol: 1e-50,
+                dtol: 1e5,
+                max_iters: maxits,
+            },
+            norm_type: CgNormType::Preconditioned,
+            single_reduction: false,
+            initial_guess_nonzero: false,
+        }
     }
 
     /// Optional runtime update of solver tolerances
@@ -48,6 +65,21 @@ impl PcgSolver {
     pub fn with_single_reduction(mut self, f: bool) -> Self {
         self.single_reduction = f;
         self
+    }
+
+    /// Indicate whether the supplied initial guess is nonzero.
+    ///
+    /// By default `x` is assumed to be zero, which avoids an extra matvec on
+    /// entry. Calling this with `true` forces the solver to compute the initial
+    /// residual `b - A x` even if `x` happens to be the zero vector.
+    pub fn with_nonzero_guess(mut self, f: bool) -> Self {
+        self.initial_guess_nonzero = f;
+        self
+    }
+
+    /// Set the nonzero initial guess flag after construction.
+    pub fn set_nonzero_guess(&mut self, f: bool) {
+        self.initial_guess_nonzero = f;
     }
 
     #[inline]
@@ -153,7 +185,7 @@ impl PcgSolver {
         }
 
         // r = b - A x
-        let zero_guess = x.iter().all(|&xi| xi == 0.0);
+        let zero_guess = !self.initial_guess_nonzero && x.iter().all(|&xi| xi == 0.0);
         if zero_guess {
             r.copy_from_slice(b);
         } else {
@@ -178,9 +210,8 @@ impl PcgSolver {
         let mut has_pending_rz = false;
 
         let mut res = match self.norm_type {
-            CgNormType::Preconditioned => rho.sqrt(),
+            CgNormType::Preconditioned | CgNormType::Natural => rho.sqrt(),
             CgNormType::Unpreconditioned => Self::nrm2(r, comm),
-            CgNormType::Natural => rho,
             CgNormType::None => 0.0,
         };
 
@@ -201,7 +232,11 @@ impl PcgSolver {
         if !matches!(reason0, ConvergedReason::Continued) {
             let mut tmp = vec![0.0; n];
             let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
-            return Ok(SolveStats { iterations: 0, final_residual: true_res, reason: s0.reason });
+            return Ok(SolveStats {
+                iterations: 0,
+                final_residual: true_res,
+                reason: s0.reason,
+            });
         }
 
         let mut iters = 0usize;
@@ -237,7 +272,11 @@ impl PcgSolver {
                 if pw <= 0.0 || !pw.is_finite() {
                     let mut tmp = vec![0.0; n];
                     let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
-                    return Ok(SolveStats { iterations: k - 1, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
+                    return Ok(SolveStats {
+                        iterations: k - 1,
+                        final_residual: true_res,
+                        reason: ConvergedReason::DivergedDtol,
+                    });
                 }
 
                 let alpha = rho_k / pw;
@@ -256,15 +295,18 @@ impl PcgSolver {
                 if rz_local_next < 0.0 || !rz_local_next.is_finite() {
                     let mut tmp = vec![0.0; n];
                     let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
-                    return Ok(SolveStats { iterations: k, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
+                    return Ok(SolveStats {
+                        iterations: k,
+                        final_residual: true_res,
+                        reason: ConvergedReason::DivergedDtol,
+                    });
                 }
                 pending_rz_local = rz_local_next;
                 has_pending_rz = true;
 
                 res = match self.norm_type {
-                    CgNormType::Preconditioned => rho_k.sqrt(),
+                    CgNormType::Preconditioned | CgNormType::Natural => rho_k.sqrt(),
                     CgNormType::Unpreconditioned => Self::nrm2(r, comm),
-                    CgNormType::Natural => rho_k,
                     CgNormType::None => res,
                 };
 
@@ -283,7 +325,11 @@ impl PcgSolver {
                     let mut tmp = vec![0.0; n];
                     let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
                     s.final_residual = true_res;
-                    return Ok(SolveStats { iterations: k, final_residual: s.final_residual, reason: s.reason });
+                    return Ok(SolveStats {
+                        iterations: k,
+                        final_residual: s.final_residual,
+                        reason: s.reason,
+                    });
                 }
 
                 z_prev.swap_with_slice(z);
@@ -294,7 +340,11 @@ impl PcgSolver {
                 if pw <= 0.0 || !pw.is_finite() {
                     let mut tmp = vec![0.0; n];
                     let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
-                    return Ok(SolveStats { iterations: k - 1, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
+                    return Ok(SolveStats {
+                        iterations: k - 1,
+                        final_residual: true_res,
+                        reason: ConvergedReason::DivergedDtol,
+                    });
                 }
 
                 let alpha = rho / pw;
@@ -313,13 +363,16 @@ impl PcgSolver {
                 if rho_new < 0.0 || !rho_new.is_finite() {
                     let mut tmp = vec![0.0; n];
                     let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
-                    return Ok(SolveStats { iterations: k, final_residual: true_res, reason: ConvergedReason::DivergedDtol });
+                    return Ok(SolveStats {
+                        iterations: k,
+                        final_residual: true_res,
+                        reason: ConvergedReason::DivergedDtol,
+                    });
                 }
 
                 res = match self.norm_type {
-                    CgNormType::Preconditioned => rho_new.sqrt(),
+                    CgNormType::Preconditioned | CgNormType::Natural => rho_new.sqrt(),
                     CgNormType::Unpreconditioned => Self::nrm2(r, comm),
-                    CgNormType::Natural => rho_new,
                     CgNormType::None => res,
                 };
 
@@ -338,7 +391,11 @@ impl PcgSolver {
                     let mut tmp = vec![0.0; n];
                     let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
                     s.final_residual = true_res;
-                    return Ok(SolveStats { iterations: k, final_residual: s.final_residual, reason: s.reason });
+                    return Ok(SolveStats {
+                        iterations: k,
+                        final_residual: s.final_residual,
+                        reason: s.reason,
+                    });
                 }
 
                 let beta = rho_new / rho;
@@ -352,7 +409,11 @@ impl PcgSolver {
 
         let mut tmp = vec![0.0; n];
         let true_res = recompute_true_residual_norm(a, b, x, comm, &mut tmp);
-        Ok(SolveStats { iterations: iters, final_residual: true_res, reason: ConvergedReason::DivergedMaxIts })
+        Ok(SolveStats {
+            iterations: iters,
+            final_residual: true_res,
+            reason: ConvergedReason::DivergedMaxIts,
+        })
     }
 }
 

--- a/tests/pcg_norm_types.rs
+++ b/tests/pcg_norm_types.rs
@@ -1,0 +1,67 @@
+use faer::Mat;
+use kryst::parallel::UniverseComm;
+use kryst::preconditioner::PcSide;
+use kryst::solver::pcg::CgNormType;
+use kryst::solver::{LinearSolver, PcgSolver};
+use std::sync::{Arc, Mutex};
+
+#[test]
+fn natural_norm_matches_preconditioned() {
+    let comm = UniverseComm::NoComm(kryst::parallel::NoComm);
+    // Simple SPD 2x2 system
+    let mut a = Mat::<f64>::zeros(2, 2);
+    a[(0, 0)] = 4.0;
+    a[(0, 1)] = 1.0;
+    a[(1, 0)] = 1.0;
+    a[(1, 1)] = 3.0;
+    let b = [1.0, 2.0];
+    let mut x1 = [0.0, 0.0];
+    let mut x2 = [0.0, 0.0];
+
+    // Preconditioned norm (default)
+    let mut solver_pre = PcgSolver::new(1e-8, 10);
+    let hist_pre = Arc::new(Mutex::new(Vec::new()));
+    let m_pre = {
+        let hist = hist_pre.clone();
+        Box::new(move |i: usize, r: f64| hist.lock().unwrap().push((i, r)))
+    };
+    let _stats_pre = solver_pre
+        .solve(
+            &a,
+            None,
+            &b,
+            &mut x1,
+            PcSide::Left,
+            &comm,
+            Some(&[m_pre]),
+            None,
+        )
+        .unwrap();
+
+    // Natural norm
+    let mut solver_nat = PcgSolver::new(1e-8, 10).with_norm(CgNormType::Natural);
+    let hist_nat = Arc::new(Mutex::new(Vec::new()));
+    let m_nat = {
+        let hist = hist_nat.clone();
+        Box::new(move |i: usize, r: f64| hist.lock().unwrap().push((i, r)))
+    };
+    let _stats_nat = solver_nat
+        .solve(
+            &a,
+            None,
+            &b,
+            &mut x2,
+            PcSide::Left,
+            &comm,
+            Some(&[m_nat]),
+            None,
+        )
+        .unwrap();
+
+    let h_pre = hist_pre.lock().unwrap();
+    let h_nat = hist_nat.lock().unwrap();
+    assert_eq!(h_pre.len(), h_nat.len());
+    for (a, b) in h_pre.iter().zip(h_nat.iter()) {
+        assert!((a.1 - b.1).abs() < 1e-12);
+    }
+}


### PR DESCRIPTION
## Summary
- add `with_nonzero_guess` / `set_nonzero_guess` to control whether the initial guess is assumed zero
- align `CgNormType::Natural` with preconditioned residual semantics and add regression test

## Testing
- `cargo test natural_norm_matches_preconditioned --test pcg_norm_types -- --nocapture`
- `cargo test` *(failed: hung, interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b6132733b4832986b8699c7bd3af30