### PR TITLE
Align PCG natural norm with PETSc semantics

### DIFF
--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -112,6 +112,9 @@ pub trait Preconditioner: Send + Sync {
     fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError>;
 
     /// Apply M⁻¹ to input vector, writing result to output slice.
+    ///
+    /// When used with CG and [`PcSide::Left`], this operation must represent an
+    /// SPD preconditioner `M` so that `rᵀ M⁻¹ r > 0` holds.
     fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError>;
 
     /// Mutable application (flexible/nonlinear preconditioners).

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -14,8 +14,8 @@ pub enum CgNormType {
     Preconditioned,
     /// Monitor the unpreconditioned residual `||r||₂`
     Unpreconditioned,
-    /// Monitor the natural norm induced by the operator (also `sqrt(rᵀz)` for
-    /// SPD systems). Included for compatibility with PETSc semantics.
+    /// Monitor the "natural" norm of the preconditioned residual vector
+    /// `||z||₂`, matching PETSc's `-ksp_norm_type natural` semantics.
     Natural,
     /// Do not compute or report a residual norm
     None,
@@ -210,8 +210,9 @@ impl PcgSolver {
         let mut has_pending_rz = false;
 
         let mut res = match self.norm_type {
-            CgNormType::Preconditioned | CgNormType::Natural => rho.sqrt(),
+            CgNormType::Preconditioned => rho.sqrt(),
             CgNormType::Unpreconditioned => Self::nrm2(r, comm),
+            CgNormType::Natural => Self::nrm2(z, comm),
             CgNormType::None => 0.0,
         };
 
@@ -225,8 +226,10 @@ impl PcgSolver {
 
         // Convergence check at k=0
         let res_check0 = match self.norm_type {
-            CgNormType::Preconditioned | CgNormType::Natural => rho.sqrt(),
-            CgNormType::Unpreconditioned | CgNormType::None => Self::nrm2(r, comm),
+            CgNormType::Preconditioned => rho.sqrt(),
+            CgNormType::Unpreconditioned => Self::nrm2(r, comm),
+            CgNormType::Natural => Self::nrm2(z, comm),
+            CgNormType::None => Self::nrm2(r, comm),
         };
         let (reason0, s0) = self.conv.check(res_check0, bnorm, 0);
         if !matches!(reason0, ConvergedReason::Continued) {
@@ -305,8 +308,9 @@ impl PcgSolver {
                 has_pending_rz = true;
 
                 res = match self.norm_type {
-                    CgNormType::Preconditioned | CgNormType::Natural => rho_k.sqrt(),
+                    CgNormType::Preconditioned => rho_k.sqrt(),
                     CgNormType::Unpreconditioned => Self::nrm2(r, comm),
+                    CgNormType::Natural => Self::nrm2(z, comm),
                     CgNormType::None => res,
                 };
 
@@ -317,8 +321,10 @@ impl PcgSolver {
                 }
 
                 let res_check = match self.norm_type {
-                    CgNormType::Preconditioned | CgNormType::Natural => rho_k.sqrt(),
-                    CgNormType::Unpreconditioned | CgNormType::None => Self::nrm2(r, comm),
+                    CgNormType::Preconditioned => rho_k.sqrt(),
+                    CgNormType::Unpreconditioned => Self::nrm2(r, comm),
+                    CgNormType::Natural => Self::nrm2(z, comm),
+                    CgNormType::None => Self::nrm2(r, comm),
                 };
                 let (reason, mut s) = self.conv.check(res_check, bnorm, k);
                 if !matches!(reason, ConvergedReason::Continued) {
@@ -371,8 +377,9 @@ impl PcgSolver {
                 }
 
                 res = match self.norm_type {
-                    CgNormType::Preconditioned | CgNormType::Natural => rho_new.sqrt(),
+                    CgNormType::Preconditioned => rho_new.sqrt(),
                     CgNormType::Unpreconditioned => Self::nrm2(r, comm),
+                    CgNormType::Natural => Self::nrm2(z, comm),
                     CgNormType::None => res,
                 };
 
@@ -383,8 +390,10 @@ impl PcgSolver {
                 }
 
                 let res_check = match self.norm_type {
-                    CgNormType::Preconditioned | CgNormType::Natural => rho_new.sqrt(),
-                    CgNormType::Unpreconditioned | CgNormType::None => Self::nrm2(r, comm),
+                    CgNormType::Preconditioned => rho_new.sqrt(),
+                    CgNormType::Unpreconditioned => Self::nrm2(r, comm),
+                    CgNormType::Natural => Self::nrm2(z, comm),
+                    CgNormType::None => Self::nrm2(r, comm),
                 };
                 let (reason, mut s) = self.conv.check(res_check, bnorm, k);
                 if !matches!(reason, ConvergedReason::Continued) {

--- a/tests/pcg_norm_types.rs
+++ b/tests/pcg_norm_types.rs
@@ -1,67 +1,64 @@
 use faer::Mat;
-use kryst::parallel::UniverseComm;
-use kryst::preconditioner::PcSide;
+use kryst::context::ksp_context::Workspace;
+use kryst::error::KError;
+use kryst::parallel::{NoComm, UniverseComm};
+use kryst::preconditioner::{PcSide, Preconditioner};
 use kryst::solver::pcg::CgNormType;
 use kryst::solver::{LinearSolver, PcgSolver};
 use std::sync::{Arc, Mutex};
 
-#[test]
-fn natural_norm_matches_preconditioned() {
-    let comm = UniverseComm::NoComm(kryst::parallel::NoComm);
-    // Simple SPD 2x2 system
-    let mut a = Mat::<f64>::zeros(2, 2);
-    a[(0, 0)] = 4.0;
-    a[(0, 1)] = 1.0;
-    a[(1, 0)] = 1.0;
-    a[(1, 1)] = 3.0;
-    let b = [1.0, 2.0];
-    let mut x1 = [0.0, 0.0];
-    let mut x2 = [0.0, 0.0];
-
-    // Preconditioned norm (default)
-    let mut solver_pre = PcgSolver::new(1e-8, 10);
-    let hist_pre = Arc::new(Mutex::new(Vec::new()));
-    let m_pre = {
-        let hist = hist_pre.clone();
-        Box::new(move |i: usize, r: f64| hist.lock().unwrap().push((i, r)))
-    };
-    let _stats_pre = solver_pre
-        .solve(
-            &a,
-            None,
-            &b,
-            &mut x1,
-            PcSide::Left,
-            &comm,
-            Some(&[m_pre]),
-            None,
-        )
-        .unwrap();
-
-    // Natural norm
-    let mut solver_nat = PcgSolver::new(1e-8, 10).with_norm(CgNormType::Natural);
-    let hist_nat = Arc::new(Mutex::new(Vec::new()));
-    let m_nat = {
-        let hist = hist_nat.clone();
-        Box::new(move |i: usize, r: f64| hist.lock().unwrap().push((i, r)))
-    };
-    let _stats_nat = solver_nat
-        .solve(
-            &a,
-            None,
-            &b,
-            &mut x2,
-            PcSide::Left,
-            &comm,
-            Some(&[m_nat]),
-            None,
-        )
-        .unwrap();
-
-    let h_pre = hist_pre.lock().unwrap();
-    let h_nat = hist_nat.lock().unwrap();
-    assert_eq!(h_pre.len(), h_nat.len());
-    for (a, b) in h_pre.iter().zip(h_nat.iter()) {
-        assert!((a.1 - b.1).abs() < 1e-12);
+struct HalfPc;
+impl Preconditioner for HalfPc {
+    fn setup(&mut self, _a: &dyn kryst::matrix::op::LinOp<S = f64>) -> Result<(), KError> {
+        Ok(())
+    }
+    fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        for (yi, xi) in y.iter_mut().zip(x) {
+            *yi = 0.5 * xi;
+        }
+        Ok(())
     }
 }
+
+fn run(norm: CgNormType, expected: f64) {
+    let a = Mat::<f64>::from_fn(1, 1, |_, _| 1.0);
+    let b = vec![2.0];
+    let mut x = vec![0.0];
+    let mut pc = HalfPc;
+    let comm = UniverseComm::NoComm(NoComm);
+    let mut solver = PcgSolver::new(1e-20, 0).with_norm(norm);
+    let mut wk = Workspace::default();
+    solver.setup_workspace(&mut wk);
+
+    let log = Arc::new(Mutex::new(Vec::new()));
+    {
+        let log_clone = log.clone();
+        let monitor: Box<dyn Fn(usize, f64) + Send + Sync> = Box::new(move |i, r| {
+            if i == 0 {
+                log_clone.lock().unwrap().push(r);
+            }
+        });
+        solver
+            .solve_with_comm(
+                &a,
+                Some(&mut pc),
+                &b,
+                &mut x,
+                PcSide::Left,
+                &comm,
+                Some(&[monitor]),
+                Some(&mut wk),
+            )
+            .unwrap();
+    }
+    let res0 = log.lock().unwrap()[0];
+    assert!((res0 - expected).abs() < 1e-12);
+}
+
+#[test]
+fn pcg_norm_variants() {
+    run(CgNormType::Preconditioned, (2.0_f64).sqrt());
+    run(CgNormType::Unpreconditioned, 2.0);
+    run(CgNormType::Natural, 1.0);
+}
+


### PR DESCRIPTION
## Summary
- treat `CgNormType::Natural` as the preconditioned residual norm `||z||` in PCG
- clarify SPD requirement in `Preconditioner` trait docs
- test PCG residual norm variants

## Testing
- ❌ `cargo fmt --all` *(cargo 1.75 lacks `edition2024` support)*
- ❌ `cargo test` *(cargo 1.75 lacks `edition2024` support)*

------
https://chatgpt.com/codex/tasks/task_e_68b619fa7ba8832993f5e8f43ddae8d9