### PR TITLE
cg: add explicit nonzero initial guess handling

### DIFF
--- a/src/solver/cg.rs
+++ b/src/solver/cg.rs
@@ -38,6 +38,11 @@ pub struct CgSolver {
     single_reduction: bool,
     trust_region: Option<f64>,
     true_residual_monitor: Option<Box<dyn Fn(usize, f64) + Send + Sync>>,
+    /// Whether the supplied initial guess in `x` should be treated as
+    /// nonzero. When `false` (the default) and `x` is numerically the zero
+    /// vector, the solver skips the initial matvec and assumes `x = 0`.
+    /// This mirrors PETSc's `KSPSetInitialGuessNonzero` semantics.
+    initial_guess_nonzero: bool,
 }
 
 impl CgSolver {
@@ -49,6 +54,7 @@ impl CgSolver {
             single_reduction: false,
             trust_region: None,
             true_residual_monitor: None,
+            initial_guess_nonzero: false,
         }
     }
 
@@ -62,6 +68,15 @@ impl CgSolver {
     }
     pub fn with_trust_region(mut self, r: f64) -> Self {
         self.trust_region = Some(r);
+        self
+    }
+    /// Indicate whether the supplied initial guess is nonzero.
+    ///
+    /// By default `x` is assumed to be the zero vector, avoiding an extra
+    /// matvec on entry. Calling this with `true` forces the solver to compute
+    /// the initial residual `b - A x` even if `x` happens to be zero.
+    pub fn with_nonzero_guess(mut self, f: bool) -> Self {
+        self.initial_guess_nonzero = f;
         self
     }
     pub fn with_true_residual_monitor(
@@ -80,6 +95,10 @@ impl CgSolver {
     }
     pub fn set_trust_region(&mut self, r: f64) {
         self.trust_region = Some(r);
+    }
+    /// Set the nonzero initial guess flag after construction.
+    pub fn set_nonzero_guess(&mut self, f: bool) {
+        self.initial_guess_nonzero = f;
     }
     pub fn set_true_residual_monitor(
         &mut self,
@@ -190,7 +209,9 @@ impl CgSolver {
 
         let (r, z, p, ap, tmp) = Self::acquire(n, work);
 
-        if x.iter().any(|&xi| xi != 0.0) {
+        let guess_nonzero =
+            self.initial_guess_nonzero || x.iter().any(|&xi| xi != 0.0);
+        if guess_nonzero {
             a.matvec(x, tmp);
             for i in 0..n {
                 r[i] = b[i] - tmp[i];

--- a/tests/cg_initial_guess.rs
+++ b/tests/cg_initial_guess.rs
@@ -1,0 +1,82 @@
+use kryst::context::ksp_context::Workspace;
+use kryst::matrix::op::LinOp;
+use kryst::parallel::{NoComm, UniverseComm};
+use kryst::preconditioner::PcSide;
+use kryst::solver::{CgSolver, LinearSolver};
+use std::any::Any;
+use std::sync::{
+    Arc,
+    atomic::{AtomicUsize, Ordering},
+};
+
+struct CountingOp {
+    count: Arc<AtomicUsize>,
+}
+impl CountingOp {
+    fn new(count: Arc<AtomicUsize>) -> Self {
+        Self { count }
+    }
+}
+impl LinOp for CountingOp {
+    type S = f64;
+    fn dims(&self) -> (usize, usize) {
+        (2, 2)
+    }
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        self.count.fetch_add(1, Ordering::SeqCst);
+        y[0] = 2.0 * x[0] + x[1];
+        y[1] = x[0] + 2.0 * x[1];
+    }
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+#[test]
+fn cg_respects_nonzero_guess_flag() {
+    let b = vec![1.0, 2.0];
+    let comm = UniverseComm::NoComm(NoComm);
+
+    // Default: zero initial guess skips first matvec
+    let counter = Arc::new(AtomicUsize::new(0));
+    let op = CountingOp::new(counter.clone());
+    let mut x = vec![0.0; 2];
+    let mut solver = CgSolver::new(1e-12, 1);
+    let mut wk = Workspace::default();
+    solver.setup_workspace(&mut wk);
+    solver
+        .solve_with_comm(
+            &op,
+            None,
+            &b,
+            &mut x,
+            PcSide::Left,
+            &comm,
+            None,
+            Some(&mut wk),
+        )
+        .unwrap();
+    let calls_default = counter.load(Ordering::SeqCst);
+
+    // Force nonzero guess: extra matvec to compute initial residual
+    let counter2 = Arc::new(AtomicUsize::new(0));
+    let op2 = CountingOp::new(counter2.clone());
+    let mut x2 = vec![0.0; 2];
+    let mut solver2 = CgSolver::new(1e-12, 1).with_nonzero_guess(true);
+    let mut wk2 = Workspace::default();
+    solver2.setup_workspace(&mut wk2);
+    solver2
+        .solve_with_comm(
+            &op2,
+            None,
+            &b,
+            &mut x2,
+            PcSide::Left,
+            &comm,
+            None,
+            Some(&mut wk2),
+        )
+        .unwrap();
+    let calls_nonzero = counter2.load(Ordering::SeqCst);
+    assert_eq!(calls_nonzero, calls_default + 1);
+}


### PR DESCRIPTION
## Summary
- add `with_nonzero_guess` / `set_nonzero_guess` to `CgSolver`
- skip initial matvec only when solver is told guess is zero
- test that the flag triggers an extra matvec

## Testing
- `cargo test --test cg_initial_guess`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b6297770648329bf8f1bc9eea335dc