### PR TITLE
Add MILU(0) row-sum correction using deferred diagonal updates

### DIFF
--- a/src/preconditioner/builders.rs
+++ b/src/preconditioner/builders.rs
@@ -1,10 +1,10 @@
 use crate::error::KError;
-use crate::preconditioner::{Preconditioner, jacobi::Jacobi, sor::MatSorType};
 #[cfg(feature = "dense-direct")]
 use crate::preconditioner::direct::{LuPc, QrPc};
+use crate::preconditioner::{Preconditioner, jacobi::Jacobi, sor::MatSorType};
 
-use crate::preconditioner::sor::SorPc;
 use crate::preconditioner::chebyshev::ChebyshevPc;
+use crate::preconditioner::sor::SorPc;
 
 #[cfg(feature = "superlu_dist")]
 use crate::preconditioner::direct::SuperLuDistPc;
@@ -49,16 +49,24 @@ pub fn build_chebyshev(
 
 pub fn build_lu() -> Result<Box<dyn Preconditioner>, KError> {
     #[cfg(feature = "dense-direct")]
-    { return Ok(Box::new(LuPc::new())); }
+    {
+        return Ok(Box::new(LuPc::new()));
+    }
     #[cfg(not(feature = "dense-direct"))]
-    { return Err(KError::Unsupported("dense-direct feature not enabled")); }
+    {
+        return Err(KError::Unsupported("dense-direct feature not enabled"));
+    }
 }
 
 pub fn build_qr() -> Result<Box<dyn Preconditioner>, KError> {
     #[cfg(feature = "dense-direct")]
-    { return Ok(Box::new(QrPc::new())); }
+    {
+        return Ok(Box::new(QrPc::new()));
+    }
     #[cfg(not(feature = "dense-direct"))]
-    { return Err(KError::Unsupported("dense-direct feature not enabled")); }
+    {
+        return Err(KError::Unsupported("dense-direct feature not enabled"));
+    }
 }
 
 pub fn build_superlu_dist() -> Result<Box<dyn Preconditioner>, KError> {
@@ -77,14 +85,14 @@ pub fn build_superlu_dist() -> Result<Box<dyn Preconditioner>, KError> {
 pub fn build_ilu0() -> Result<Box<dyn Preconditioner>, KError> {
     use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
     let cfg = IluCsrConfig {
-            kind: IluKind::Ilu0,
-            pivot: PivotStrategy::DiagonalPerturbation,
-            pivot_threshold: 1e-12,
-            diag_perturb_factor: 1e-10,
-            level_sched: cfg!(feature = "rayon"),
-            numeric_update_fixed: true,
-            logging: 0,
-        };
+        kind: IluKind::Ilu0,
+        pivot: PivotStrategy::DiagonalPerturbation,
+        pivot_threshold: 1e-12,
+        diag_perturb_factor: 1e-10,
+        level_sched: cfg!(feature = "rayon"),
+        numeric_update_fixed: true,
+        logging: 0,
+    };
     let pc = IluCsr::new_with_config(cfg);
     Ok(Box::new(pc))
 }
@@ -110,7 +118,10 @@ pub fn build_ilut(
 ) -> Result<Box<dyn Preconditioner>, KError> {
     use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
     let cfg = IluCsrConfig {
-        kind: IluKind::Ilut { drop_tol, max_per_row: max_fill },
+        kind: IluKind::Ilut {
+            drop_tol,
+            max_per_row: max_fill,
+        },
         pivot: PivotStrategy::DiagonalPerturbation,
         pivot_threshold: 1e-12,
         diag_perturb_factor: 1e-10,
@@ -123,7 +134,17 @@ pub fn build_ilut(
 }
 
 pub fn build_milu0() -> Result<Box<dyn Preconditioner>, KError> {
-    build_ilu0()
+    use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
+    let cfg = IluCsrConfig {
+        kind: IluKind::Milu0,
+        pivot: PivotStrategy::DiagonalPerturbation,
+        pivot_threshold: 1e-12,
+        diag_perturb_factor: 1e-10,
+        level_sched: cfg!(feature = "rayon"),
+        numeric_update_fixed: true,
+        logging: 0,
+    };
+    Ok(Box::new(IluCsr::new_with_config(cfg)))
 }
 
 // ---- ASM / AMG stubs -----------------------------------------------------
@@ -145,14 +166,19 @@ pub fn build_asm(
     };
 
     // Construct ASM with empty subdomains (will be partitioned on setup).
-    let mut asm = AdditiveSchwarz::<faer::Mat<f64>, Vec<f64>, f64>::new(overlap, Vec::new(), factory);
+    let mut asm =
+        AdditiveSchwarz::<faer::Mat<f64>, Vec<f64>, f64>::new(overlap, Vec::new(), factory);
 
     // Mode
     if let Some(m) = mode.as_deref() {
         let m = match m {
             "asm" => AsmMode::ASM,
             "ras" => AsmMode::RAS,
-            other => return Err(KError::InvalidInput(format!("unknown pc_asm_mode: {other}"))),
+            other => {
+                return Err(KError::InvalidInput(format!(
+                    "unknown pc_asm_mode: {other}"
+                )));
+            }
         };
         asm.set_mode(m);
     }
@@ -165,11 +191,19 @@ pub fn build_asm(
             "linear" => Weighting::SmoothLinear,
             s if s.starts_with("poly:") => {
                 let pstr = &s[5..];
-                let p: u32 = pstr.parse().map_err(|_| KError::InvalidInput(format!("invalid poly exponent in pc_asm_weighting: {s}")))?;
-                if p < 2 { return Err(KError::InvalidInput("poly exponent must be >= 2".into())); }
+                let p: u32 = pstr.parse().map_err(|_| {
+                    KError::InvalidInput(format!("invalid poly exponent in pc_asm_weighting: {s}"))
+                })?;
+                if p < 2 {
+                    return Err(KError::InvalidInput("poly exponent must be >= 2".into()));
+                }
                 Weighting::SmoothPoly(p)
             }
-            other => return Err(KError::InvalidInput(format!("unknown pc_asm_weighting: {other}"))),
+            other => {
+                return Err(KError::InvalidInput(format!(
+                    "unknown pc_asm_weighting: {other}"
+                )));
+            }
         };
         asm.set_weighting(w);
     }

--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -16,6 +16,7 @@ pub use pivot::PivotStrategy;
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum IluKind {
     Ilu0,
+    Milu0,
     Iluk { k: usize },
     Ilut { drop_tol: f64, max_per_row: usize },
 }
@@ -63,6 +64,8 @@ pub struct IluCsr {
     u_col: Vec<usize>,
     u_val: Vec<f64>,
     u_diag_ix: Vec<usize>,
+    // Accumulated MILU(0) diagonal corrections per row
+    delta_diag: Vec<f64>,
     // Optional per-entry levels for ILUK
     l_lev: Vec<usize>,
     u_lev: Vec<usize>,
@@ -91,6 +94,7 @@ impl IluCsr {
             u_col: Vec::new(),
             u_val: Vec::new(),
             u_diag_ix: Vec::new(),
+            delta_diag: Vec::new(),
             l_lev: Vec::new(),
             u_lev: Vec::new(),
             levels_fwd: Vec::new(),
@@ -166,15 +170,18 @@ impl IluCsr {
 
     fn factor_symbolic_and_numeric(&mut self, a: &CsrMatrix<f64>) -> Result<(), KError> {
         match self.cfg.kind {
-            IluKind::Ilu0 => self.factor_ilu0(a),
+            IluKind::Ilu0 | IluKind::Milu0 => self.factor_ilu0(a),
             IluKind::Iluk { k } => self.factor_iluk(a, k),
-            IluKind::Ilut { drop_tol, max_per_row } => self.factor_ilut(a, drop_tol, max_per_row),
+            IluKind::Ilut {
+                drop_tol,
+                max_per_row,
+            } => self.factor_ilut(a, drop_tol, max_per_row),
         }
     }
 
     fn factor_numeric_only(&mut self, a: &CsrMatrix<f64>) -> Result<(), KError> {
         match self.cfg.kind {
-            IluKind::Ilu0 => self.factor_ilu0_numeric_only(a),
+            IluKind::Ilu0 | IluKind::Milu0 => self.factor_ilu0_numeric_only(a),
             IluKind::Iluk { k } => self.factor_iluk_numeric_only(a, k),
             IluKind::Ilut { .. } => self.factor_ilut_numeric_only(a),
         }
@@ -249,9 +256,12 @@ impl IluCsr {
         // not used in ILU0
         self.l_lev.resize(self.l_col.len(), 0);
         self.u_lev.resize(self.u_col.len(), 0);
+        // Prepare MILU(0) correction storage
+        self.delta_diag.resize(n, 0.0);
 
         // Numeric factorization using work row over A's pattern only (no fill added).
-        self.ilu0_numeric(a)
+        let milu = matches!(self.cfg.kind, IluKind::Milu0);
+        self.ilu0_numeric(a, milu)
     }
 
     fn factor_ilu0_numeric_only(&mut self, a: &CsrMatrix<f64>) -> Result<(), KError> {
@@ -259,20 +269,29 @@ impl IluCsr {
             return self.factor_ilu0(a);
         }
         if self.n != a.nrows() || a.nrows() != a.ncols() {
-            return Err(KError::InvalidInput("ILU0 numeric update: size/shape mismatch".into()));
+            return Err(KError::InvalidInput(
+                "ILU0 numeric update: size/shape mismatch".into(),
+            ));
         }
+        // Prepare MILU(0) correction storage
+        self.delta_diag.resize(self.n, 0.0);
         // Keep pattern intact; just recompute numeric values.
-        self.ilu0_numeric(a)
+        let milu = matches!(self.cfg.kind, IluKind::Milu0);
+        self.ilu0_numeric(a, milu)
     }
 
-    fn ilu0_numeric(&mut self, a: &CsrMatrix<f64>) -> Result<(), KError> {
+    fn ilu0_numeric(&mut self, a: &CsrMatrix<f64>, milu: bool) -> Result<(), KError> {
         use symbolic::RowWork;
         let n = self.n;
         let rp = a.row_ptr();
         let cj = a.col_idx();
         let vv = a.values();
 
-        let mut w = RowWork { mark: Vec::new(), idx: Vec::new(), val: Vec::new() };
+        let mut w = RowWork {
+            mark: Vec::new(),
+            idx: Vec::new(),
+            val: Vec::new(),
+        };
         symbolic::ensure_rowwork(&mut w, n);
 
         // Precompute max |A_ii| for pivot handling
@@ -280,7 +299,10 @@ impl IluCsr {
         for i in 0..n {
             let mut di = 0.0;
             for p in rp[i]..rp[i + 1] {
-                if cj[p] == i { di = vv[p]; break; }
+                if cj[p] == i {
+                    di = vv[p];
+                    break;
+                }
             }
             max_diag_abs = max_diag_abs.max(di.abs());
         }
@@ -293,6 +315,10 @@ impl IluCsr {
                 let pos = symbolic::find_or_insert(&mut w, j);
                 w.val[pos] = vv[p];
             }
+            // Ensure diagonal slot exists and commit any prior MILU correction
+            let diag_pos = symbolic::find_or_insert(&mut w, i);
+            w.val[diag_pos] += self.delta_diag[i];
+            self.delta_diag[i] = 0.0;
 
             // Eliminate against previously computed rows, restricted to L pattern of row i
             let ls = self.l_row[i];
@@ -300,7 +326,11 @@ impl IluCsr {
             for pos in ls..le {
                 let j = self.l_col[pos];
                 // work value at column j (0 if not present)
-                let lij_num = if w.mark[j] >= 0 { w.val[w.mark[j] as usize] } else { 0.0 };
+                let lij_num = if w.mark[j] >= 0 {
+                    w.val[w.mark[j] as usize]
+                } else {
+                    0.0
+                };
                 if lij_num == 0.0 {
                     self.l_val[pos] = 0.0;
                     continue;
@@ -309,7 +339,10 @@ impl IluCsr {
                 let djj = self.u_val[self.u_diag_ix[j]];
                 if djj == 0.0 {
                     // row j diagonal not yet set means j<i and we should have a pivot; if 0.0, treat as error
-                    return Err(KError::FactorError(format!("zero U(j,j) encountered at row {}", j)));
+                    return Err(KError::FactorError(format!(
+                        "zero U(j,j) encountered at row {}",
+                        j
+                    )));
                 }
                 let lij = lij_num / djj;
                 self.l_val[pos] = lij;
@@ -319,14 +352,23 @@ impl IluCsr {
                 let ure = self.u_row[j + 1];
                 for q in urs..ure {
                     let kcol = self.u_col[q];
-                    if kcol <= j { continue; }
+                    if kcol <= j {
+                        continue;
+                    }
                     let mk = w.mark.get(kcol).copied().unwrap_or(-1);
                     if mk >= 0 {
                         let idx = mk as usize;
                         w.val[idx] -= lij * self.u_val[q];
+                    } else if milu {
+                        self.delta_diag[i] -= lij * self.u_val[q];
                     }
                 }
             }
+
+            // Commit any dropped fill to the diagonal before finalizing
+            let diag_pos2 = w.mark[i] as usize;
+            w.val[diag_pos2] += self.delta_diag[i];
+            self.delta_diag[i] = 0.0;
 
             // Finalize U row: copy from work for pattern k >= i (zeros if absent)
             let us = self.u_row[i];
@@ -336,8 +378,12 @@ impl IluCsr {
                 let k = self.u_col[q];
                 let v = if w.mark.get(k).copied().unwrap_or(-1) >= 0 {
                     w.val[w.mark[k] as usize]
-                } else { 0.0 };
-                if k == i { diag_val = v; }
+                } else {
+                    0.0
+                };
+                if k == i {
+                    diag_val = v;
+                }
                 self.u_val[q] = v;
             }
 
@@ -348,7 +394,8 @@ impl IluCsr {
                 self.cfg.pivot_threshold,
                 self.cfg.diag_perturb_factor,
                 max_diag_abs,
-            ).map_err(|_| KError::ZeroPivot(i))?;
+            )
+            .map_err(|_| KError::ZeroPivot(i))?;
 
             let dix = self.u_diag_ix[i];
             self.u_val[dix] = fixed;
@@ -369,10 +416,14 @@ impl IluCsr {
         self.n = n;
 
         // Initialize CSR row pointers to 0; we’ll build per-row then append.
-        self.l_row.clear(); self.u_row.clear();
-        self.l_col.clear(); self.u_col.clear();
-        self.l_val.clear(); self.u_val.clear();
-        self.l_lev.clear(); self.u_lev.clear();
+        self.l_row.clear();
+        self.u_row.clear();
+        self.l_col.clear();
+        self.u_col.clear();
+        self.l_val.clear();
+        self.u_val.clear();
+        self.l_lev.clear();
+        self.u_lev.clear();
         self.u_diag_ix.clear();
         self.l_row.resize(n + 1, 0);
         self.u_row.resize(n + 1, 0);
@@ -382,7 +433,11 @@ impl IluCsr {
         let rp = a.row_ptr();
         let cj = a.col_idx();
         let vv = a.values();
-        let mut w = RowWork { mark: Vec::new(), idx: Vec::new(), val: Vec::new() };
+        let mut w = RowWork {
+            mark: Vec::new(),
+            idx: Vec::new(),
+            val: Vec::new(),
+        };
         let mut wlev: Vec<usize> = Vec::new();
         symbolic::ensure_rowwork(&mut w, n);
 
@@ -390,7 +445,12 @@ impl IluCsr {
         let mut max_diag_abs = 0.0f64;
         for i in 0..n {
             let mut di = 0.0;
-            for p in rp[i]..rp[i + 1] { if cj[p] == i { di = vv[p]; break; } }
+            for p in rp[i]..rp[i + 1] {
+                if cj[p] == i {
+                    di = vv[p];
+                    break;
+                }
+            }
             max_diag_abs = max_diag_abs.max(di.abs());
         }
 
@@ -401,12 +461,19 @@ impl IluCsr {
             for p in rp[i]..rp[i + 1] {
                 let j = cj[p];
                 let pos = symbolic::find_or_insert(&mut w, j);
-                if pos == wlev.len() { wlev.push(0); } else { wlev[pos] = 0; }
+                if pos == wlev.len() {
+                    wlev.push(0);
+                } else {
+                    wlev[pos] = 0;
+                }
                 w.val[pos] = vv[p];
             }
 
             // Create sorted list of lower columns present
-            let mut lowers: Vec<(usize, usize)> = w.idx.iter().enumerate()
+            let mut lowers: Vec<(usize, usize)> = w
+                .idx
+                .iter()
+                .enumerate()
                 .filter_map(|(pos, &col)| if col < i { Some((col, pos)) } else { None })
                 .collect();
             lowers.sort_by_key(|x| x.0);
@@ -415,15 +482,23 @@ impl IluCsr {
             for &(j, pos) in &lowers {
                 let lij_level = wlev[pos];
                 // If level exceeds k, skip elimination for this j
-                if lij_level > k_limit { continue; }
+                if lij_level > k_limit {
+                    continue;
+                }
                 let wij = w.val[pos];
-                if wij == 0.0 { continue; }
+                if wij == 0.0 {
+                    continue;
+                }
                 let djj = {
                     let dix = self.u_diag_ix.get(j).copied().unwrap_or(0);
                     if j < i && self.u_val.get(dix).copied().unwrap_or(0.0) == 0.0 {
                         // Not yet built; for row 0 there is none — but we will handle when j<i holds
                     }
-                    if j < i { self.u_val[self.u_diag_ix[j]] } else { 1.0 }
+                    if j < i {
+                        self.u_val[self.u_diag_ix[j]]
+                    } else {
+                        1.0
+                    }
                 };
                 let lij = wij / djj;
 
@@ -432,12 +507,20 @@ impl IluCsr {
                 let ure = self.u_row.get(j + 1).copied().unwrap_or(0);
                 for q in urs..ure {
                     let kcol = self.u_col[q];
-                    if kcol <= j { continue; }
+                    if kcol <= j {
+                        continue;
+                    }
                     let new_level = lij_level + self.u_lev[q] + 1;
-                    if new_level > k_limit { continue; }
+                    if new_level > k_limit {
+                        continue;
+                    }
                     let kpos = symbolic::find_or_insert(&mut w, kcol);
-                    if kpos == wlev.len() { wlev.push(new_level); } else {
-                        if new_level < wlev[kpos] { wlev[kpos] = new_level; }
+                    if kpos == wlev.len() {
+                        wlev.push(new_level);
+                    } else {
+                        if new_level < wlev[kpos] {
+                            wlev[kpos] = new_level;
+                        }
                     }
                     w.val[kpos] -= lij * self.u_val[q];
                 }
@@ -446,17 +529,33 @@ impl IluCsr {
 
             // Finalize L and U rows from work row with level <= k
             // Gather L (j<i)
-            let mut l_pairs: Vec<(usize, f64, usize)> = w.idx.iter().enumerate()
-                .filter_map(|(pos, &col)| if col < i && wlev[pos] <= k_limit {
-                    Some((col, w.val[pos], wlev[pos]))
-                } else { None }).collect();
+            let mut l_pairs: Vec<(usize, f64, usize)> = w
+                .idx
+                .iter()
+                .enumerate()
+                .filter_map(|(pos, &col)| {
+                    if col < i && wlev[pos] <= k_limit {
+                        Some((col, w.val[pos], wlev[pos]))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
             l_pairs.sort_by_key(|x| x.0);
 
             // Gather U (k>=i); ensure diagonal exists with some level (0)
-            let mut u_pairs: Vec<(usize, f64, usize)> = w.idx.iter().enumerate()
-                .filter_map(|(pos, &col)| if col >= i && wlev[pos] <= k_limit {
-                    Some((col, w.val[pos], wlev[pos]))
-                } else { None }).collect();
+            let mut u_pairs: Vec<(usize, f64, usize)> = w
+                .idx
+                .iter()
+                .enumerate()
+                .filter_map(|(pos, &col)| {
+                    if col >= i && wlev[pos] <= k_limit {
+                        Some((col, w.val[pos], wlev[pos]))
+                    } else {
+                        None
+                    }
+                })
+                .collect();
             if !u_pairs.iter().any(|(c, _, _)| *c == i) {
                 u_pairs.push((i, 0.0, 0));
             }
@@ -464,12 +563,20 @@ impl IluCsr {
 
             // Write L row
             self.l_row[i + 1] = self.l_row[i] + l_pairs.len();
-            for (c, v, lev) in l_pairs { self.l_col.push(c); self.l_val.push(v); self.l_lev.push(lev); }
+            for (c, v, lev) in l_pairs {
+                self.l_col.push(c);
+                self.l_val.push(v);
+                self.l_lev.push(lev);
+            }
 
             // Write U row and remember diag ix; pivot later after elimination loop
             let u_start = self.u_col.len();
             self.u_row[i + 1] = self.u_row[i] + u_pairs.len();
-            for (c, v, lev) in &u_pairs { self.u_col.push(*c); self.u_val.push(*v); self.u_lev.push(*lev); }
+            for (c, v, lev) in &u_pairs {
+                self.u_col.push(*c);
+                self.u_val.push(*v);
+                self.u_lev.push(*lev);
+            }
             let d_rel = u_pairs.iter().position(|(c, _, _)| *c == i).unwrap();
             self.u_diag_ix[i] = u_start + d_rel;
 
@@ -481,13 +588,22 @@ impl IluCsr {
         self.iluk_numeric_only(a, k_limit, max_diag_abs)
     }
 
-    fn iluk_numeric_only(&mut self, a: &CsrMatrix<f64>, _k_limit: usize, max_diag_abs: f64) -> Result<(), KError> {
+    fn iluk_numeric_only(
+        &mut self,
+        a: &CsrMatrix<f64>,
+        _k_limit: usize,
+        max_diag_abs: f64,
+    ) -> Result<(), KError> {
         use symbolic::RowWork;
         let n = self.n;
         let rp = a.row_ptr();
         let cj = a.col_idx();
         let vv = a.values();
-        let mut w = RowWork { mark: Vec::new(), idx: Vec::new(), val: Vec::new() };
+        let mut w = RowWork {
+            mark: Vec::new(),
+            idx: Vec::new(),
+            val: Vec::new(),
+        };
         symbolic::ensure_rowwork(&mut w, n);
 
         for i in 0..n {
@@ -504,7 +620,11 @@ impl IluCsr {
             let le = self.l_row[i + 1];
             for pos in ls..le {
                 let j = self.l_col[pos];
-                let wij = if w.mark[j] >= 0 { w.val[w.mark[j] as usize] } else { 0.0 };
+                let wij = if w.mark[j] >= 0 {
+                    w.val[w.mark[j] as usize]
+                } else {
+                    0.0
+                };
                 let djj = self.u_val[self.u_diag_ix[j]];
                 let lij = if djj != 0.0 { wij / djj } else { 0.0 };
                 self.l_val[pos] = lij;
@@ -512,9 +632,14 @@ impl IluCsr {
                 let urs = self.u_row[j];
                 let ure = self.u_row[j + 1];
                 for q in urs..ure {
-                    let kcol = self.u_col[q]; if kcol <= j { continue; }
+                    let kcol = self.u_col[q];
+                    if kcol <= j {
+                        continue;
+                    }
                     let mk = w.mark.get(kcol).copied().unwrap_or(-1);
-                    if mk >= 0 { w.val[mk as usize] -= lij * self.u_val[q]; }
+                    if mk >= 0 {
+                        w.val[mk as usize] -= lij * self.u_val[q];
+                    }
                 }
             }
 
@@ -524,8 +649,14 @@ impl IluCsr {
             let mut diag = 0.0;
             for q in us..ue {
                 let k = self.u_col[q];
-                let v = if w.mark.get(k).copied().unwrap_or(-1) >= 0 { w.val[w.mark[k] as usize] } else { 0.0 };
-                if k == i { diag = v; }
+                let v = if w.mark.get(k).copied().unwrap_or(-1) >= 0 {
+                    w.val[w.mark[k] as usize]
+                } else {
+                    0.0
+                };
+                if k == i {
+                    diag = v;
+                }
                 self.u_val[q] = v;
             }
             // pivot
@@ -535,7 +666,8 @@ impl IluCsr {
                 self.cfg.pivot_threshold,
                 self.cfg.diag_perturb_factor,
                 max_diag_abs,
-            ).map_err(|_| KError::ZeroPivot(i))?;
+            )
+            .map_err(|_| KError::ZeroPivot(i))?;
             let dix = self.u_diag_ix[i];
             self.u_val[dix] = fixed;
 
@@ -544,7 +676,11 @@ impl IluCsr {
         Ok(())
     }
 
-    fn factor_iluk_numeric_only(&mut self, a: &CsrMatrix<f64>, k_limit: usize) -> Result<(), KError> {
+    fn factor_iluk_numeric_only(
+        &mut self,
+        a: &CsrMatrix<f64>,
+        k_limit: usize,
+    ) -> Result<(), KError> {
         // Recompute max diag
         let mut max_diag_abs = 0.0f64;
         let rp = a.row_ptr();
@@ -552,22 +688,39 @@ impl IluCsr {
         let vv = a.values();
         for i in 0..self.n {
             let mut di = 0.0;
-            for p in rp[i]..rp[i + 1] { if cj[p] == i { di = vv[p]; break; } }
+            for p in rp[i]..rp[i + 1] {
+                if cj[p] == i {
+                    di = vv[p];
+                    break;
+                }
+            }
             max_diag_abs = max_diag_abs.max(di.abs());
         }
         self.iluk_numeric_only(a, k_limit, max_diag_abs)
     }
 
     // === ILUT(drop_tol, max_per_row) implementation ===
-    fn factor_ilut(&mut self, a: &CsrMatrix<f64>, drop_tol: f64, max_per_row: usize) -> Result<(), KError> {
+    fn factor_ilut(
+        &mut self,
+        a: &CsrMatrix<f64>,
+        drop_tol: f64,
+        max_per_row: usize,
+    ) -> Result<(), KError> {
         let n = a.nrows();
-        if n != a.ncols() { return Err(KError::InvalidInput("ILUT requires square matrix".into())); }
+        if n != a.ncols() {
+            return Err(KError::InvalidInput("ILUT requires square matrix".into()));
+        }
         self.n = n;
 
-        self.l_row.clear(); self.l_col.clear(); self.l_val.clear();
-        self.u_row.clear(); self.u_col.clear(); self.u_val.clear();
+        self.l_row.clear();
+        self.l_col.clear();
+        self.l_val.clear();
+        self.u_row.clear();
+        self.u_col.clear();
+        self.u_val.clear();
         self.u_diag_ix.clear();
-        self.l_lev.clear(); self.u_lev.clear(); // not used by ILUT
+        self.l_lev.clear();
+        self.u_lev.clear(); // not used by ILUT
         self.l_row.resize(n + 1, 0);
         self.u_row.resize(n + 1, 0);
         self.u_diag_ix.resize(n, 0);
@@ -576,19 +729,33 @@ impl IluCsr {
         let rp = a.row_ptr();
         let cj = a.col_idx();
         let vv = a.values();
-        let mut w = RowWork { mark: Vec::new(), idx: Vec::new(), val: Vec::new() };
+        let mut w = RowWork {
+            mark: Vec::new(),
+            idx: Vec::new(),
+            val: Vec::new(),
+        };
         symbolic::ensure_rowwork(&mut w, n);
 
         // Precompute max |A_ii| for pivot handling
         let mut max_diag_abs = 0.0f64;
         for i in 0..n {
-            let mut di = 0.0; for p in rp[i]..rp[i + 1] { if cj[p] == i { di = vv[p]; break; } }
+            let mut di = 0.0;
+            for p in rp[i]..rp[i + 1] {
+                if cj[p] == i {
+                    di = vv[p];
+                    break;
+                }
+            }
             max_diag_abs = max_diag_abs.max(di.abs());
         }
 
         for i in 0..n {
             symbolic::ensure_rowwork(&mut w, n);
-            for p in rp[i]..rp[i + 1] { let j = cj[p]; let pos = symbolic::find_or_insert(&mut w, j); w.val[pos] = vv[p]; }
+            for p in rp[i]..rp[i + 1] {
+                let j = cj[p];
+                let pos = symbolic::find_or_insert(&mut w, j);
+                w.val[pos] = vv[p];
+            }
 
             // lower candidates sorted by column
             let mut lowers: Vec<usize> = w.idx.iter().copied().filter(|&c| c < i).collect();
@@ -596,46 +763,98 @@ impl IluCsr {
             for &j in &lowers {
                 let pos = w.mark[j] as usize;
                 let wij = w.val[pos];
-                if wij.abs() < drop_tol { continue; }
-                let djj = self.u_val.get(self.u_diag_ix.get(j).copied().unwrap_or(0)).copied().unwrap_or(1.0);
+                if wij.abs() < drop_tol {
+                    continue;
+                }
+                let djj = self
+                    .u_val
+                    .get(self.u_diag_ix.get(j).copied().unwrap_or(0))
+                    .copied()
+                    .unwrap_or(1.0);
                 let lij = wij / djj;
                 // update work for k>j, but skip tiny values
                 let rs = self.u_row.get(j).copied().unwrap_or(0);
                 let re = self.u_row.get(j + 1).copied().unwrap_or(0);
                 for q in rs..re {
-                    let kcol = self.u_col[q]; if kcol <= j { continue; }
+                    let kcol = self.u_col[q];
+                    if kcol <= j {
+                        continue;
+                    }
                     let kpos = symbolic::find_or_insert(&mut w, kcol);
                     let newv = w.val[kpos] - lij * self.u_val[q];
                     // Drop small ones early to control workspace
-                    if newv.abs() < drop_tol { w.val[kpos] = 0.0; } else { w.val[kpos] = newv; }
+                    if newv.abs() < drop_tol {
+                        w.val[kpos] = 0.0;
+                    } else {
+                        w.val[kpos] = newv;
+                    }
                 }
             }
 
             // Partition and apply per-row cap on off-diagonals
             // L part (j<i, off-diagonals only) with threshold
-            let mut l_keep: Vec<(usize, f64)> = w.idx.iter().filter_map(|&c| if c < i {
-                let v = w.val[w.mark[c] as usize]; if v.abs() >= drop_tol { Some((c, v)) } else { None }
-            } else { None }).collect();
+            let mut l_keep: Vec<(usize, f64)> = w
+                .idx
+                .iter()
+                .filter_map(|&c| {
+                    if c < i {
+                        let v = w.val[w.mark[c] as usize];
+                        if v.abs() >= drop_tol {
+                            Some((c, v))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                })
+                .collect();
             if max_per_row > 0 && l_keep.len() > max_per_row {
-                let m = max_per_row; l_keep.select_nth_unstable_by(m, |a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap()); l_keep.truncate(m);
+                let m = max_per_row;
+                l_keep.select_nth_unstable_by(m, |a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap());
+                l_keep.truncate(m);
             }
             l_keep.sort_by_key(|x| x.0);
 
             // U part (k>=i); ensure diagonal always present
-            let mut u_keep: Vec<(usize, f64)> = w.idx.iter().filter_map(|&c| if c >= i {
-                let v = w.val[w.mark[c] as usize]; if c == i || v.abs() >= drop_tol { Some((c, v)) } else { None }
-            } else { None }).collect();
-            if !u_keep.iter().any(|(c, _)| *c == i) { u_keep.push((i, 0.0)); }
+            let mut u_keep: Vec<(usize, f64)> = w
+                .idx
+                .iter()
+                .filter_map(|&c| {
+                    if c >= i {
+                        let v = w.val[w.mark[c] as usize];
+                        if c == i || v.abs() >= drop_tol {
+                            Some((c, v))
+                        } else {
+                            None
+                        }
+                    } else {
+                        None
+                    }
+                })
+                .collect();
+            if !u_keep.iter().any(|(c, _)| *c == i) {
+                u_keep.push((i, 0.0));
+            }
             // Apply cap to off-diagonals only
             if max_per_row > 0 {
-                let mut offs: Vec<(usize, f64)> = u_keep.iter().cloned().filter(|(c, _)| *c > i).collect();
+                let mut offs: Vec<(usize, f64)> =
+                    u_keep.iter().cloned().filter(|(c, _)| *c > i).collect();
                 if offs.len() > max_per_row {
-                    let m = max_per_row; offs.select_nth_unstable_by(m, |a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap()); offs.truncate(m);
+                    let m = max_per_row;
+                    offs.select_nth_unstable_by(m, |a, b| {
+                        b.1.abs().partial_cmp(&a.1.abs()).unwrap()
+                    });
+                    offs.truncate(m);
                 }
                 offs.sort_by_key(|x| x.0);
                 // rebuild u_keep with diag + offs
                 let mut new_u: Vec<(usize, f64)> = Vec::with_capacity(1 + offs.len());
-                let diagv = u_keep.iter().find(|(c, _)| *c == i).map(|(_, v)| *v).unwrap_or(0.0);
+                let diagv = u_keep
+                    .iter()
+                    .find(|(c, _)| *c == i)
+                    .map(|(_, v)| *v)
+                    .unwrap_or(0.0);
                 new_u.push((i, diagv));
                 new_u.extend(offs.into_iter());
                 u_keep = new_u;
@@ -644,11 +863,17 @@ impl IluCsr {
 
             // Store L row
             self.l_row[i + 1] = self.l_row[i] + l_keep.len();
-            for (c, v) in l_keep { self.l_col.push(c); self.l_val.push(v); }
+            for (c, v) in l_keep {
+                self.l_col.push(c);
+                self.l_val.push(v);
+            }
             // Store U row
             let u_start = self.u_col.len();
             self.u_row[i + 1] = self.u_row[i] + u_keep.len();
-            for (c, v) in &u_keep { self.u_col.push(*c); self.u_val.push(*v); }
+            for (c, v) in &u_keep {
+                self.u_col.push(*c);
+                self.u_val.push(*v);
+            }
             let d_rel = u_keep.iter().position(|(c, _)| *c == i).unwrap();
             self.u_diag_ix[i] = u_start + d_rel;
 
@@ -664,30 +889,72 @@ impl IluCsr {
         // Re-run elimination using fixed L/U patterns (no drop/cap)
         use symbolic::RowWork;
         let n = self.n;
-        let rp = a.row_ptr(); let cj = a.col_idx(); let vv = a.values();
-        let mut w = RowWork { mark: Vec::new(), idx: Vec::new(), val: Vec::new() };
+        let rp = a.row_ptr();
+        let cj = a.col_idx();
+        let vv = a.values();
+        let mut w = RowWork {
+            mark: Vec::new(),
+            idx: Vec::new(),
+            val: Vec::new(),
+        };
         symbolic::ensure_rowwork(&mut w, n);
         for i in 0..n {
             symbolic::ensure_rowwork(&mut w, n);
-            for p in rp[i]..rp[i + 1] { let j = cj[p]; let pos = symbolic::find_or_insert(&mut w, j); w.val[pos] = vv[p]; }
+            for p in rp[i]..rp[i + 1] {
+                let j = cj[p];
+                let pos = symbolic::find_or_insert(&mut w, j);
+                w.val[pos] = vv[p];
+            }
             // eliminate across L pattern
-            let ls = self.l_row[i]; let le = self.l_row[i + 1];
+            let ls = self.l_row[i];
+            let le = self.l_row[i + 1];
             for pos in ls..le {
                 let j = self.l_col[pos];
-                let wij = if w.mark[j] >= 0 { w.val[w.mark[j] as usize] } else { 0.0 };
+                let wij = if w.mark[j] >= 0 {
+                    w.val[w.mark[j] as usize]
+                } else {
+                    0.0
+                };
                 let djj = self.u_val[self.u_diag_ix[j]];
                 let lij = if djj != 0.0 { wij / djj } else { 0.0 };
                 self.l_val[pos] = lij;
-                let urs = self.u_row[j]; let ure = self.u_row[j + 1];
-                for q in urs..ure { let kcol = self.u_col[q]; if kcol <= j { continue; }
-                    let mk = w.mark.get(kcol).copied().unwrap_or(-1); if mk >= 0 { w.val[mk as usize] -= lij * self.u_val[q]; }
+                let urs = self.u_row[j];
+                let ure = self.u_row[j + 1];
+                for q in urs..ure {
+                    let kcol = self.u_col[q];
+                    if kcol <= j {
+                        continue;
+                    }
+                    let mk = w.mark.get(kcol).copied().unwrap_or(-1);
+                    if mk >= 0 {
+                        w.val[mk as usize] -= lij * self.u_val[q];
+                    }
                 }
             }
             // finalize U row
-            let us = self.u_row[i]; let ue = self.u_row[i + 1]; let mut diag = 0.0;
-            for q in us..ue { let k = self.u_col[q]; let v = if w.mark.get(k).copied().unwrap_or(-1) >= 0 { w.val[w.mark[k] as usize] } else { 0.0 };
-                if k == i { diag = v; } self.u_val[q] = v; }
-            let fixed = pivot::handle_pivot(diag, self.cfg.pivot, self.cfg.pivot_threshold, self.cfg.diag_perturb_factor, max_diag_abs).map_err(|_| KError::ZeroPivot(i))?;
+            let us = self.u_row[i];
+            let ue = self.u_row[i + 1];
+            let mut diag = 0.0;
+            for q in us..ue {
+                let k = self.u_col[q];
+                let v = if w.mark.get(k).copied().unwrap_or(-1) >= 0 {
+                    w.val[w.mark[k] as usize]
+                } else {
+                    0.0
+                };
+                if k == i {
+                    diag = v;
+                }
+                self.u_val[q] = v;
+            }
+            let fixed = pivot::handle_pivot(
+                diag,
+                self.cfg.pivot,
+                self.cfg.pivot_threshold,
+                self.cfg.diag_perturb_factor,
+                max_diag_abs,
+            )
+            .map_err(|_| KError::ZeroPivot(i))?;
             self.u_val[self.u_diag_ix[i]] = fixed;
             symbolic::clear_rowwork(&mut w);
         }
@@ -696,8 +963,20 @@ impl IluCsr {
 
     fn factor_ilut_numeric_only(&mut self, a: &CsrMatrix<f64>) -> Result<(), KError> {
         // recompute max_diag_abs
-        let rp = a.row_ptr(); let cj = a.col_idx(); let vv = a.values();
-        let mut max_diag_abs = 0.0f64; for i in 0..self.n { let mut di=0.0; for p in rp[i]..rp[i+1] { if cj[p]==i { di = vv[p]; break; } } max_diag_abs = max_diag_abs.max(di.abs()); }
+        let rp = a.row_ptr();
+        let cj = a.col_idx();
+        let vv = a.values();
+        let mut max_diag_abs = 0.0f64;
+        for i in 0..self.n {
+            let mut di = 0.0;
+            for p in rp[i]..rp[i + 1] {
+                if cj[p] == i {
+                    di = vv[p];
+                    break;
+                }
+            }
+            max_diag_abs = max_diag_abs.max(di.abs());
+        }
         self.ilut_numeric_only(a, max_diag_abs)
     }
 }
@@ -733,7 +1012,9 @@ impl Preconditioner for IluCsr {
         if x.len() != self.n || y.len() != self.n {
             return Err(KError::InvalidInput(format!(
                 "IluCsr::apply dimension mismatch: n={}, x.len()={}, y.len()={}",
-                self.n, x.len(), y.len()
+                self.n,
+                x.len(),
+                y.len()
             )));
         }
         if self.cfg.level_sched {
@@ -781,30 +1062,54 @@ impl Preconditioner for IluCsr {
 // === Simple accessors for internal solves ===
 impl IluCsr {
     #[inline]
-    pub(crate) fn n(&self) -> usize { self.n }
+    pub(crate) fn n(&self) -> usize {
+        self.n
+    }
     #[inline]
-    pub(crate) fn l_row(&self) -> &[usize] { &self.l_row }
+    pub(crate) fn l_row(&self) -> &[usize] {
+        &self.l_row
+    }
     #[inline]
-    pub(crate) fn l_col(&self) -> &[usize] { &self.l_col }
+    pub(crate) fn l_col(&self) -> &[usize] {
+        &self.l_col
+    }
     #[inline]
-    pub(crate) fn l_val(&self) -> &[f64] { &self.l_val }
+    pub(crate) fn l_val(&self) -> &[f64] {
+        &self.l_val
+    }
     #[inline]
-    pub(crate) fn u_row(&self) -> &[usize] { &self.u_row }
+    pub(crate) fn u_row(&self) -> &[usize] {
+        &self.u_row
+    }
     #[inline]
-    pub(crate) fn u_col(&self) -> &[usize] { &self.u_col }
+    pub(crate) fn u_col(&self) -> &[usize] {
+        &self.u_col
+    }
     #[inline]
-    pub(crate) fn u_val(&self) -> &[f64] { &self.u_val }
+    pub(crate) fn u_val(&self) -> &[f64] {
+        &self.u_val
+    }
     #[inline]
-    pub(crate) fn u_diag_ix(&self) -> &[usize] { &self.u_diag_ix }
+    pub(crate) fn u_diag_ix(&self) -> &[usize] {
+        &self.u_diag_ix
+    }
     #[allow(dead_code)]
     #[inline]
-    pub(crate) fn tmp(&self) -> &[f64] { &self.tmp }
+    pub(crate) fn tmp(&self) -> &[f64] {
+        &self.tmp
+    }
     #[allow(dead_code)]
     #[inline]
-    pub(crate) fn tmp_mut(&mut self) -> &mut [f64] { &mut self.tmp }
+    pub(crate) fn tmp_mut(&mut self) -> &mut [f64] {
+        &mut self.tmp
+    }
 
     #[inline]
-    pub(crate) fn buckets_fwd(&self) -> &[Vec<usize>] { &self.buckets_fwd }
+    pub(crate) fn buckets_fwd(&self) -> &[Vec<usize>] {
+        &self.buckets_fwd
+    }
     #[inline]
-    pub(crate) fn buckets_bwd(&self) -> &[Vec<usize>] { &self.buckets_bwd }
+    pub(crate) fn buckets_bwd(&self) -> &[Vec<usize>] {
+        &self.buckets_bwd
+    }
 }

--- a/src/preconditioner/tests/ilu_csr.rs
+++ b/src/preconditioner/tests/ilu_csr.rs
@@ -1,6 +1,6 @@
 use crate::matrix::sparse::CsrMatrix;
-use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
 use crate::preconditioner::Preconditioner;
+use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
 
 fn tridiag_csr(n: usize, a: f64, b: f64, c: f64) -> CsrMatrix<f64> {
     // main diag b, subdiag a, superdiag c
@@ -51,7 +51,8 @@ fn iluk_basic_pivots_nonzero() {
     // Apply on a vector and ensure finite results
     let x = vec![1.0; n];
     let mut y = vec![0.0; n];
-    pc.apply(crate::preconditioner::PcSide::Left, &x, &mut y).unwrap();
+    pc.apply(crate::preconditioner::PcSide::Left, &x, &mut y)
+        .unwrap();
     assert!(y.iter().all(|v| v.is_finite()));
 }
 
@@ -60,7 +61,10 @@ fn ilut_basic_and_numeric_update_keeps_pattern() {
     let n = 10;
     let a = tridiag_csr(n, -1.0, 4.0, -1.0);
     let cfg = IluCsrConfig {
-        kind: IluKind::Ilut { drop_tol: 1e-6, max_per_row: 2 },
+        kind: IluKind::Ilut {
+            drop_tol: 1e-6,
+            max_per_row: 2,
+        },
         pivot: PivotStrategy::DiagonalPerturbation,
         pivot_threshold: 1e-12,
         diag_perturb_factor: 1e-10,
@@ -80,7 +84,9 @@ fn ilut_basic_and_numeric_update_keeps_pattern() {
 
     // Build a numerically changed matrix with identical structure: scale values
     let mut a2 = a.clone();
-    for v in a2.values_mut() { *v *= 2.0; }
+    for v in a2.values_mut() {
+        *v *= 2.0;
+    }
 
     // Update numeric only
     pc.update_numeric(&a2).unwrap();
@@ -95,7 +101,66 @@ fn ilut_basic_and_numeric_update_keeps_pattern() {
     // Apply and ensure finite results
     let x = vec![1.0; n];
     let mut y = vec![0.0; n];
-    pc.apply(crate::preconditioner::PcSide::Left, &x, &mut y).unwrap();
+    pc.apply(crate::preconditioner::PcSide::Left, &x, &mut y)
+        .unwrap();
     assert!(y.iter().all(|v| v.is_finite()));
 }
 
+#[test]
+fn milu0_preserves_row_sums() {
+    use crate::preconditioner::ilu_csr::IluKind;
+    // 4x4 "arrow" matrix that induces dropped fill in ILU(0)
+    // [2 1 1 1; 1 2 0 0; 1 0 2 0; 1 0 0 2]
+    let n = 4;
+    let row_ptr = vec![0, 4, 6, 8, 10];
+    let col_idx = vec![0, 1, 2, 3, 0, 1, 0, 2, 0, 3];
+    let vals = vec![2.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 2.0];
+    let a = CsrMatrix::from_csr(n, n, row_ptr, col_idx, vals);
+
+    // Row sums of original matrix
+    let mut a_row_sum = vec![0.0; n];
+    for i in 0..n {
+        let rs = a.row_ptr()[i];
+        let re = a.row_ptr()[i + 1];
+        for p in rs..re {
+            a_row_sum[i] += a.values()[p];
+        }
+    }
+
+    // Factor with MILU(0)
+    let cfg = IluCsrConfig {
+        kind: IluKind::Milu0,
+        pivot: PivotStrategy::DiagonalPerturbation,
+        pivot_threshold: 1e-12,
+        diag_perturb_factor: 1e-10,
+        level_sched: false,
+        numeric_update_fixed: true,
+        logging: 0,
+    };
+    let mut pc = IluCsr::new_with_config(cfg);
+    pc.setup(&a).unwrap();
+
+    // Compute M*1 where M = L*U
+    let ones = vec![1.0; n];
+    // z = U * 1
+    let mut z = vec![0.0; n];
+    for i in 0..n {
+        for p in pc.u_row()[i]..pc.u_row()[i + 1] {
+            let j = pc.u_col()[p];
+            z[i] += pc.u_val()[p] * ones[j];
+        }
+    }
+    // y = L * z (L has unit diagonal)
+    let mut y = z.clone();
+    for i in 0..n {
+        for p in pc.l_row()[i]..pc.l_row()[i + 1] {
+            let j = pc.l_col()[p];
+            y[i] += pc.l_val()[p] * z[j];
+        }
+    }
+
+    for i in 0..n {
+        let diff = (y[i] - a_row_sum[i]).abs();
+        assert!(diff < 1e-9, "row {} diff {}", i, diff);
+    }
+}


### PR DESCRIPTION
## Summary
- add MILU0 variant and deferred `delta_diag` accumulation to `IluCsr`
- support building MILU0 preconditioners
- test that MILU0 preserves row sums on an arrow matrix

## Testing
- `cargo test preconditioner::tests::ilu_csr::milu0_preserves_row_sums`

------
https://chatgpt.com/codex/tasks/task_e_68b652d6ec048329890c3a0c0c7d78e8