### PR TITLE
Add transpose-aware preconditioner ops

### DIFF
--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -5,7 +5,8 @@ use crate::matrix::convert::csr_from_linop;
 use crate::matrix::format::FormatHint;
 use crate::matrix::op::{LinOp, StructureId, ValuesId};
 use crate::matrix::sparse::CsrMatrix;
-use crate::preconditioner::{PcSide, Preconditioner};
+use crate::preconditioner::{Op, PcCaps, PcSide, Preconditioner};
+use once_cell::sync::OnceCell;
 
 mod pivot;
 mod tri_solve;
@@ -122,6 +123,10 @@ pub struct IluCsr {
     l_lev: Vec<usize>,
     u_lev: Vec<usize>,
 
+    // cached transposes, built lazily
+    lt: OnceCell<(Vec<usize>, Vec<usize>, Vec<f64>)>,
+    ut: OnceCell<(Vec<usize>, Vec<usize>, Vec<f64>)>,
+
     // optional level scheduling
     levels_fwd: Vec<usize>,
     levels_bwd: Vec<usize>,
@@ -153,6 +158,8 @@ impl IluCsr {
             buckets_fwd: Vec::new(),
             buckets_bwd: Vec::new(),
             tmp: Vec::new(),
+            lt: OnceCell::new(),
+            ut: OnceCell::new(),
         }
     }
 
@@ -1000,6 +1007,10 @@ impl Preconditioner for IluCsr {
     }
 
     fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        self.apply_op(Op::NoTrans, x, y)
+    }
+
+    fn apply_op(&self, op: Op, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
         if x.len() != self.n || y.len() != self.n {
             return Err(KError::InvalidInput(format!(
                 "IluCsr::apply dimension mismatch: n={}, x.len()={}, y.len()={}",
@@ -1008,10 +1019,29 @@ impl Preconditioner for IluCsr {
                 y.len()
             )));
         }
-        if self.cfg.level_sched {
-            tri_solve::tri_solve_level_scheduled(self, x, y)
-        } else {
-            tri_solve::tri_solve_serial(self, x, y)
+        match op {
+            Op::NoTrans => {
+                if self.cfg.level_sched {
+                    tri_solve::tri_solve_level_scheduled(self, x, y)
+                } else {
+                    tri_solve::tri_solve_serial(self, x, y)
+                }
+            }
+            Op::Trans | Op::ConjTrans => {
+                let ut = self.ut.get_or_init(|| transpose_csr(self.n, &self.u_row, &self.u_col, &self.u_val));
+                let lt = self.lt.get_or_init(|| transpose_csr(self.n, &self.l_row, &self.l_col, &self.l_val));
+                tri_solve::tri_solve_transpose_serial(
+                    self,
+                    &ut.0,
+                    &ut.1,
+                    &ut.2,
+                    &lt.0,
+                    &lt.1,
+                    &lt.2,
+                    x,
+                    y,
+                )
+            }
         }
     }
 
@@ -1047,6 +1077,15 @@ impl Preconditioner for IluCsr {
 
     fn required_format(&self) -> FormatHint {
         FormatHint::Csr
+    }
+
+    fn capabilities(&self) -> PcCaps {
+        PcCaps {
+            supports_transpose: true,
+            supports_conj_trans: false,
+            is_spd: false,
+            side_restriction: None,
+        }
     }
 }
 
@@ -1103,4 +1142,33 @@ impl IluCsr {
     pub(crate) fn buckets_bwd(&self) -> &[Vec<usize>] {
         &self.buckets_bwd
     }
+}
+
+fn transpose_csr(
+    n: usize,
+    row: &[usize],
+    col: &[usize],
+    val: &[f64],
+) -> (Vec<usize>, Vec<usize>, Vec<f64>) {
+    let nnz = col.len();
+    let mut t_row = vec![0usize; n + 1];
+    for &j in col {
+        t_row[j + 1] += 1;
+    }
+    for i in 0..n {
+        t_row[i + 1] += t_row[i];
+    }
+    let mut t_col = vec![0usize; nnz];
+    let mut t_val = vec![0f64; nnz];
+    let mut offset = t_row.clone();
+    for i in 0..n {
+        for p in row[i]..row[i + 1] {
+            let j = col[p];
+            let dest = offset[j];
+            t_col[dest] = i;
+            t_val[dest] = val[p];
+            offset[j] += 1;
+        }
+    }
+    (t_row, t_col, t_val)
 }

--- a/src/preconditioner/ilu_csr/tri_solve.rs
+++ b/src/preconditioner/ilu_csr/tri_solve.rs
@@ -151,3 +151,47 @@ pub fn tri_solve_level_scheduled(pc: &IluCsr, x: &[f64], y: &mut [f64]) -> Resul
 
     Ok(())
 }
+
+pub fn tri_solve_transpose_serial(
+    pc: &IluCsr,
+    ut_row: &[usize],
+    ut_col: &[usize],
+    ut_val: &[f64],
+    lt_row: &[usize],
+    lt_col: &[usize],
+    lt_val: &[f64],
+    x: &[f64],
+    y: &mut [f64],
+) -> Result<(), KError> {
+    let n = pc.n();
+    if x.len() != n || y.len() != n {
+        return Err(KError::InvalidInput("tri_solve: dimension mismatch".into()));
+    }
+
+    // Forward solve with U^T (lower with diag)
+    for i in 0..n {
+        let mut s = x[i];
+        for p in ut_row[i]..ut_row[i + 1] {
+            let j = ut_col[p];
+            if j < i {
+                s -= ut_val[p] * y[j];
+            }
+        }
+        let d = pc.u_val()[pc.u_diag_ix()[i]];
+        y[i] = s / d;
+    }
+
+    // Backward solve with L^T (upper unit)
+    for i in (0..n).rev() {
+        let mut s = y[i];
+        for p in lt_row[i]..lt_row[i + 1] {
+            let j = lt_col[p];
+            if j > i {
+                s -= lt_val[p] * y[j];
+            }
+        }
+        y[i] = s;
+    }
+
+    Ok(())
+}

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -80,6 +80,36 @@ impl Default for PcSide {
     }
 }
 
+/// Matrix operation selector for preconditioner application.
+///
+/// `Op::NoTrans` applies the factor as-is, while `Op::Trans` applies the
+/// transpose. `Op::ConjTrans` is reserved for future complex-number support and
+/// maps to `Op::Trans` for real-valued matrices.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Op {
+    /// Use the factors as stored.
+    NoTrans,
+    /// Apply the transpose of the factors.
+    Trans,
+    /// Apply the conjugate-transpose of the factors. Equivalent to `Trans` for
+    /// real data.
+    ConjTrans,
+}
+
+/// Capability flags advertised by a preconditioner so that solvers can
+/// negotiate required operations.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct PcCaps {
+    /// Whether the preconditioner supports applying the transpose inverse.
+    pub supports_transpose: bool,
+    /// Whether the preconditioner supports a conjugate-transpose operation.
+    pub supports_conj_trans: bool,
+    /// Whether the preconditioner is symmetric positive definite when applied on the left.
+    pub is_spd: bool,
+    /// Restrict application to a specific side (left/right) if needed.
+    pub side_restriction: Option<PcSide>,
+}
+
 #[derive(Clone, Copy, Debug)]
 pub enum PcReusePolicy {
     Never,
@@ -111,11 +141,40 @@ pub trait Preconditioner: Send + Sync {
     /// Build any factorization/hierarchy once from the system matrix.
     fn setup(&mut self, a: &dyn LinOp<S = f64>) -> Result<(), KError>;
 
-    /// Apply M⁻¹ to input vector, writing result to output slice.
+    /// Apply `M^{-op}` to input vector, writing result to output slice.
     ///
     /// When used with CG and [`PcSide::Left`], this operation must represent an
     /// SPD preconditioner `M` so that `rᵀ M⁻¹ r > 0` holds.
     fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError>;
+
+    /// Apply `M^{-op}` where the operation (`op`) specifies transpose handling.
+    ///
+    /// The default implementation routes `Op::NoTrans` to [`apply`]; transpose
+    /// requests return [`KError::Unsupported`]. Implementations overriding this
+    /// method should ignore the [`PcSide`] argument entirely and instead allow
+    /// callers to decide left/right placement by where they invoke the method.
+    fn apply_op(&self, op: Op, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        match op {
+            Op::NoTrans => self.apply(PcSide::Left, x, y),
+            Op::Trans | Op::ConjTrans => {
+                Err(KError::Unsupported("transpose application not supported"))
+            }
+        }
+    }
+
+    /// Convenience helper for in-place application (y := M^{-op} y).
+    ///
+    /// The default implementation allocates a temporary buffer; performance-
+    /// sensitive implementations should override this.
+    fn apply_op_inplace(&self, op: Op, y: &mut [f64]) -> Result<(), KError> {
+        let mut tmp = y.to_vec();
+        self.apply_op(op, &tmp, y)
+    }
+
+    /// Capabilities advertised by this preconditioner.
+    fn capabilities(&self) -> PcCaps {
+        PcCaps::default()
+    }
 
     /// Mutable application (flexible/nonlinear preconditioners).
     ///


### PR DESCRIPTION
## Summary
- Introduce Op enum and PcCaps struct for preconditioner operation modes
- Implement transpose-aware apply_op in ILU CSR preconditioner with cached transposes
- Expose capabilities including transpose support for ILU CSR

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b666b80a208329bd87e9856e7aea93