### PR TITLE
Add permutation-based reordering to ILU preconditioner

### DIFF
--- a/src/algebra/blas.rs
+++ b/src/algebra/blas.rs
@@ -1,4 +1,4 @@
-use super::scalar::Scalar;
+use super::scalar::{Scalar, RealScalar};
 
 /// Compute the dot product \(x^\mathrm{H} y\).
 #[inline]

--- a/src/preconditioner/asm.rs
+++ b/src/preconditioner/asm.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 #[cfg(feature = "dense-direct")]
 use crate::solver::direct_lu::LuSolver;
 use crate::utils::partition::{contiguous_partition, greedy_nnz_balanced_partition};
-use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
+use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy, ReorderingOptions};
 use crate::matrix::op::CsrOp;
 
 /// Additive Schwarz (overlapping block Jacobi) preconditioner.
@@ -329,6 +329,7 @@ impl ObjPreconditioner for AdditiveSchwarz<faer::Mat<f64>, Vec<f64>, f64> {
                         level_sched: cfg!(feature = "rayon"),
                         numeric_update_fixed: true,
                         logging: 0,
+                        reordering: ReorderingOptions::default(),
                     };
                     for meta in self.blocks_meta.iter() {
                         let idx = &meta.indices;
@@ -369,6 +370,7 @@ impl ObjPreconditioner for AdditiveSchwarz<faer::Mat<f64>, Vec<f64>, f64> {
                     level_sched: cfg!(feature = "rayon"),
                     numeric_update_fixed: true,
                     logging: 0,
+                    reordering: ReorderingOptions::default(),
                 };
                 for meta in self.blocks_meta.iter() {
                     let idx = &meta.indices;
@@ -606,6 +608,7 @@ impl ObjPreconditioner for AdditiveSchwarz<faer::Mat<f64>, Vec<f64>, f64> {
                         level_sched: cfg!(feature = "rayon"),
                         numeric_update_fixed: true,
                         logging: 0,
+                        reordering: ReorderingOptions::default(),
                     };
                     for meta in self.blocks_meta.iter() {
                         let indices = &meta.indices;
@@ -626,6 +629,7 @@ impl ObjPreconditioner for AdditiveSchwarz<faer::Mat<f64>, Vec<f64>, f64> {
                     level_sched: cfg!(feature = "rayon"),
                     numeric_update_fixed: true,
                     logging: 0,
+                    reordering: ReorderingOptions::default(),
                 };
                 for meta in self.blocks_meta.iter() {
                     let indices = &meta.indices;
@@ -711,6 +715,7 @@ impl ObjPreconditioner for AdditiveSchwarz<faer::Mat<f64>, Vec<f64>, f64> {
                         level_sched: cfg!(feature = "rayon"),
                         numeric_update_fixed: true,
                         logging: 0,
+                        reordering: ReorderingOptions::default(),
                     };
                     for meta in self.blocks_meta.iter() {
                         let indices = &meta.indices;
@@ -731,6 +736,7 @@ impl ObjPreconditioner for AdditiveSchwarz<faer::Mat<f64>, Vec<f64>, f64> {
                     level_sched: cfg!(feature = "rayon"),
                     numeric_update_fixed: true,
                     logging: 0,
+                    reordering: ReorderingOptions::default(),
                 };
                 for meta in self.blocks_meta.iter() {
                     let indices = &meta.indices;

--- a/src/preconditioner/block_jacobi.rs
+++ b/src/preconditioner/block_jacobi.rs
@@ -17,7 +17,7 @@ use crate::preconditioner::PcSide;
 #[cfg(feature = "dense-direct")]
 use crate::solver::direct_lu::LuSolver;
 #[cfg(not(feature = "dense-direct"))]
-use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
+use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy, ReorderingOptions};
 #[cfg(not(feature = "dense-direct"))]
 use crate::matrix::sparse::CsrMatrix;
 #[cfg(not(feature = "dense-direct"))]
@@ -102,6 +102,7 @@ impl BlockJacobi<f64> {
             level_sched: cfg!(feature = "rayon"),
             numeric_update_fixed: true,
             logging: 0,
+            reordering: ReorderingOptions::default(),
         };
         for block in &self.blocks {
             let n = block.len();

--- a/src/preconditioner/builders.rs
+++ b/src/preconditioner/builders.rs
@@ -83,7 +83,7 @@ pub fn build_superlu_dist() -> Result<Box<dyn Preconditioner>, KError> {
 // ---- ILU family builders -------------------------------------------------
 
 pub fn build_ilu0() -> Result<Box<dyn Preconditioner>, KError> {
-    use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
+    use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy, ReorderingOptions};
     let cfg = IluCsrConfig {
         kind: IluKind::Ilu0,
         pivot: PivotStrategy::DiagonalPerturbation,
@@ -92,13 +92,14 @@ pub fn build_ilu0() -> Result<Box<dyn Preconditioner>, KError> {
         level_sched: cfg!(feature = "rayon"),
         numeric_update_fixed: true,
         logging: 0,
+        reordering: ReorderingOptions::default(),
     };
     let pc = IluCsr::new_with_config(cfg);
     Ok(Box::new(pc))
 }
 
 pub fn build_iluk(level: usize) -> Result<Box<dyn Preconditioner>, KError> {
-    use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
+    use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy, ReorderingOptions};
     let cfg = IluCsrConfig {
         kind: IluKind::Iluk { k: level },
         pivot: PivotStrategy::DiagonalPerturbation,
@@ -107,6 +108,7 @@ pub fn build_iluk(level: usize) -> Result<Box<dyn Preconditioner>, KError> {
         level_sched: cfg!(feature = "rayon"),
         numeric_update_fixed: true,
         logging: 0,
+        reordering: ReorderingOptions::default(),
     };
     Ok(Box::new(IluCsr::new_with_config(cfg)))
 }
@@ -117,7 +119,7 @@ pub fn build_ilut(
     _reordering: Option<String>,
 ) -> Result<Box<dyn Preconditioner>, KError> {
     use crate::preconditioner::ilu_csr::{
-        IluCsr, IluCsrConfig, IluKind, PivotStrategy, IlutParams, PivotPolicy, Pivoting,
+        IluCsr, IluCsrConfig, IluKind, PivotStrategy, IlutParams, PivotPolicy, Pivoting, ReorderingOptions,
     };
     let params = IlutParams {
         droptol_abs: drop_tol,
@@ -139,12 +141,13 @@ pub fn build_ilut(
         // For ILUT, fast numeric update requires fixed pattern. Let callers override later if needed.
         numeric_update_fixed: true,
         logging: 0,
+        reordering: ReorderingOptions::default(),
     };
     Ok(Box::new(IluCsr::new_with_config(cfg)))
 }
 
 pub fn build_milu0() -> Result<Box<dyn Preconditioner>, KError> {
-    use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy};
+    use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind, PivotStrategy, ReorderingOptions};
     let cfg = IluCsrConfig {
         kind: IluKind::Milu0,
         pivot: PivotStrategy::DiagonalPerturbation,
@@ -153,6 +156,7 @@ pub fn build_milu0() -> Result<Box<dyn Preconditioner>, KError> {
         level_sched: cfg!(feature = "rayon"),
         numeric_update_fixed: true,
         logging: 0,
+        reordering: ReorderingOptions::default(),
     };
     Ok(Box::new(IluCsr::new_with_config(cfg)))
 }

--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -6,6 +6,7 @@ use crate::matrix::format::FormatHint;
 use crate::matrix::op::{LinOp, StructureId, ValuesId};
 use crate::matrix::sparse::CsrMatrix;
 use crate::preconditioner::{Op, PcCaps, PcSide, Preconditioner};
+use crate::utils::permutation::{rcm_csr, permute_csr_symmetric, Permutation};
 use once_cell::sync::OnceCell;
 
 mod pivot;
@@ -85,6 +86,7 @@ pub struct IluCsrConfig {
     pub level_sched: bool,
     pub numeric_update_fixed: bool,
     pub logging: usize,
+    pub reordering: ReorderingOptions,
 }
 
 impl Default for IluCsrConfig {
@@ -97,7 +99,27 @@ impl Default for IluCsrConfig {
             level_sched: cfg!(feature = "rayon"),
             numeric_update_fixed: true,
             logging: 0,
+            reordering: ReorderingOptions::default(),
         }
+    }
+}
+
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum ReorderingKind {
+    None,
+    Rcm,
+}
+
+#[derive(Clone, Debug)]
+pub struct ReorderingOptions {
+    pub kind: ReorderingKind,
+    pub symmetric: bool,
+    pub deterministic: bool,
+}
+
+impl Default for ReorderingOptions {
+    fn default() -> Self {
+        Self { kind: ReorderingKind::None, symmetric: true, deterministic: true }
     }
 }
 
@@ -135,6 +157,7 @@ pub struct IluCsr {
 
     // scratch for apply
     tmp: Vec<f64>,
+    perm: Permutation,
 }
 
 impl IluCsr {
@@ -160,6 +183,7 @@ impl IluCsr {
             tmp: Vec::new(),
             lt: OnceCell::new(),
             ut: OnceCell::new(),
+            perm: Permutation::identity(0),
         }
     }
 
@@ -990,15 +1014,27 @@ impl Preconditioner for IluCsr {
         let values_changed = self.last_vid != Some(vid);
 
         if structure_changed || !self.cfg.numeric_update_fixed {
-            self.factor_symbolic_and_numeric(&a)?;
+            // compute permutation
+            let perm = match self.cfg.reordering.kind {
+                ReorderingKind::None => Permutation::identity(a.nrows()),
+                ReorderingKind::Rcm => rcm_csr(&a),
+            };
+            let a_perm = if self.cfg.reordering.symmetric {
+                permute_csr_symmetric(&a, &perm)
+            } else {
+                // nonsymmetric not yet supported
+                permute_csr_symmetric(&a, &perm)
+            };
+            self.perm = perm;
+            self.factor_symbolic_and_numeric(&a_perm)?;
             self.build_levels_if_enabled();
             self.last_sid = Some(sid);
             self.last_vid = Some(vid);
-            // scratch
-            self.tmp.resize(a.nrows(), 0.0);
+            self.tmp.resize(a_perm.nrows(), 0.0);
             Ok(())
         } else if values_changed {
-            self.factor_numeric_only(&a)?;
+            let a_perm = permute_csr_symmetric(&a, &self.perm);
+            self.factor_numeric_only(&a_perm)?;
             self.last_vid = Some(vid);
             Ok(())
         } else {
@@ -1019,12 +1055,15 @@ impl Preconditioner for IluCsr {
                 y.len()
             )));
         }
-        match op {
+        let mut x_perm = vec![0.0; self.n];
+        let mut y_perm = vec![0.0; self.n];
+        self.perm.apply_vec(x, &mut x_perm);
+        let res = match op {
             Op::NoTrans => {
                 if self.cfg.level_sched {
-                    tri_solve::tri_solve_level_scheduled(self, x, y)
+                    tri_solve::tri_solve_level_scheduled(self, &x_perm, &mut y_perm)
                 } else {
-                    tri_solve::tri_solve_serial(self, x, y)
+                    tri_solve::tri_solve_serial(self, &x_perm, &mut y_perm)
                 }
             }
             Op::Trans | Op::ConjTrans => {
@@ -1038,11 +1077,13 @@ impl Preconditioner for IluCsr {
                     &lt.0,
                     &lt.1,
                     &lt.2,
-                    x,
-                    y,
+                    &x_perm,
+                    &mut y_perm,
                 )
             }
-        }
+        };
+        self.perm.apply_vec_t(&y_perm, y);
+        res
     }
 
     fn apply_mut(&mut self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {

--- a/src/preconditioner/tests/ilu_csr.rs
+++ b/src/preconditioner/tests/ilu_csr.rs
@@ -2,6 +2,7 @@ use crate::matrix::sparse::CsrMatrix;
 use crate::preconditioner::Preconditioner;
 use crate::preconditioner::ilu_csr::{
     IluCsr, IluCsrConfig, IluKind, PivotStrategy, IlutParams, PivotPolicy, Pivoting,
+    ReorderingOptions, ReorderingKind,
 };
 
 fn tridiag_csr(n: usize, a: f64, b: f64, c: f64) -> CsrMatrix<f64> {
@@ -38,6 +39,7 @@ fn iluk_basic_pivots_nonzero() {
         level_sched: cfg!(feature = "rayon"),
         numeric_update_fixed: true,
         logging: 0,
+        reordering: ReorderingOptions::default(),
     };
     let mut pc = IluCsr::new_with_config(cfg);
     pc.setup(&a).unwrap();
@@ -81,6 +83,7 @@ fn ilut_basic_and_numeric_update_keeps_pattern() {
         level_sched: false,
         numeric_update_fixed: true,
         logging: 0,
+        reordering: ReorderingOptions::default(),
     };
     let mut pc = IluCsr::new_with_config(cfg);
     pc.setup(&a).unwrap();
@@ -146,6 +149,7 @@ fn milu0_preserves_row_sums() {
         level_sched: false,
         numeric_update_fixed: true,
         logging: 0,
+        reordering: ReorderingOptions::default(),
     };
     let mut pc = IluCsr::new_with_config(cfg);
     pc.setup(&a).unwrap();
@@ -173,4 +177,26 @@ fn milu0_preserves_row_sums() {
         let diff = (y[i] - a_row_sum[i]).abs();
         assert!(diff < 1e-9, "row {} diff {}", i, diff);
     }
+}
+
+#[test]
+fn ilu0_with_rcm_setup() {
+    let n = 8;
+    let a = tridiag_csr(n, -1.0, 4.0, -1.0);
+    let cfg = IluCsrConfig {
+        kind: IluKind::Ilu0,
+        pivot: PivotStrategy::DiagonalPerturbation,
+        pivot_threshold: 1e-12,
+        diag_perturb_factor: 1e-10,
+        level_sched: false,
+        numeric_update_fixed: true,
+        logging: 0,
+        reordering: ReorderingOptions { kind: ReorderingKind::Rcm, symmetric: true, deterministic: true },
+    };
+    let mut pc = IluCsr::new_with_config(cfg);
+    pc.setup(&a).unwrap();
+    let x = vec![1.0; n];
+    let mut y = vec![0.0; n];
+    pc.apply(crate::preconditioner::PcSide::Left, &x, &mut y).unwrap();
+    assert!(y.iter().all(|v| v.is_finite()));
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -6,6 +6,7 @@ pub mod matrix_market;
 pub mod monitor;
 pub mod profiling;
 pub mod reordering;
+pub mod permutation;
 #[cfg(feature = "tuning")]
 pub mod tuning;
 pub mod partition;

--- a/src/utils/permutation.rs
+++ b/src/utils/permutation.rs
@@ -1,0 +1,168 @@
+use crate::algebra::scalar::Scalar;
+use crate::matrix::sparse::CsrMatrix;
+
+/// Permutation with cached inverse mapping.
+#[derive(Clone, Debug)]
+pub struct Permutation {
+    /// Maps new index -> old index (p[i] = old index of new position i)
+    pub p: Vec<usize>,
+    /// Maps old index -> new index (pinv[old] = new position of old index)
+    pub pinv: Vec<usize>,
+}
+
+impl Permutation {
+    /// Identity permutation of length `n`.
+    pub fn identity(n: usize) -> Self {
+        let p: Vec<usize> = (0..n).collect();
+        let pinv = p.clone();
+        Self { p, pinv }
+    }
+
+    /// Length of permutation.
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.p.len()
+    }
+
+    /// Apply permutation to a vector: y(new) = x(old)[p[new]]
+    pub fn apply_vec<S: Scalar>(&self, x_old: &[S], y_new: &mut [S]) {
+        for (i, y) in y_new.iter_mut().enumerate() {
+            *y = x_old[self.p[i]];
+        }
+    }
+
+    /// Apply transpose permutation to a vector: y(old) = x(new)[pinv[old]]
+    pub fn apply_vec_t<S: Scalar>(&self, x_new: &[S], y_old: &mut [S]) {
+        for (i, y) in y_old.iter_mut().enumerate() {
+            *y = x_new[self.pinv[i]];
+        }
+    }
+}
+
+/// Symmetric permutation of CSR matrix: A' = P A P^T
+pub fn permute_csr_symmetric(a: &CsrMatrix<f64>, perm: &Permutation) -> CsrMatrix<f64> {
+    let n = a.nrows();
+    assert_eq!(n, a.ncols());
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx = Vec::with_capacity(vv.len());
+    let mut values = Vec::with_capacity(vv.len());
+    row_ptr.push(0);
+
+    for new_i in 0..n {
+        let old_i = perm.p[new_i];
+        let rs = rp[old_i];
+        let re = rp[old_i + 1];
+        let mut entries: Vec<(usize, f64)> = Vec::with_capacity(re - rs);
+        for k in rs..re {
+            let old_j = cj[k];
+            let new_j = perm.pinv[old_j];
+            entries.push((new_j, vv[k]));
+        }
+        entries.sort_unstable_by_key(|e| e.0);
+        for (j, v) in entries {
+            col_idx.push(j);
+            values.push(v);
+        }
+        row_ptr.push(col_idx.len());
+    }
+
+    CsrMatrix::from_csr(n, n, row_ptr, col_idx, values)
+}
+
+/// Reverse Cuthill-McKee ordering for a symmetric graph given by CSR matrix.
+pub fn rcm_csr(a: &CsrMatrix<f64>) -> Permutation {
+    let n = a.nrows();
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    // build symmetric adjacency list
+    let mut adj = vec![Vec::new(); n];
+    for i in 0..n {
+        for k in rp[i]..rp[i + 1] {
+            let j = cj[k];
+            if i == j { continue; }
+            adj[i].push(j);
+            adj[j].push(i);
+        }
+    }
+    for v in &mut adj {
+        v.sort_unstable();
+        v.dedup();
+    }
+
+    let degrees: Vec<usize> = adj.iter().map(|nbrs| nbrs.len()).collect();
+    for i in 0..n {
+        adj[i].sort_unstable_by(|&a, &b| degrees[a].cmp(&degrees[b]).then(a.cmp(&b)));
+    }
+
+    let mut visited = vec![false; n];
+    let mut order = Vec::with_capacity(n);
+    for start in 0..n {
+        if visited[start] { continue; }
+        // find unvisited node with smallest degree
+        let mut s = start;
+        let mut min_deg = degrees[start];
+        for i in start..n {
+            if !visited[i] && degrees[i] < min_deg {
+                min_deg = degrees[i];
+                s = i;
+            }
+        }
+        let mut queue = std::collections::VecDeque::new();
+        queue.push_back(s);
+        visited[s] = true;
+        while let Some(i) = queue.pop_front() {
+            order.push(i);
+            for &j in &adj[i] {
+                if !visited[j] {
+                    visited[j] = true;
+                    queue.push_back(j);
+                }
+            }
+        }
+    }
+    order.reverse();
+
+    let mut pinv = vec![0; n];
+    for (new, &old) in order.iter().enumerate() {
+        pinv[old] = new;
+    }
+    Permutation { p: order, pinv }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn permute_csr_symmetric_matches_dense() {
+        // 3x3 matrix
+        // [1 2 0; 0 3 4; 5 0 6]
+        let row_ptr = vec![0,2,4,6];
+        let col_idx = vec![0,1,1,2,0,2];
+        let vals = vec![1.0,2.0,3.0,4.0,5.0,6.0];
+        let a = CsrMatrix::from_csr(3,3,row_ptr,col_idx,vals);
+        let perm = Permutation{ p: vec![2,0,1], pinv: vec![1,2,0] };
+        let ap = permute_csr_symmetric(&a,&perm);
+        let dense_ap = ap.to_dense();
+        // compute dense reference
+        let dense_a = a.to_dense();
+        let mut ref_dense = faer::Mat::<f64>::zeros(3,3);
+        for i in 0..3 {
+            for j in 0..3 {
+                let old_i = perm.p[i];
+                let old_j = perm.p[j];
+                ref_dense[(i,j)] = dense_a[(old_i,old_j)];
+            }
+        }
+        for i in 0..3 {
+            for j in 0..3 {
+                assert!((dense_ap[(i,j)] - ref_dense[(i,j)]).abs() < 1e-12);
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- introduce reusable `Permutation` with CSR symmetrically permuted matrix routine and RCM orderer
- extend ILU(CSR) with reordering options and apply permutation in setup and solves

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b66dcf1f708329a7d4cd945f2cb258