### PR TITLE
Add thread-safe solve timing metrics for ILU

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ superlu3d = []
 tuning = []
 iai = []
 transpose-cache = ["dep:parking_lot"]
+metrics = []
 
 # Gate top-level re-exports of dense-direct solvers (LU/QR)
 dense-direct = []

--- a/src/preconditioner/ilu.rs
+++ b/src/preconditioner/ilu.rs
@@ -74,6 +74,7 @@ use crate::error::KError;
 use crate::matrix::sparse::CsrMatrix;
 use crate::matrix::utils;
 use crate::preconditioner::{legacy::Preconditioner, pivot::*, PcSide};
+use crate::utils::metrics::{Counters, SolveTimer};
 use faer::traits::ComplexField;
 use faer::Mat;
 use num_traits::Float;
@@ -367,8 +368,7 @@ pub struct Ilu<T> {
     running_max_u: T,
     /// Performance timing
     setup_time: f64,
-    solve_time: f64,
-    solve_count: usize,
+    solve_ctrs: Counters,
 }
 
 /// Consolidated workspace for all ILU operations to minimize allocations
@@ -480,8 +480,7 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Ilu<T> {
             row_gersh_a: Vec::new(),
             running_max_u: T::zero(),
             setup_time: 0.0,
-            solve_time: 0.0,
-            solve_count: 0,
+            solve_ctrs: Counters::new(),
         })
     }
 
@@ -1112,14 +1111,20 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Ilu<T> {
 
     /// Get factorization statistics (HYPRE-style diagnostics)
     pub fn get_stats(&self) -> IluStats {
+        let (total_ns, count, _) = self.solve_ctrs.snapshot();
+        let avg = if count == 0 {
+            0.0
+        } else {
+            (total_ns as f64) / (count as f64) / 1e9
+        };
         IluStats {
             setup_complexity: self.setup_complexity,
             nnz_l: self.nnz_l,
             nnz_u: self.nnz_u,
             num_zero_pivots: self.num_zero_pivots,
             setup_time: self.setup_time,
-            solve_time: self.solve_time,
-            solve_count: self.solve_count,
+            solve_time: avg,
+            solve_count: count as usize,
         }
     }
 
@@ -1325,8 +1330,6 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Preconditioner<M
 
     /// HYPRE-inspired apply with configurable triangular solves and zero-allocation workspace
     fn apply(&self, _side: PcSide, x: &Vec<T>, y: &mut Vec<T>) -> Result<(), KError> {
-        let solve_start = std::time::Instant::now();
-
         if x.len() != self.l.nrows() {
             return Err(KError::InvalidInput(format!(
                 "Vector length {} doesn't match matrix size {}",
@@ -1334,6 +1337,8 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Preconditioner<M
                 self.l.nrows()
             )));
         }
+
+        let timer = SolveTimer::start(&self.solve_ctrs);
 
         let n = x.len();
 
@@ -1370,11 +1375,9 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Preconditioner<M
             }
         } // workspace automatically released here
 
-        // Update timing statistics (would need interior mutability in practice)
-        let _solve_time = solve_start.elapsed().as_secs_f64();
-
         #[cfg(feature = "logging")]
         if self.config.logging_level > 2 {
+            let _solve_time = timer.elapsed().as_secs_f64();
             trace!(
                 "ILU Apply: solve_time={:.6}s, workspace_size={}",
                 _solve_time,

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -1,0 +1,83 @@
+#[cfg(feature = "metrics")]
+mod enabled {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{Duration, Instant};
+
+    pub struct Counters {
+        pub total_nanos: AtomicU64,
+        pub count: AtomicU64,
+        pub last_nanos: AtomicU64,
+    }
+
+    impl Counters {
+        pub const fn new() -> Self {
+            Self {
+                total_nanos: AtomicU64::new(0),
+                count: AtomicU64::new(0),
+                last_nanos: AtomicU64::new(0),
+            }
+        }
+
+        #[inline]
+        pub fn snapshot(&self) -> (u64, u64, u64) {
+            (
+                self.total_nanos.load(Ordering::Relaxed),
+                self.count.load(Ordering::Relaxed),
+                self.last_nanos.load(Ordering::Relaxed),
+            )
+        }
+    }
+
+    pub struct SolveTimer<'a> {
+        start: Instant,
+        ctrs: &'a Counters,
+    }
+
+    impl<'a> SolveTimer<'a> {
+        #[inline]
+        pub fn start(ctrs: &'a Counters) -> Self {
+            Self { start: Instant::now(), ctrs }
+        }
+
+        #[inline]
+        pub fn elapsed(&self) -> Duration {
+            self.start.elapsed()
+        }
+    }
+
+    impl<'a> Drop for SolveTimer<'a> {
+        #[inline]
+        fn drop(&mut self) {
+            let dt = self.start.elapsed().as_nanos() as u64;
+            self.ctrs.total_nanos.fetch_add(dt, Ordering::Relaxed);
+            self.ctrs.count.fetch_add(1, Ordering::Relaxed);
+            self.ctrs.last_nanos.store(dt, Ordering::Relaxed);
+        }
+    }
+}
+
+#[cfg(feature = "metrics")]
+pub use enabled::*;
+
+#[cfg(not(feature = "metrics"))]
+mod disabled {
+    use std::time::Duration;
+
+    pub struct Counters;
+    impl Counters {
+        pub const fn new() -> Self { Self }
+        pub fn snapshot(&self) -> (u64, u64, u64) { (0, 0, 0) }
+    }
+
+    pub struct SolveTimer<'a> { _p: core::marker::PhantomData<&'a ()> }
+    impl<'a> SolveTimer<'a> {
+        #[inline]
+        pub fn start(_: &'a Counters) -> Self { Self { _p: core::marker::PhantomData } }
+        #[inline]
+        pub fn elapsed(&self) -> Duration { Duration::ZERO }
+    }
+    impl<'a> Drop for SolveTimer<'a> { fn drop(&mut self) {} }
+}
+
+#[cfg(not(feature = "metrics"))]
+pub use disabled::*;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@ pub mod monitor;
 pub mod profiling;
 pub mod reordering;
 pub mod permutation;
+pub mod metrics;
 #[cfg(feature = "tuning")]
 pub mod tuning;
 pub mod partition;


### PR DESCRIPTION
## Summary
- introduce optional `metrics` feature with reusable `Counters` and RAII `SolveTimer`
- track average solve time and call count for ILU using atomic counters
- expose metrics module from utils for future preconditioners/solvers

## Testing
- `cargo test --no-run` *(fails: hung and was interrupted)*

------
https://chatgpt.com/codex/tasks/task_e_68b670ccd2d08329be4e00980a9246ba