### PR TITLE
Add epoch-based position map

### DIFF
--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -6,17 +6,18 @@ use crate::matrix::format::FormatHint;
 use crate::matrix::op::{LinOp, StructureId, ValuesId};
 use crate::matrix::sparse::CsrMatrix;
 use crate::preconditioner::{Op, PcCaps, PcSide, Preconditioner};
-use crate::utils::permutation::{rcm_csr, permute_csr_symmetric, Permutation};
+use crate::utils::permutation::{permute_csr_symmetric, rcm_csr, Permutation};
 use once_cell::sync::OnceCell;
 
-mod pivot;
-mod tri_solve;
-mod ilut_params;
 mod csr_builder;
+mod ilut_params;
+mod pivot;
+mod pos_map;
 mod row_work;
+mod tri_solve;
 
-pub use pivot::PivotStrategy;
 pub use ilut_params::{IlutParams, PivotPolicy, Pivoting};
+pub use pivot::PivotStrategy;
 
 use csr_builder::CsrBuilder;
 use row_work::RowWork;
@@ -119,7 +120,11 @@ pub struct ReorderingOptions {
 
 impl Default for ReorderingOptions {
     fn default() -> Self {
-        Self { kind: ReorderingKind::None, symmetric: true, deterministic: true }
+        Self {
+            kind: ReorderingKind::None,
+            symmetric: true,
+            deterministic: true,
+        }
     }
 }
 
@@ -1067,8 +1072,12 @@ impl Preconditioner for IluCsr {
                 }
             }
             Op::Trans | Op::ConjTrans => {
-                let ut = self.ut.get_or_init(|| transpose_csr(self.n, &self.u_row, &self.u_col, &self.u_val));
-                let lt = self.lt.get_or_init(|| transpose_csr(self.n, &self.l_row, &self.l_col, &self.l_val));
+                let ut = self
+                    .ut
+                    .get_or_init(|| transpose_csr(self.n, &self.u_row, &self.u_col, &self.u_val));
+                let lt = self
+                    .lt
+                    .get_or_init(|| transpose_csr(self.n, &self.l_row, &self.l_col, &self.l_val));
                 tri_solve::tri_solve_transpose_serial(
                     self,
                     &ut.0,

--- a/src/preconditioner/ilu_csr/pos_map.rs
+++ b/src/preconditioner/ilu_csr/pos_map.rs
@@ -1,0 +1,70 @@
+use std::usize;
+
+/// Position map for tracking column indices within a row during
+/// sparse factorization.
+///
+/// This structure uses epoch-based marking to provide O(1) inserts
+/// and lookups without clearing the entire map for each row.
+#[derive(Clone, Debug)]
+pub struct PosMap {
+    pos: Vec<usize>,
+    mark: Vec<u32>,
+    epoch: u32,
+}
+
+impl PosMap {
+    /// Create a new `PosMap` with capacity for `n` columns.
+    pub fn new(n: usize) -> Self {
+        Self {
+            pos: vec![usize::MAX; n],
+            mark: vec![0; n],
+            epoch: 1,
+        }
+    }
+
+    /// Advance to a new epoch, logically clearing the map.
+    #[inline]
+    pub fn clear(&mut self) {
+        self.epoch = self.epoch.wrapping_add(1);
+    }
+
+    /// Get the position associated with column `j` if it exists in the
+    /// current epoch.
+    #[inline]
+    pub fn get(&self, j: usize) -> Option<usize> {
+        if self.mark.get(j).copied().unwrap_or(0) == self.epoch {
+            Some(self.pos[j])
+        } else {
+            None
+        }
+    }
+
+    /// Set the position for column `j` to `idx` in the current epoch.
+    #[inline]
+    pub fn set(&mut self, j: usize, idx: usize) {
+        if j >= self.pos.len() {
+            let new_len = j + 1;
+            self.pos.resize(new_len, usize::MAX);
+            self.mark.resize(new_len, 0);
+        }
+        self.pos[j] = idx;
+        self.mark[j] = self.epoch;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::PosMap;
+
+    #[test]
+    fn pos_map_basic() {
+        let mut pm = PosMap::new(5);
+        assert_eq!(pm.get(2), None);
+        pm.set(2, 7);
+        assert_eq!(pm.get(2), Some(7));
+        pm.clear();
+        assert_eq!(pm.get(2), None);
+        pm.set(2, 3);
+        assert_eq!(pm.get(2), Some(3));
+    }
+}


### PR DESCRIPTION
## Summary
- add PosMap for O(1) column lookups during ILU factorizations
- wire PosMap module into ilu_csr preconditioner

## Testing
- `cargo test pos_map_basic`


------
https://chatgpt.com/codex/tasks/task_e_68b6765592f08329b782c5d0135a0694