### PR TITLE
Add deterministic reduction engine

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,7 @@ pub mod preconditioner;
 pub mod solver;
 pub mod utils;
 pub mod algebra;
+pub mod reduction;
 
 // Re-exports for convenience
 pub use config::*;
@@ -40,6 +41,7 @@ pub use error::*;
 pub use matrix::*;
 pub use utils::*;
 pub use algebra::*;
+pub use reduction::*;
 
 // Re-export SolveStats at the crate root for convenience
 pub use utils::convergence::SolveStats;

--- a/src/reduction.rs
+++ b/src/reduction.rs
@@ -1,0 +1,311 @@
+use crate::parallel::Comm;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReproMode {
+    Fast,
+    Deterministic,
+    DeterministicAccurate,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct ReductionOptions {
+    pub mode: ReproMode,
+    pub single_thread_local: bool,
+    pub chunk_len: usize,
+    pub packet_width: usize,
+}
+
+impl Default for ReductionOptions {
+    fn default() -> Self {
+        Self {
+            mode: ReproMode::Fast,
+            single_thread_local: true,
+            chunk_len: 32_768,
+            packet_width: 1,
+        }
+    }
+}
+
+pub trait Accum {
+    fn add(&mut self, x: f64);
+    fn finish(self) -> f64;
+}
+
+#[derive(Clone, Copy)]
+pub struct Kahan {
+    pub sum: f64,
+    pub c: f64,
+}
+
+impl Kahan {
+    #[inline]
+    pub fn new() -> Self {
+        Self { sum: 0.0, c: 0.0 }
+    }
+}
+
+impl Accum for Kahan {
+    #[inline]
+    fn add(&mut self, x: f64) {
+        let y = x - self.c;
+        let t = self.sum + y;
+        self.c = (t - self.sum) - y;
+        self.sum = t;
+    }
+    #[inline]
+    fn finish(self) -> f64 {
+        self.sum
+    }
+}
+
+#[derive(Clone, Copy)]
+pub struct DD {
+    pub hi: f64,
+    pub lo: f64,
+}
+
+impl DD {
+    #[inline]
+    pub fn new() -> Self {
+        Self { hi: 0.0, lo: 0.0 }
+    }
+}
+
+impl Accum for DD {
+    #[inline]
+    fn add(&mut self, x: f64) {
+        let s = self.hi + x;
+        let z = s - self.hi;
+        let e = (self.hi - (s - z)) + (x - z) + self.lo;
+        self.hi = s + e;
+        self.lo = e - (self.hi - s);
+    }
+    #[inline]
+    fn finish(self) -> f64 {
+        self.hi + self.lo
+    }
+}
+
+#[inline]
+pub fn dot_local_slice(u: &[f64], v: &[f64], mode: ReproMode) -> f64 {
+    debug_assert_eq!(u.len(), v.len());
+    match mode {
+        ReproMode::Fast => u.iter().zip(v).map(|(a, b)| a * b).sum(),
+        ReproMode::Deterministic => {
+            let mut acc = Kahan::new();
+            for (&a, &b) in u.iter().zip(v) {
+                acc.add(a * b);
+            }
+            acc.finish()
+        }
+        ReproMode::DeterministicAccurate => {
+            let mut acc = DD::new();
+            for (&a, &b) in u.iter().zip(v) {
+                acc.add(a * b);
+            }
+            acc.finish()
+        }
+    }
+}
+
+#[allow(dead_code)]
+pub fn dot_local_deterministic_parallel(
+    u: &[f64],
+    v: &[f64],
+    _chunk_len: usize,
+    mode: ReproMode,
+) -> f64 {
+    // Placeholder: currently executes serial deterministic dot.
+    // A fully parallel deterministic implementation can be added later.
+    dot_local_slice(u, v, mode)
+}
+
+#[repr(C)]
+#[derive(Clone)]
+pub struct Packet<const N: usize> {
+    pub v: [f64; N],
+}
+
+impl<const N: usize> Default for Packet<N> {
+    fn default() -> Self {
+        Self { v: [0.0; N] }
+    }
+}
+
+pub trait PacketAccum<const N: usize> {
+    fn add(&mut self, x: &Packet<N>);
+    fn finish(self) -> Packet<N>;
+}
+
+pub struct KahanP<const N: usize> {
+    sum: [f64; N],
+    c: [f64; N],
+}
+
+impl<const N: usize> KahanP<N> {
+    pub fn new() -> Self {
+        Self {
+            sum: [0.0; N],
+            c: [0.0; N],
+        }
+    }
+}
+
+impl<const N: usize> PacketAccum<N> for KahanP<N> {
+    #[inline]
+    fn add(&mut self, x: &Packet<N>) {
+        for i in 0..N {
+            let y = x.v[i] - self.c[i];
+            let t = self.sum[i] + y;
+            self.c[i] = (t - self.sum[i]) - y;
+            self.sum[i] = t;
+        }
+    }
+    #[inline]
+    fn finish(self) -> Packet<N> {
+        Packet { v: self.sum }
+    }
+}
+
+pub struct DDP<const N: usize> {
+    hi: [f64; N],
+    lo: [f64; N],
+}
+
+impl<const N: usize> DDP<N> {
+    pub fn new() -> Self {
+        Self {
+            hi: [0.0; N],
+            lo: [0.0; N],
+        }
+    }
+}
+
+impl<const N: usize> PacketAccum<N> for DDP<N> {
+    #[inline]
+    fn add(&mut self, x: &Packet<N>) {
+        for i in 0..N {
+            let s = self.hi[i] + x.v[i];
+            let z = s - self.hi[i];
+            let e = (self.hi[i] - (s - z)) + (x.v[i] - z) + self.lo[i];
+            self.hi[i] = s + e;
+            self.lo[i] = e - (self.hi[i] - s);
+        }
+    }
+    #[inline]
+    fn finish(self) -> Packet<N> {
+        let mut out = [0.0f64; N];
+        for i in 0..N {
+            out[i] = self.hi[i] + self.lo[i];
+        }
+        Packet { v: out }
+    }
+}
+
+pub trait CommDeterministic {
+    fn allreduce_det<const N: usize>(&self, local: &Packet<N>, mode: ReproMode) -> Packet<N>;
+}
+
+use crate::parallel::UniverseComm;
+
+impl CommDeterministic for UniverseComm {
+    fn allreduce_det<const N: usize>(&self, local: &Packet<N>, mode: ReproMode) -> Packet<N> {
+        if matches!(mode, ReproMode::Fast) {
+            let mut tmp = local.clone();
+            self.allreduce_sum_slice(&mut tmp.v);
+            return tmp;
+        }
+        let size = self.size();
+        let rank = self.rank();
+        if size == 1 {
+            return local.clone();
+        }
+        if rank == 0 {
+            match mode {
+                ReproMode::DeterministicAccurate => {
+                    let mut acc = DDP::<N>::new();
+                    acc.add(local);
+                    for src in 1..size {
+                        let mut buf = Packet::<N>::default();
+                        let mut r = self.irecv_from(&mut buf.v, src as i32);
+                        self.wait_all(std::slice::from_mut(&mut r));
+                        acc.add(&buf);
+                    }
+                    let total = acc.finish();
+                    for dest in 1..size {
+                        let mut s = self.isend_to(&total.v, dest as i32);
+                        self.wait_all(std::slice::from_mut(&mut s));
+                    }
+                    total
+                }
+                _ => {
+                    let mut acc = KahanP::<N>::new();
+                    acc.add(local);
+                    for src in 1..size {
+                        let mut buf = Packet::<N>::default();
+                        let mut r = self.irecv_from(&mut buf.v, src as i32);
+                        self.wait_all(std::slice::from_mut(&mut r));
+                        acc.add(&buf);
+                    }
+                    let total = acc.finish();
+                    for dest in 1..size {
+                        let mut s = self.isend_to(&total.v, dest as i32);
+                        self.wait_all(std::slice::from_mut(&mut s));
+                    }
+                    total
+                }
+            }
+        } else {
+            let mut s = self.isend_to(&local.v, 0);
+            self.wait_all(std::slice::from_mut(&mut s));
+            let mut buf = Packet::<N>::default();
+            let mut r = self.irecv_from(&mut buf.v, 0);
+            self.wait_all(std::slice::from_mut(&mut r));
+            buf
+        }
+    }
+}
+
+pub struct DotEngine {
+    pub opts: ReductionOptions,
+}
+
+impl Default for DotEngine {
+    fn default() -> Self {
+        Self {
+            opts: ReductionOptions::default(),
+        }
+    }
+}
+
+impl DotEngine {
+    pub fn dot<C: Comm + CommDeterministic>(
+        &self,
+        u: &[f64],
+        v: &[f64],
+        comm: &C,
+    ) -> f64 {
+        let local = if self.opts.mode == ReproMode::Fast {
+            u.iter().zip(v).map(|(a, b)| a * b).sum()
+        } else if self.opts.single_thread_local {
+            dot_local_slice(u, v, self.opts.mode)
+        } else {
+            dot_local_deterministic_parallel(u, v, self.opts.chunk_len, self.opts.mode)
+        };
+        let packet = Packet::<1> { v: [local] };
+        let g = comm.allreduce_det(&packet, self.opts.mode);
+        g.v[0]
+    }
+
+    pub fn dot2<C: Comm + CommDeterministic>(
+        &self,
+        a: f64,
+        b: f64,
+        comm: &C,
+    ) -> (f64, f64) {
+        let packet = Packet::<2> { v: [a, b] };
+        let g = comm.allreduce_det(&packet, self.opts.mode);
+        (g.v[0], g.v[1])
+    }
+}
+

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -2,6 +2,7 @@ use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::parallel::{Comm, UniverseComm};
+use crate::reduction::{CommDeterministic, DotEngine, ReductionOptions, ReproMode};
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
@@ -23,7 +24,7 @@ pub enum CgNormType {
 pub struct PcgSolver {
     pub(crate) conv: Convergence<f64>,
     norm_type: CgNormType,
-    reproducible: bool,
+    reduction: ReductionOptions,
     true_residual_monitor: Option<Box<dyn Fn(usize, f64) + Send + Sync>>,
     /// Whether the initial guess in `x` should be treated as nonzero.
     ///
@@ -43,8 +44,8 @@ impl PcgSolver {
                 dtol: 1e5,
                 max_iters: maxits,
             },
-            norm_type: CgNormType::Preconditioned,
-            reproducible: false,
+              norm_type: CgNormType::Preconditioned,
+              reduction: ReductionOptions::default(),
             true_residual_monitor: None,
             initial_guess_nonzero: false,
         }
@@ -66,10 +67,10 @@ impl PcgSolver {
     /// Enable a more reproducible (but slightly slower) local dot product using
     /// Kahan summation. When combined with a deterministic MPI reduction this
     /// yields bitwise-identical results across runs.
-    pub fn with_reproducible_dot(mut self, f: bool) -> Self {
-        self.reproducible = f;
-        self
-    }
+      pub fn with_reproducible_dot(mut self, f: bool) -> Self {
+          self.reduction.mode = if f { ReproMode::Deterministic } else { ReproMode::Fast };
+          self
+      }
 
     /// Install a monitor that receives the true residual norm `||b - A x||₂`
     /// at each iteration. This uses the already available residual and is
@@ -95,9 +96,9 @@ impl PcgSolver {
     }
 
     /// Toggle reproducible local dot products after construction.
-    pub fn set_reproducible_dot(&mut self, f: bool) {
-        self.reproducible = f;
-    }
+      pub fn set_reproducible_dot(&mut self, f: bool) {
+          self.reduction.mode = if f { ReproMode::Deterministic } else { ReproMode::Fast };
+      }
 
     /// Set or clear the true residual monitor after construction.
     pub fn set_true_residual_monitor(&mut self, m: Option<Box<dyn Fn(usize, f64) + Send + Sync>>) {
@@ -105,41 +106,18 @@ impl PcgSolver {
     }
 
     #[inline]
-    fn dot<C: Comm>(&self, u: &[f64], v: &[f64], comm: &C) -> f64 {
-        if self.reproducible {
-            let local = Self::local_dot_kahan(u, v);
-            if comm.size() == 1 {
-                local
-            } else {
-                comm.allreduce_sum(local)
-            }
-        } else {
-            comm.dot(u, v)
-        }
-    }
+      fn dot<C: Comm + CommDeterministic>(&self, u: &[f64], v: &[f64], comm: &C) -> f64 {
+          let engine = DotEngine {
+              opts: self.reduction,
+          };
+          engine.dot(u, v, comm)
+      }
+
 
     #[inline]
-    fn local_dot(u: &[f64], v: &[f64]) -> f64 {
-        u.iter().zip(v).map(|(a, b)| a * b).sum::<f64>()
-    }
-
-    #[inline]
-    fn local_dot_kahan(u: &[f64], v: &[f64]) -> f64 {
-        let mut sum = 0.0f64;
-        let mut c = 0.0f64;
-        for (a, b) in u.iter().zip(v.iter()) {
-            let y = a * b - c;
-            let t = sum + y;
-            c = (t - sum) - y;
-            sum = t;
-        }
-        sum
-    }
-
-    #[inline]
-    fn nrm2<C: Comm>(&self, u: &[f64], comm: &C) -> f64 {
-        self.dot(u, u, comm).sqrt()
-    }
+      fn nrm2<C: Comm + CommDeterministic>(&self, u: &[f64], comm: &C) -> f64 {
+          self.dot(u, u, comm).sqrt()
+      }
 
     fn take_or_resize(buf: &mut Vec<f64>, n: usize) {
         if buf.len() != n {
@@ -148,7 +126,7 @@ impl PcgSolver {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn solve_with_comm<C: Comm>(
+      pub fn solve_with_comm<C: Comm + CommDeterministic>(
         &mut self,
         a: &dyn LinOp<S = f64>,
         pc: Option<&mut dyn Preconditioner>,
@@ -163,7 +141,7 @@ impl PcgSolver {
     }
 
     #[allow(clippy::too_many_arguments)]
-    fn solve_impl<C: Comm>(
+      fn solve_impl<C: Comm + CommDeterministic>(
         &mut self,
         a: &dyn LinOp<S = f64>,
         pc: Option<&mut dyn Preconditioner>,

--- a/tests/support/reduce_counter.rs
+++ b/tests/support/reduce_counter.rs
@@ -1,6 +1,7 @@
 use std::sync::{Arc, atomic::{AtomicUsize, Ordering}};
 
 use kryst::parallel::{Comm, UniverseComm};
+use kryst::reduction::{CommDeterministic, Packet, ReproMode};
 
 #[derive(Clone)]
 pub struct CountingComm<C> {
@@ -80,5 +81,12 @@ impl<C: Comm + Clone> Comm for CountingComm<C> {
 
     fn wait_all<'a>(&self, reqs: &mut [Self::Request<'a>]) {
         self.inner.wait_all(reqs)
+    }
+}
+
+impl<C: Comm + CommDeterministic + Clone> CommDeterministic for CountingComm<C> {
+    fn allreduce_det<const N: usize>(&self, local: &Packet<N>, mode: ReproMode) -> Packet<N> {
+        self.reduces.fetch_add(1, Ordering::Relaxed);
+        self.inner.allreduce_det(local, mode)
     }
 }


### PR DESCRIPTION
## Summary
- introduce reduction module with reproducible dot products and deterministic MPI-style reductions
- wire PCG solver through new DotEngine options
- track reductions in test CountingComm

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b683083cd88329991047a8963b9942