### PR TITLE
Add structured ILU options and builder

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,6 +161,9 @@ name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b8e56985ec62d17e9c1001dc89c88ecd7dc08e47eba5ec7c29c7b5eeecde967"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "block-buffer"
@@ -289,7 +292,7 @@ checksum = "4ea181bf566f71cb9a5d17a59e1871af638180a18fb0035c92ae62b705207123"
 dependencies = [
  "bitflags 1.3.2",
  "clap_lex",
- "indexmap",
+ "indexmap 1.9.3",
  "textwrap",
 ]
 
@@ -567,6 +570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "equivalent"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+
+[[package]]
 name = "errno"
 version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -840,6 +849,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
+name = "hashbrown"
+version = "0.15.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+
+[[package]]
 name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -912,7 +927,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
- "hashbrown",
+ "hashbrown 0.12.3",
+]
+
+[[package]]
+name = "indexmap"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2481980430f9f78649238835720ddccc57e52df14ffce1c6f37391d61b563e9"
+dependencies = [
+ "equivalent",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1005,6 +1030,7 @@ dependencies = [
  "smallvec",
  "tempfile",
  "thiserror 1.0.69",
+ "toml",
 ]
 
 [[package]]
@@ -1885,6 +1911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2048,6 +2083,47 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap 2.11.0",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tracing"
@@ -2525,6 +2601,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen-rt"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,9 +28,10 @@ doctest = false
 faer = "0.22.6"
 num-traits = "0.2"
 thiserror = "1.0"
-bitflags = "2.9.1"
+bitflags = { version = "2.9.1", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
+toml = "0.8"
 rayon = { version = "1.0", optional = true }
 mpi = { version = "0.8", optional = true }
 num_cpus = { version = "1.0", optional = true }
@@ -60,6 +61,7 @@ tuning = []
 iai = []
 transpose-cache = ["dep:parking_lot"]
 metrics = []
+amd = []
 
 # Gate top-level re-exports of dense-direct solvers (LU/QR)
 dense-direct = []

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 use crate::config::options_core::{Sink, Spec, expand_options_files, parse_as};
 use crate::config::options_core::is_help_requested;
 use crate::config::registry::registry;
+use crate::preconditioner::ilu_options::{IluOptions, IluKind, ReorderingType, TriSolveType, PivotPolicy, IterativeSetupType, Overlay};
 
 /// KSP (Krylov Solver) options.
 #[derive(Debug, Default, Clone)]
@@ -135,6 +136,8 @@ pub struct PcOptions {
     pub ilu_pivot_monitoring: Option<bool>,
     pub ilu_optimize_workspace: Option<bool>,
     pub ilu_pivot_threshold: Option<f64>,
+    /// Structured ILU options (new schema).
+    pub ilu: IluOptions,
     // ---- Approximate inverse (CSR) ----
     pub approxinv_kind: Option<String>,        // "fsai" | "spai"
     pub approxinv_levels: Option<usize>,
@@ -394,43 +397,83 @@ impl Sink for PcOptions {
                 set_opt!(&mut self.amg_min_iterations, parse_as::<usize>(v, spec)?)
             }
             "pc_chain" => set_opt!(&mut self.pc_chain, v.to_string()),
-            "pc_ilu_type" => set_opt!(&mut self.ilu_type, v.to_lowercase()),
+            "pc_ilu_type" => {
+                set_opt!(&mut self.ilu_type, v.to_lowercase())?;
+                self.update_ilu_kind();
+                Ok(())
+            }
             "pc_ilu_level_of_fill" => {
-                set_opt!(&mut self.ilu_level_of_fill, parse_as::<usize>(v, spec)?)
+                let val = parse_as::<usize>(v, spec)?;
+                set_opt!(&mut self.ilu_level_of_fill, val)?;
+                self.update_ilu_kind();
+                Ok(())
             }
             "pc_ilu_max_fill_per_row" => {
-                set_opt!(&mut self.ilu_max_fill_per_row, parse_as::<usize>(v, spec)?)
+                let val = parse_as::<usize>(v, spec)?;
+                set_opt!(&mut self.ilu_max_fill_per_row, val)?;
+                self.update_ilu_kind();
+                Ok(())
             }
-            "pc_ilu_offdiag_drop_tolerance" => set_opt!(
-                &mut self.ilu_offdiag_drop_tolerance,
-                parse_as::<f64>(v, spec)?
-            ),
-            "pc_ilu_schur_drop_tolerance" => set_opt!(
-                &mut self.ilu_schur_drop_tolerance,
-                parse_as::<f64>(v, spec)?
-            ),
-            "pc_ilu_reordering_type" => set_opt!(&mut self.ilu_reordering_type, v.to_lowercase()),
-            "pc_ilu_triangular_solve" => set_opt!(&mut self.ilu_triangular_solve, v.to_lowercase()),
-            "pc_ilu_lower_jacobi_iters" => set_opt!(
-                &mut self.ilu_lower_jacobi_iters,
-                parse_as::<usize>(v, spec)?
-            ),
-            "pc_ilu_upper_jacobi_iters" => set_opt!(
-                &mut self.ilu_upper_jacobi_iters,
-                parse_as::<usize>(v, spec)?
-            ),
-            "pc_ilu_tolerance" => set_opt!(&mut self.ilu_tolerance, parse_as::<f64>(v, spec)?),
+            "pc_ilu_offdiag_drop_tolerance" => {
+                let val = parse_as::<f64>(v, spec)?;
+                set_opt!(&mut self.ilu_offdiag_drop_tolerance, val)?;
+                self.update_ilu_kind();
+                Ok(())
+            }
+            "pc_ilu_schur_drop_tolerance" => {
+                let val = parse_as::<f64>(v, spec)?;
+                set_opt!(&mut self.ilu_schur_drop_tolerance, val)?;
+                self.update_ilu_schur();
+                Ok(())
+            }
+            "pc_ilu_reordering_type" => {
+                set_opt!(&mut self.ilu_reordering_type, v.to_lowercase())?;
+                self.update_ilu_reordering();
+                Ok(())
+            }
+            "pc_ilu_triangular_solve" => {
+                set_opt!(&mut self.ilu_triangular_solve, v.to_lowercase())?;
+                self.update_ilu_tri_solve();
+                Ok(())
+            }
+            "pc_ilu_lower_jacobi_iters" => {
+                let val = parse_as::<usize>(v, spec)?;
+                set_opt!(&mut self.ilu_lower_jacobi_iters, val)?;
+                self.update_ilu_tri_solve();
+                Ok(())
+            }
+            "pc_ilu_upper_jacobi_iters" => {
+                let val = parse_as::<usize>(v, spec)?;
+                set_opt!(&mut self.ilu_upper_jacobi_iters, val)?;
+                self.update_ilu_tri_solve();
+                Ok(())
+            }
+            "pc_ilu_tolerance" => {
+                let val = parse_as::<f64>(v, spec)?;
+                set_opt!(&mut self.ilu_tolerance, val)?;
+                self.update_ilu_iterative();
+                Ok(())
+            }
             "pc_ilu_max_iterations" => {
-                set_opt!(&mut self.ilu_max_iterations, parse_as::<usize>(v, spec)?)
+                let val = parse_as::<usize>(v, spec)?;
+                set_opt!(&mut self.ilu_max_iterations, val)?;
+                self.update_ilu_iterative();
+                Ok(())
             }
             "pc_ilu_logging_level" => {
-                set_opt!(&mut self.ilu_logging_level, parse_as::<usize>(v, spec)?)
+                let val = parse_as::<usize>(v, spec)?;
+                set_opt!(&mut self.ilu_logging_level, val)?;
+                self.update_ilu_logging();
+                Ok(())
             }
             "pc_ilu_print_level" => {
                 set_opt!(&mut self.ilu_print_level, parse_as::<usize>(v, spec)?)
             }
             "pc_ilu_pivot_threshold" => {
-                set_opt!(&mut self.ilu_pivot_threshold, parse_as::<f64>(v, spec)?)
+                let val = parse_as::<f64>(v, spec)?;
+                set_opt!(&mut self.ilu_pivot_threshold, val)?;
+                self.update_ilu_pivot();
+                Ok(())
             }
             "pc_superlu_pivot_threshold" => {
                 set_opt!(&mut self.superlu_pivot_threshold, parse_as::<f64>(v, spec)?)
@@ -648,6 +691,90 @@ impl KspOptions {
 }
 
 impl PcOptions {
+    fn update_ilu_kind(&mut self) {
+        if let Some(ref ty) = self.ilu_type {
+            match ty.as_str() {
+                "ilu0" => self.ilu.kind = IluKind::ILU0,
+                "iluk" => {
+                    let k = self.ilu_level_of_fill.unwrap_or(0) as u32;
+                    self.ilu.kind = IluKind::ILUK { k };
+                }
+                "ilut" => {
+                    let droptol = self.ilu_offdiag_drop_tolerance.unwrap_or(0.0);
+                    let max_fill = self.ilu_max_fill_per_row.unwrap_or(0) as u32;
+                    self.ilu.kind = IluKind::ILUT { droptol, max_fill_per_row: max_fill };
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn update_ilu_reordering(&mut self) {
+        if let Some(ref t) = self.ilu_reordering_type {
+            self.ilu.reordering = match t.as_str() {
+                "none" | "natural" => ReorderingType::None,
+                "rcm" => ReorderingType::RCM,
+                "amd" => ReorderingType::AMD,
+                _ => self.ilu.reordering,
+            };
+        }
+    }
+
+    fn update_ilu_tri_solve(&mut self) {
+        if let Some(ref t) = self.ilu_triangular_solve {
+            if t == "iterative" {
+                let l = self.ilu_lower_jacobi_iters.unwrap_or(0) as u32;
+                let u = self.ilu_upper_jacobi_iters.unwrap_or(0) as u32;
+                self.ilu.tri_solve.kind = TriSolveType::Iterative { lower_jacobi_iters: l, upper_jacobi_iters: u };
+            } else {
+                self.ilu.tri_solve.kind = TriSolveType::Exact;
+            }
+        }
+    }
+
+    fn update_ilu_iterative(&mut self) {
+        if let Some(tol) = self.ilu_tolerance {
+            self.ilu.iterative_setup.tol = tol;
+            if matches!(self.ilu.iterative_setup.ty, IterativeSetupType::Disabled) {
+                self.ilu.iterative_setup.ty = IterativeSetupType::ParILUFixedPoint;
+            }
+        }
+        if let Some(maxit) = self.ilu_max_iterations {
+            self.ilu.iterative_setup.max_iter = maxit as u32;
+            if matches!(self.ilu.iterative_setup.ty, IterativeSetupType::Disabled) {
+                self.ilu.iterative_setup.ty = IterativeSetupType::ParILUFixedPoint;
+            }
+        }
+    }
+
+    fn update_ilu_logging(&mut self) {
+        if let Some(level) = self.ilu_logging_level {
+            self.ilu.logging_level = level as u8;
+        }
+    }
+
+    fn update_ilu_pivot(&mut self) {
+        if let Some(tau) = self.ilu_pivot_threshold {
+            self.ilu.pivot = PivotPolicy::Threshold { tau };
+        }
+    }
+
+    fn update_ilu_schur(&mut self) {
+        if let Some(dt) = self.ilu_schur_drop_tolerance {
+            self.ilu.schur.droptol_s = dt;
+        }
+    }
+
+    fn sync_ilu_all(&mut self) {
+        self.update_ilu_kind();
+        self.update_ilu_reordering();
+        self.update_ilu_tri_solve();
+        self.update_ilu_iterative();
+        self.update_ilu_logging();
+        self.update_ilu_pivot();
+        self.update_ilu_schur();
+    }
+
     pub fn new() -> Self {
         Self::default()
     }
@@ -666,6 +793,7 @@ impl PcOptions {
         if let Some(ref t) = me.amg_relax_type { kinds::AmgRelaxKind::from_str(t)?; }
         if let Some(ref t) = me.asm_block_solver { kinds::AsmBlockSolverKind::from_str(t)?; }
         if let Some(ref t) = me.asm_mode { kinds::AsmModeKind::from_str(t)?; }
+        me.sync_ilu_all();
         Ok(me)
     }
 
@@ -714,6 +842,7 @@ impl PcOptions {
         if let Ok(v) = std::env::var("KRYST_PC_SCALING") {
             me.scaling = Some(v.to_lowercase());
         }
+        me.sync_ilu_all();
         Ok(me)
     }
 }
@@ -879,6 +1008,8 @@ pub fn parse_all_options(args: &[String]) -> Result<(KspOptions, PcOptions), KEr
         superlu_preallocation_strategy,
     );
 
+    pc_opts.ilu = pc_opts.ilu.overlay(&cli_pc.ilu);
+
     Ok((ksp_opts, pc_opts))
 }
 
@@ -888,6 +1019,7 @@ pub fn parse_all_options(args: &[String]) -> Result<(KspOptions, PcOptions), KEr
 mod tests {
     use super::*;
     use crate::error::KError;
+    use crate::preconditioner::ilu_options::{IluKind, ReorderingType, TriSolveType, PivotPolicy};
 
     #[test]
     fn ksp_bool_toggle() {
@@ -1571,6 +1703,13 @@ mod old_tests {
         assert_eq!(opts.ilu_pivot_monitoring, Some(false));
         assert_eq!(opts.ilu_optimize_workspace, Some(true));
         assert_eq!(opts.ilu_pivot_threshold, Some(1e-10));
+        assert!(matches!(opts.ilu.kind, IluKind::ILUT { droptol, max_fill_per_row } if (droptol - 1e-5).abs() < 1e-12 && max_fill_per_row == 50));
+        assert_eq!(opts.ilu.reordering, ReorderingType::RCM);
+        assert!(matches!(opts.ilu.tri_solve.kind, TriSolveType::Iterative { lower_jacobi_iters: 2, upper_jacobi_iters: 3 }));
+        assert!((opts.ilu.iterative_setup.tol - 1e-8).abs() < 1e-12);
+        assert_eq!(opts.ilu.iterative_setup.max_iter, 10);
+        assert_eq!(opts.ilu.logging_level, 2);
+        assert!(matches!(opts.ilu.pivot, PivotPolicy::Threshold { tau } if (tau - 1e-10).abs() < 1e-12));
     }
 
     #[test]
@@ -1652,6 +1791,8 @@ mod old_tests {
         assert_eq!(opts.pc_type, Some("ilu".to_string()));
         assert_eq!(opts.ilu_type, Some("ilu0".to_string()));
         assert_eq!(opts.ilu_reordering_type, Some("none".to_string()));
+        assert!(matches!(opts.ilu.kind, IluKind::ILU0));
+        assert_eq!(opts.ilu.reordering, ReorderingType::None);
     }
 
     #[test]

--- a/src/preconditioner/ilu_options.rs
+++ b/src/preconditioner/ilu_options.rs
@@ -1,0 +1,421 @@
+//! ILU configuration options and builders.
+//!
+//! This module provides a stable, serde-friendly configuration surface for the
+//! ILU preconditioner family.  It mirrors the design sketched in the
+//! user-facing Step 5 API and focuses on the option schema, layering via an
+//! `Overlay` trait, validation/derived defaults through `resolve`, and simple
+//! serialization helpers.  Runtime wiring into the various ILU engines will be
+//! completed in subsequent steps.
+
+use bitflags::bitflags;
+use serde::{Deserialize, Serialize};
+
+use crate::error::KError;
+
+/// Reordering strategies for ILU.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReorderingType {
+    None,
+    RCM,
+    AMD,
+}
+
+bitflags! {
+    /// Miscellaneous feature toggles for iterative ParILU setup.
+    #[derive(Serialize, Deserialize, PartialEq, Eq, Clone, Copy, Debug)]
+    pub struct IterativeSetupBits: u32 {
+        const DAMPING_AUTO  = 1 << 0;
+        const REPRODUCIBLE  = 1 << 1;
+        const TRACE_HISTORY = 1 << 2;
+        const PIVOT_STAB    = 1 << 3;
+        const OVERLAP_COMM  = 1 << 4;
+    }
+}
+
+/// Iterative setup strategies.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum IterativeSetupType {
+    Disabled,
+    ParILUFixedPoint,
+}
+
+/// Triangular solve strategies.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum TriSolveType {
+    Exact,
+    Iterative {
+        lower_jacobi_iters: u32,
+        upper_jacobi_iters: u32,
+    },
+}
+
+/// ILU kind.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum IluKind {
+    ILU0,
+    ILUK { k: u32 },
+    ILUT { droptol: f64, max_fill_per_row: u32 },
+}
+
+/// Pivoting policy.
+#[derive(Clone, Copy, Debug, PartialEq, Serialize, Deserialize)]
+pub enum PivotPolicy {
+    Strict,
+    Threshold { tau: f64 },
+    DiagPerturb { eta: f64 },
+}
+
+/// Reduction/reproducibility mode.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReproMode {
+    Fast,
+    Deterministic,
+    DeterministicAccurate,
+}
+
+/// Configuration for Schur complement handling.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct SchurConfig {
+    pub enable: bool,
+    pub droptol_b: f64,
+    pub droptol_ef: f64,
+    pub droptol_s: f64,
+    pub max_row_nnz: u32,
+}
+
+impl Default for SchurConfig {
+    fn default() -> Self {
+        Self {
+            enable: false,
+            droptol_b: 1e-4,
+            droptol_ef: 1e-4,
+            droptol_s: 1e-4,
+            max_row_nnz: 64,
+        }
+    }
+}
+
+/// Configuration for ParILU fixed-point iterations.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IterativeSetupConfig {
+    pub ty: IterativeSetupType,
+    pub tol: f64,
+    pub max_iter: u32,
+    pub option_bits: IterativeSetupBits,
+    pub keep_history: bool,
+}
+
+impl Default for IterativeSetupConfig {
+    fn default() -> Self {
+        Self {
+            ty: IterativeSetupType::Disabled,
+            tol: 1e-2,
+            max_iter: 10,
+            option_bits: IterativeSetupBits::PIVOT_STAB,
+            keep_history: false,
+        }
+    }
+}
+
+/// Configuration for triangular solve phase.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct TriSolveConfig {
+    pub kind: TriSolveType,
+}
+
+impl Default for TriSolveConfig {
+    fn default() -> Self {
+        Self {
+            kind: TriSolveType::Exact,
+        }
+    }
+}
+
+/// Execution toggles governing parallel/distributed paths.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ExecutionToggles {
+    pub enable_parallel_factorization: bool,
+    pub enable_parallel_triangular_solve: bool,
+    pub enable_distributed: bool,
+}
+
+impl Default for ExecutionToggles {
+    fn default() -> Self {
+        Self {
+            enable_parallel_factorization: false,
+            enable_parallel_triangular_solve: true,
+            enable_distributed: false,
+        }
+    }
+}
+
+/// Options for reproducible reductions.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct ReductionOptions {
+    pub mode: ReproMode,
+    pub single_thread_local: bool,
+    pub chunk_len: usize,
+    pub packet_width: usize,
+}
+
+impl Default for ReductionOptions {
+    fn default() -> Self {
+        Self {
+            mode: ReproMode::Fast,
+            single_thread_local: true,
+            chunk_len: 32_768,
+            packet_width: 2,
+        }
+    }
+}
+
+/// Top-level ILU options exposed publicly.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct IluOptions {
+    pub kind: IluKind,
+    pub reordering: ReorderingType,
+    pub iterative_setup: IterativeSetupConfig,
+    pub tri_solve: TriSolveConfig,
+    pub schur: SchurConfig,
+    pub exec: ExecutionToggles,
+    pub pivot: PivotPolicy,
+    pub reductions: ReductionOptions,
+    pub logging_level: u8,
+}
+
+impl Default for IluOptions {
+    fn default() -> Self {
+        Self {
+            kind: IluKind::ILU0,
+            reordering: ReorderingType::RCM,
+            iterative_setup: IterativeSetupConfig::default(),
+            tri_solve: TriSolveConfig::default(),
+            schur: SchurConfig::default(),
+            exec: ExecutionToggles::default(),
+            pivot: PivotPolicy::DiagPerturb { eta: 1e-10 },
+            reductions: ReductionOptions::default(),
+            logging_level: 0,
+        }
+    }
+}
+
+/// Overlay trait for hierarchical option resolution.
+pub trait Overlay {
+    fn overlay(self, top: &Self) -> Self;
+}
+
+impl Overlay for IluOptions {
+    fn overlay(mut self, top: &Self) -> Self {
+        // Shallow overlay—`top` replaces `self`.
+        self.kind = top.kind;
+        self.reordering = top.reordering;
+        self.iterative_setup = top.iterative_setup.clone();
+        self.tri_solve = top.tri_solve.clone();
+        self.schur = top.schur.clone();
+        self.exec = top.exec.clone();
+        self.pivot = top.pivot;
+        self.reductions = top.reductions.clone();
+        self.logging_level = top.logging_level;
+        self
+    }
+}
+
+/// Resolved options after validation and derived defaults.
+#[derive(Clone, Debug, PartialEq)]
+pub struct ResolvedIluOptions {
+    pub o: IluOptions,
+}
+
+impl IluOptions {
+    /// Validate and derive smart defaults, returning a resolved set of options.
+    pub fn resolve(self, matrix_is_distributed: bool) -> Result<ResolvedIluOptions, KError> {
+        // Reordering feature gate.
+        if matches!(self.reordering, ReorderingType::AMD) && !cfg!(feature = "amd") {
+            return Err(KError::InvalidInput(
+                "AMD reordering requested but 'amd' feature not enabled".into(),
+            ));
+        }
+
+        // Derived behavior #1: ILUK/ILUT imply ParILU unless explicitly set.
+        let mut it = self.iterative_setup.clone();
+        if matches!(self.kind, IluKind::ILUK { .. } | IluKind::ILUT { .. })
+            && matches!(it.ty, IterativeSetupType::Disabled)
+        {
+            it.ty = IterativeSetupType::ParILUFixedPoint;
+            it.option_bits.insert(IterativeSetupBits::PIVOT_STAB);
+        }
+
+        // Derived behavior #2: enforce distributed toggles.
+        let mut exec = self.exec.clone();
+        if matrix_is_distributed {
+            exec.enable_distributed = true;
+            exec.enable_parallel_factorization = true;
+            exec.enable_parallel_triangular_solve = true;
+        }
+
+        let tol = it.tol.clamp(1e-16, 1.0);
+        let max_iter = it.max_iter.max(1);
+
+        let pivot = match self.pivot {
+            PivotPolicy::Strict => PivotPolicy::Strict,
+            PivotPolicy::Threshold { tau } => PivotPolicy::Threshold { tau: tau.max(0.0) },
+            PivotPolicy::DiagPerturb { eta } => {
+                PivotPolicy::DiagPerturb { eta: eta.max(0.0) }
+            }
+        };
+
+        let reductions = prefer_repro_in_ci(self.reductions.clone());
+
+        let keep_history = it.keep_history
+            || it.option_bits.contains(IterativeSetupBits::TRACE_HISTORY);
+
+        let o2 = IluOptions {
+            iterative_setup: IterativeSetupConfig {
+                ty: it.ty,
+                tol,
+                max_iter,
+                option_bits: it.option_bits,
+                keep_history,
+            },
+            exec,
+            pivot,
+            reductions,
+            ..self
+        };
+
+        Ok(ResolvedIluOptions { o: o2 })
+    }
+}
+
+fn prefer_repro_in_ci(mut r: ReductionOptions) -> ReductionOptions {
+    if std::env::var("KRYST_REPRO").is_ok() || std::env::var("CI").is_ok() {
+        r.mode = ReproMode::Deterministic;
+    }
+    r
+}
+
+impl IluOptions {
+    /// Parse options from a TOML string.
+    pub fn from_toml_str(s: &str) -> Result<Self, KError> {
+        toml::from_str(s).map_err(|e| KError::InvalidInput(e.to_string()))
+    }
+
+    /// Serialize options to a TOML string.
+    pub fn to_toml(&self) -> Result<String, KError> {
+        toml::to_string_pretty(self).map_err(|e| KError::InvalidInput(e.to_string()))
+    }
+}
+
+/// Simple builder façade over [`IluOptions`].
+#[derive(Clone, Debug)]
+pub struct IluBuilder {
+    opts: IluOptions,
+}
+
+impl IluBuilder {
+    pub fn new() -> Self {
+        Self {
+            opts: IluOptions::default(),
+        }
+    }
+
+    pub fn ilu_kind(mut self, kind: IluKind) -> Self {
+        self.opts.kind = kind;
+        self
+    }
+
+    pub fn reordering(mut self, r: ReorderingType) -> Self {
+        self.opts.reordering = r;
+        self
+    }
+
+    pub fn iterative_setup(mut self, f: impl FnOnce(&mut IterativeSetupConfig)) -> Self {
+        f(&mut self.opts.iterative_setup);
+        self
+    }
+
+    pub fn tri_solve(mut self, kind: TriSolveType) -> Self {
+        self.opts.tri_solve.kind = kind;
+        self
+    }
+
+    pub fn schur(mut self, f: impl FnOnce(&mut SchurConfig)) -> Self {
+        f(&mut self.opts.schur);
+        self
+    }
+
+    pub fn exec(mut self, f: impl FnOnce(&mut ExecutionToggles)) -> Self {
+        f(&mut self.opts.exec);
+        self
+    }
+
+    pub fn reductions(mut self, f: impl FnOnce(&mut ReductionOptions)) -> Self {
+        f(&mut self.opts.reductions);
+        self
+    }
+
+    pub fn pivot(mut self, p: PivotPolicy) -> Self {
+        self.opts.pivot = p;
+        self
+    }
+
+    pub fn logging_level(mut self, level: u8) -> Self {
+        self.opts.logging_level = level;
+        self
+    }
+
+    pub fn build(self) -> IluOptions {
+        self.opts
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn derived_parilu_for_iluk() {
+        let opts = IluOptions {
+            kind: IluKind::ILUK { k: 2 },
+            ..Default::default()
+        };
+        let resolved = opts.resolve(false).unwrap();
+        assert!(matches!(
+            resolved.o.iterative_setup.ty,
+            IterativeSetupType::ParILUFixedPoint
+        ));
+        assert!(resolved
+            .o
+            .iterative_setup
+            .option_bits
+            .contains(IterativeSetupBits::PIVOT_STAB));
+    }
+
+    #[test]
+    #[cfg(not(feature = "amd"))]
+    fn amd_requires_feature() {
+        let opts = IluOptions {
+            reordering: ReorderingType::AMD,
+            ..Default::default()
+        };
+        let err = opts.resolve(false).unwrap_err();
+        match err {
+            KError::InvalidInput(msg) => {
+                assert!(msg.contains("amd"));
+            }
+            other => panic!("unexpected error: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn serde_roundtrip() {
+        let opts = IluOptions {
+            logging_level: 1,
+            ..Default::default()
+        };
+        let toml = opts.to_toml().unwrap();
+        let parsed = IluOptions::from_toml_str(&toml).unwrap();
+        assert_eq!(opts, parsed);
+    }
+}
+

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -382,6 +382,7 @@ pub mod builders;
 pub mod chain;
 pub mod chebyshev;
 pub mod direct;
+pub mod ilu_options;
 pub mod ilu;
 pub mod ilup;
 pub mod ilut;


### PR DESCRIPTION
## Summary
- introduce serde-friendly ILU option schema with enums, bitflags and defaults
- add resolve method for derived defaults and feature validation
- provide builder API and overlay trait for hierarchical configuration
- wire command-line ILU flags into structured `IluOptions`

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_68b6853806888329b29ce802ca1688f1