### PR TITLE
Introduce reusable buffer pool and halo plan scaffolding

### DIFF
--- a/src/context/ksp_context/workspace.rs
+++ b/src/context/ksp_context/workspace.rs
@@ -15,6 +15,10 @@ pub struct Workspace {
     pub sn: Vec<f64>,
     pub g: Vec<f64>,
     pub blk_scratch: Vec<f64>,
+    // Shared communication arenas
+    pub send_arena: crate::utils::buffer_pool::BufferPool<u8>,
+    pub recv_arena: crate::utils::buffer_pool::BufferPool<u8>,
+    pub packet_arena: crate::utils::buffer_pool::BufferPool<u8>,
     n: usize,
     m: usize,
     need_z: bool,
@@ -44,6 +48,9 @@ impl Default for Workspace {
             sn: Vec::new(),
             g: Vec::new(),
             blk_scratch: Vec::new(),
+            send_arena: crate::utils::buffer_pool::BufferPool::default(),
+            recv_arena: crate::utils::buffer_pool::BufferPool::default(),
+            packet_arena: crate::utils::buffer_pool::BufferPool::default(),
             n: 0,
             m: 0,
             need_z: false,
@@ -58,6 +65,12 @@ impl Workspace {
         ws.tmp2.resize(n, 0.0);
         ws.n = n;
         ws
+    }
+
+    /// Ensure communication buffers have enough bytes for upcoming operations.
+    pub fn ensure_comm_bytes(&mut self, max_send: usize, max_recv: usize) {
+        self.send_arena.ensure_len(max_send);
+        self.recv_arena.ensure_len(max_recv);
     }
 
     #[inline]

--- a/src/matrix/parcsr/halo.rs
+++ b/src/matrix/parcsr/halo.rs
@@ -1,0 +1,9 @@
+/// Communication plan for halo exchanges in distributed matrices.
+#[derive(Debug, Default, Clone)]
+pub struct HaloPlan {
+    pub neighbors: Vec<i32>,
+    pub send_ptr: Vec<usize>,
+    pub send_idx: Vec<u64>,
+    pub recv_ptr: Vec<usize>,
+    pub recv_idx: Vec<u64>,
+}

--- a/src/matrix/parcsr/mod.rs
+++ b/src/matrix/parcsr/mod.rs
@@ -2,3 +2,4 @@ pub type Global = u64;
 pub type Local = usize;
 
 pub mod builder;
+pub mod halo;

--- a/src/utils/buffer_pool.rs
+++ b/src/utils/buffer_pool.rs
@@ -1,0 +1,52 @@
+use std::{cell::RefCell, mem::MaybeUninit};
+
+/// Simple buffer pool that can be reused across calls to avoid allocations.
+#[derive(Debug)]
+pub struct BufferPool<T> {
+    buf: RefCell<Vec<MaybeUninit<T>>>,
+    len: usize,
+}
+
+impl<T> BufferPool<T> {
+    /// Create a new pool with given capacity.
+    pub fn with_capacity(n: usize) -> Self {
+        Self { buf: RefCell::new(Vec::with_capacity(n)), len: 0 }
+    }
+
+    /// Ensure the internal buffer can hold at least `n` elements.
+    pub fn ensure_len(&mut self, n: usize) {
+        let mut b = self.buf.borrow_mut();
+        if b.len() < n {
+            b.resize_with(n, || MaybeUninit::uninit());
+        }
+        self.len = n;
+    }
+
+    /// Mutable slice view assuming caller initializes elements before reading.
+    pub fn as_mut_slice_init(&self) -> &mut [T] {
+        // SAFETY: Caller guarantees initialization of all elements before use.
+        unsafe {
+            &mut *(self.buf.borrow_mut().as_mut_slice() as *mut [MaybeUninit<T>] as *mut [T])
+        }
+    }
+
+    /// Immutable slice view for already initialized data.
+    pub fn as_slice(&self) -> &[T] {
+        unsafe { &*(self.buf.borrow().as_slice() as *const [MaybeUninit<T>] as *const [T]) }
+    }
+}
+
+impl<T> Default for BufferPool<T> {
+    fn default() -> Self {
+        Self::with_capacity(0)
+    }
+}
+
+impl<T> Clone for BufferPool<T> {
+    fn clone(&self) -> Self {
+        let len = self.buf.borrow().len();
+        let mut vec = Vec::with_capacity(len);
+        vec.resize_with(len, || MaybeUninit::uninit());
+        Self { buf: RefCell::new(vec), len: self.len }
+    }
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,5 +10,6 @@ pub mod partition;
 pub mod permutation;
 pub mod profiling;
 pub mod reordering;
+pub mod buffer_pool;
 #[cfg(feature = "tuning")]
 pub mod tuning;


### PR DESCRIPTION
## Summary
- add reusable `BufferPool` utility
- start a `HaloPlan` structure for distributed halo exchanges
- extend solver `Workspace` with shared communication arenas

## Testing
- `cargo +nightly test`

------
https://chatgpt.com/codex/tasks/task_e_68b68b5c610883298fb9e093fa975fed