### PR TITLE
Add merge-walk helpers and ILU row builders

### DIFF
--- a/src/preconditioner/ilu_csr/csr_builder.rs
+++ b/src/preconditioner/ilu_csr/csr_builder.rs
@@ -1,4 +1,7 @@
 use num_traits::Zero;
+use crate::algebra::scalar::Scalar;
+use std::cmp::Reverse;
+use std::collections::BinaryHeap;
 
 #[derive(Clone, Debug)]
 pub struct CsrRowBuilder<T> {
@@ -75,3 +78,226 @@ where
         (row_ptr, col_idx, vals)
     }
 }
+
+/// Metadata associated with candidate fill entries when building ILU rows.
+pub enum Meta<R> {
+    /// No extra metadata (ILU0)
+    None,
+    /// Level information used by ILU(k)
+    Level(u32),
+    /// Magnitude for ILUT
+    Magn(R),
+}
+
+/// Trait for building a single sparse row under a given ILU policy.
+pub trait RowBuilder<S: Scalar> {
+    /// Reset the builder for a new row without allocating.
+    fn clear(&mut self);
+    /// Update an existing column value. The column is guaranteed to be present
+    /// in the row structure for ILU(0) style builders.
+    fn push_existing(&mut self, col: usize, val: S);
+    /// Attempt to insert a candidate fill with associated metadata.
+    fn try_insert(&mut self, col: usize, meta: Meta<S::Real>, val: S);
+    /// Finalize the row by appending its columns and values to the provided
+    /// arrays. The arrays are expected to be empty and are not cleared by the
+    /// builder.
+    fn finalize_into(&mut self, row_cols: &mut Vec<usize>, row_vals: &mut Vec<S>);
+}
+
+/// ILU(0) row builder that only updates existing structure slots.
+pub struct Ilu0Row<'a, S> {
+    cols: &'a [usize],
+    vals: &'a mut [S],
+}
+
+impl<'a, S: Scalar> Ilu0Row<'a, S> {
+    pub fn new(cols: &'a [usize], vals: &'a mut [S]) -> Self {
+        Self { cols, vals }
+    }
+}
+
+impl<'a, S: Scalar> RowBuilder<S> for Ilu0Row<'a, S> {
+    fn clear(&mut self) {}
+
+    fn push_existing(&mut self, col: usize, val: S) {
+        if let Ok(pos) = self.cols.binary_search(&col) {
+            self.vals[pos] = val;
+        }
+    }
+
+    fn try_insert(&mut self, _col: usize, _meta: Meta<S::Real>, _val: S) {}
+
+    fn finalize_into(&mut self, _row_cols: &mut Vec<usize>, _row_vals: &mut Vec<S>) {}
+}
+
+/// ILU(k) row builder using fixed-size arrays for candidate fills.
+pub struct IlukRow<S: Scalar, const CAP: usize> {
+    pub used: usize,
+    pub max_level: u32,
+    pub cand_col: [usize; CAP],
+    pub cand_lev: [u32; CAP],
+    pub cand_val: [S; CAP],
+}
+
+impl<S: Scalar, const CAP: usize> IlukRow<S, CAP> {
+    pub fn new(max_level: u32) -> Self {
+        Self {
+            used: 0,
+            max_level,
+            cand_col: [0; CAP],
+            cand_lev: [0; CAP],
+            cand_val: [S::zero(); CAP],
+        }
+    }
+
+    #[inline]
+    fn upsert(&mut self, col: usize, lev: u32, val: S) {
+        for i in 0..self.used {
+            if self.cand_col[i] == col {
+                self.cand_val[i] = self.cand_val[i] + val;
+                if lev < self.cand_lev[i] {
+                    self.cand_lev[i] = lev;
+                }
+                return;
+            }
+        }
+        if lev > self.max_level {
+            return;
+        }
+        if self.used < CAP {
+            self.cand_col[self.used] = col;
+            self.cand_lev[self.used] = lev;
+            self.cand_val[self.used] = val;
+            self.used += 1;
+            return;
+        }
+        // Replace worst entry if the new one is better
+        let mut worst = 0usize;
+        for i in 1..CAP {
+            let worse = self.cand_lev[i] > self.cand_lev[worst]
+                || (self.cand_lev[i] == self.cand_lev[worst]
+                    && self.cand_val[i].abs() < self.cand_val[worst].abs());
+            if worse {
+                worst = i;
+            }
+        }
+        let better = lev < self.cand_lev[worst]
+            || (lev == self.cand_lev[worst]
+                && val.abs() > self.cand_val[worst].abs());
+        if better {
+            self.cand_col[worst] = col;
+            self.cand_lev[worst] = lev;
+            self.cand_val[worst] = val;
+        }
+    }
+}
+
+impl<S: Scalar, const CAP: usize> RowBuilder<S> for IlukRow<S, CAP> {
+    fn clear(&mut self) {
+        self.used = 0;
+    }
+
+    fn push_existing(&mut self, col: usize, val: S) {
+        self.upsert(col, 0, val);
+    }
+
+    fn try_insert(&mut self, col: usize, meta: Meta<S::Real>, val: S) {
+        let lev = match meta {
+            Meta::Level(l) => l,
+            _ => 0,
+        };
+        self.upsert(col, lev, val);
+    }
+
+    fn finalize_into(&mut self, row_cols: &mut Vec<usize>, row_vals: &mut Vec<S>) {
+        // simple insertion sort
+        for i in 1..self.used {
+            let mut j = i;
+            while j > 0 && self.cand_col[j - 1] > self.cand_col[j] {
+                self.cand_col.swap(j - 1, j);
+                self.cand_lev.swap(j - 1, j);
+                self.cand_val.swap(j - 1, j);
+                j -= 1;
+            }
+        }
+        row_cols.extend_from_slice(&self.cand_col[..self.used]);
+        row_vals.extend_from_slice(&self.cand_val[..self.used]);
+        self.used = 0;
+    }
+}
+
+#[derive(Clone)]
+struct HeapElem<S: Scalar> {
+    mag: S::Real,
+    col: usize,
+    val: S,
+}
+
+impl<S: Scalar> PartialEq for HeapElem<S> {
+    fn eq(&self, other: &Self) -> bool {
+        self.mag == other.mag
+    }
+}
+
+impl<S: Scalar> Eq for HeapElem<S> {}
+
+impl<S: Scalar> PartialOrd for HeapElem<S> {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        self.mag.partial_cmp(&other.mag)
+    }
+}
+
+impl<S: Scalar> Ord for HeapElem<S> {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.partial_cmp(other).unwrap()
+    }
+}
+
+/// ILUT row builder using a magnitude-based capped heap.
+pub struct IlutRow<S: Scalar> {
+    p: usize,
+    drop_tol: S::Real,
+    heap: BinaryHeap<Reverse<HeapElem<S>>>,
+}
+
+impl<S: Scalar> IlutRow<S> {
+    pub fn new(p: usize, drop_tol: S::Real) -> Self {
+        Self { p, drop_tol, heap: BinaryHeap::new() }
+    }
+}
+
+impl<S: Scalar> RowBuilder<S> for IlutRow<S> {
+    fn clear(&mut self) {
+        self.heap.clear();
+    }
+
+    fn push_existing(&mut self, col: usize, val: S) {
+        self.try_insert(col, Meta::None, val);
+    }
+
+    fn try_insert(&mut self, col: usize, _meta: Meta<S::Real>, val: S) {
+        let mag = val.abs();
+        if mag < self.drop_tol {
+            return;
+        }
+        let elem = Reverse(HeapElem { mag, col, val });
+        if self.heap.len() < self.p {
+            self.heap.push(elem);
+        } else if let Some(peek) = self.heap.peek() {
+            if mag > peek.0.mag {
+                let _ = self.heap.pop();
+                self.heap.push(elem);
+            }
+        }
+    }
+
+    fn finalize_into(&mut self, row_cols: &mut Vec<usize>, row_vals: &mut Vec<S>) {
+        let mut elems: Vec<_> = self.heap.drain().map(|r| r.0).collect();
+        elems.sort_by_key(|e| e.col);
+        for e in elems {
+            row_cols.push(e.col);
+            row_vals.push(e.val);
+        }
+    }
+}
+

--- a/src/utils/merge.rs
+++ b/src/utils/merge.rs
@@ -1,5 +1,22 @@
 use crate::algebra::scalar::Scalar;
 
+/// Map a slice of value slots into an iterator over references into the
+/// underlying value array.
+#[inline]
+pub fn map_vals<'a, S>(vals: &'a [S], slots: &'a [usize]) -> impl Iterator<Item = &'a S> {
+    slots.iter().map(move |&p| &vals[p])
+}
+
+/// Lookup a value within a sorted sparse row returning `None` if the column is
+/// absent.
+#[inline]
+pub fn lookup_in_row<S: Scalar>(cols: &[usize], vals: &[S], col: usize) -> Option<S> {
+    match cols.binary_search(&col) {
+        Ok(pos) => Some(vals[pos]),
+        Err(_) => None,
+    }
+}
+
 /// Compute the dot product of two sparse rows up to a column limit by
 /// simultaneously walking both index arrays.
 #[inline]
@@ -22,6 +39,40 @@ pub fn merged_dot_prefix<S: Scalar>(
         if cj >= col_limit {
             break;
         }
+        if ci == cj {
+            acc = acc + a_vals[i] * b_vals[j];
+            i += 1;
+            j += 1;
+        } else if ci < cj {
+            i += 1;
+        } else {
+            j += 1;
+        }
+    }
+    acc
+}
+
+/// Compute the dot product of the strictly upper part of two rows after a
+/// given starting column. The walk skips all columns `<= start_col` in the
+/// first row and only accumulates products where columns match and are greater
+/// than `start_col`.
+#[inline]
+pub fn merged_dot_strict_upper<S: Scalar>(
+    a_cols: &[usize],
+    a_vals: &[S],
+    start_col: usize,
+    b_cols: &[usize],
+    b_vals: &[S],
+) -> S {
+    let mut i = match a_cols.binary_search(&(start_col + 1)) {
+        Ok(idx) => idx,
+        Err(idx) => idx,
+    };
+    let mut j = 0;
+    let mut acc = S::zero();
+    while i < a_cols.len() && j < b_cols.len() {
+        let ci = a_cols[i];
+        let cj = b_cols[j];
         if ci == cj {
             acc = acc + a_vals[i] * b_vals[j];
             i += 1;
@@ -77,7 +128,7 @@ pub fn merged_dot_prefix_kahan<S: Scalar>(
 
 #[cfg(test)]
 mod tests {
-    use super::{merged_dot_prefix, merged_dot_prefix_kahan};
+    use super::{lookup_in_row, merged_dot_prefix, merged_dot_prefix_kahan, merged_dot_strict_upper};
 
     #[test]
     fn basic_prefix() {
@@ -98,5 +149,24 @@ mod tests {
         let res_std = merged_dot_prefix(&a_cols, &a_vals, &b_cols, &b_vals, 3);
         let res_kahan = merged_dot_prefix_kahan(&a_cols, &a_vals, &b_cols, &b_vals, 3);
         assert!((res_std - res_kahan).abs() <= 1e-10);
+    }
+
+    #[test]
+    fn strict_upper() {
+        let a_cols = [0, 2, 4, 7];
+        let a_vals = [1.0, 2.0, 3.0, 4.0];
+        let b_cols = [1, 2, 4, 6, 7];
+        let b_vals = [5.0, 6.0, 7.0, 8.0, 9.0];
+        let res = merged_dot_strict_upper(&a_cols, &a_vals, 2, &b_cols, &b_vals);
+        // columns greater than 2 that match are 4 and 7
+        assert_eq!(res, 3.0 * 7.0 + 4.0 * 9.0);
+    }
+
+    #[test]
+    fn lookup_basic() {
+        let cols = [0, 3, 5];
+        let vals = [1.0, 2.0, 3.0];
+        assert_eq!(lookup_in_row(&cols, &vals, 3), Some(2.0));
+        assert!(lookup_in_row(&cols, &vals, 2).is_none());
     }
 }


### PR DESCRIPTION
## Summary
- add CSR helpers for mapping slots, row lookups, and strict-upper merge dot products
- introduce generic RowBuilder trait with ILU0, ILUK, and ILUT implementations

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b695b2529c8329adf17136caa3f8f4