### PR TITLE
feat: add ParILU monitoring and history

### DIFF
--- a/src/preconditioner/ilu.rs
+++ b/src/preconditioner/ilu.rs
@@ -74,7 +74,9 @@ use crate::error::KError;
 use crate::matrix::sparse::CsrMatrix;
 use crate::matrix::utils;
 use crate::preconditioner::{legacy::Preconditioner, pivot::*, PcSide};
+use crate::preconditioner::stats::{ParIluHistory, ParIluIterSample};
 use crate::utils::metrics::{Counters, SolveTimer};
+use crate::utils::monitor::{Event, Monitor};
 use faer::traits::ComplexField;
 use faer::Mat;
 use num_traits::Float;
@@ -200,6 +202,28 @@ impl Default for IluConfig {
             enable_distributed: false,            // Conservative default
         }
     }
+}
+
+#[cfg(feature = "logging")]
+fn print_ilu_banner(cfg: &IluConfig) {
+    if cfg.logging_level == 0 { return; }
+    info!("ILU Setup:");
+    info!("  kind                 : {:?}", cfg.ilu_type);
+    info!("  reordering           : {:?}", cfg.reordering_type);
+    let tri = match cfg.triangular_solve {
+        TriSolveType::Exact => "Exact".to_string(),
+        TriSolveType::Jacobi => format!("Jacobi (L:{} U:{})", cfg.lower_jacobi_iters, cfg.upper_jacobi_iters),
+        TriSolveType::GaussSeidel => "GaussSeidel".to_string(),
+    };
+    info!("  triangular solve     : {}", tri);
+    info!("  iterative setup      : tol={:.2e}, max_iter={}", cfg.tolerance, cfg.max_iterations);
+    info!(
+        "  exec                 : distributed={}, par_factorization={}, par_trisolve={}",
+        cfg.enable_distributed,
+        cfg.enable_parallel_factorization,
+        cfg.enable_parallel_triangular_solve
+    );
+    info!("  pivot                : {:?}", cfg.pivot_policy);
 }
 
 /// HYPRE-inspired ILU builder for advanced configuration
@@ -375,6 +399,10 @@ pub struct Ilu<T> {
     /// Performance timing
     setup_time: f64,
     solve_ctrs: Counters,
+    /// Optional ParILU iteration history
+    history: Option<ParIluHistory>,
+    /// Optional event monitor
+    monitor: Option<Box<dyn Monitor>>,
 }
 
 /// Consolidated workspace for all ILU operations to minimize allocations
@@ -567,6 +595,8 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Ilu<T> {
             running_max_u: T::zero(),
             setup_time: 0.0,
             solve_ctrs: Counters::new(),
+            history: None,
+            monitor: None,
         })
     }
 
@@ -1317,6 +1347,10 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Preconditioner<M
     fn setup(&mut self, matrix: &Mat<T>) -> Result<(), KError> {
         let setup_start = std::time::Instant::now();
 
+        if let Some(m) = &self.monitor {
+            m.on_event(Event::IluSetupBegin { opts_hash: 0 });
+        }
+
         // HYPRE-style validation and safety checks
         Self::validate_matrix(matrix)?;
 
@@ -1331,6 +1365,9 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Preconditioner<M
 
         let n = matrix.nrows();
         let original_nnz = Self::count_nnz(matrix);
+
+        #[cfg(feature = "logging")]
+        print_ilu_banner(&self.config);
 
         // Precompute scaling terms for pivoting
         let mut max_diag = T::zero();
@@ -1429,6 +1466,13 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Preconditioner<M
                 );
             }
         }
+        if let Some(m) = &self.monitor {
+            m.on_event(Event::IluSetupEnd {
+                iters: 0,
+                converged: true,
+                setup_time_s: self.setup_time,
+            });
+        }
 
         Ok(())
     }
@@ -1477,6 +1521,16 @@ impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Preconditioner<M
         }
 
         Ok(())
+    }
+}
+
+impl<T: Float + Send + Sync + ComplexField + std::fmt::Display> Ilu<T> {
+    pub fn parilu_history(&self) -> Option<&[ParIluIterSample]> {
+        self.history.as_ref().map(|h| h.as_slice())
+    }
+
+    pub fn set_monitor(&mut self, m: Option<Box<dyn Monitor>>) {
+        self.monitor = m;
     }
 }
 

--- a/src/preconditioner/stats.rs
+++ b/src/preconditioner/stats.rs
@@ -24,3 +24,36 @@ macro_rules! pc_log {
     };
 }
 
+#[derive(Debug, Clone)]
+pub struct ParIluIterSample {
+    pub iter: u32,
+    pub rel_corr_L: f64,
+    pub rel_corr_U: f64,
+    pub rel_residual: f64,
+    pub max_pivot_rel: f64,
+}
+
+#[derive(Debug, Clone)]
+pub struct ParIluHistory {
+    pub used: u32,
+    pub buf: Vec<ParIluIterSample>,
+}
+
+impl ParIluHistory {
+    pub fn with_capacity(cap: usize) -> Self {
+        let buf = Vec::with_capacity(cap);
+        Self { used: 0, buf }
+    }
+
+    #[inline]
+    pub fn push(&mut self, s: ParIluIterSample) {
+        self.buf.push(s);
+        self.used += 1;
+    }
+
+    pub fn as_slice(&self) -> &[ParIluIterSample] {
+        &self.buf[..self.used as usize]
+    }
+}
+
+

--- a/src/preconditioner/tests/ilu_history.rs
+++ b/src/preconditioner/tests/ilu_history.rs
@@ -1,0 +1,30 @@
+use crate::preconditioner::stats::{ParIluIterSample, ParIluHistory};
+use crate::utils::monitor::{Event, Monitor};
+use std::sync::Mutex;
+
+struct TestMonitor(Mutex<Vec<&'static str>>);
+
+impl Monitor for TestMonitor {
+    fn on_event(&self, ev: Event<'_>) {
+        let mut v = self.0.lock().unwrap();
+        match ev {
+            Event::IluSetupBegin { .. } => v.push("begin"),
+            Event::IluSetupIter { .. } => v.push("iter"),
+            Event::IluSetupEnd { .. } => v.push("end"),
+        }
+    }
+}
+
+#[test]
+fn history_and_monitor_basic() {
+    let mut h = ParIluHistory::with_capacity(2);
+    h.push(ParIluIterSample { iter: 1, rel_corr_L: 0.1, rel_corr_U: 0.2, rel_residual: 0.3, max_pivot_rel: 0.4 });
+    assert_eq!(h.as_slice().len(), 1);
+
+    let m = TestMonitor(Mutex::new(Vec::new()));
+    m.on_event(Event::IluSetupBegin { opts_hash: 0 });
+    m.on_event(Event::IluSetupIter { sample: &h.as_slice()[0] });
+    m.on_event(Event::IluSetupEnd { iters: 1, converged: true, setup_time_s: 0.0 });
+    let events = m.0.lock().unwrap();
+    assert_eq!(&events[..], ["begin", "iter", "end"]);
+}

--- a/src/preconditioner/tests/mod.rs
+++ b/src/preconditioner/tests/mod.rs
@@ -53,3 +53,4 @@ fn default_apply_mut_forwards_to_apply() {
 mod legacy_bridge;
 mod direct_apply;
 mod ilu_csr;
+mod ilu_history;

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -13,3 +13,5 @@ pub mod reordering;
 pub mod buffer_pool;
 #[cfg(feature = "tuning")]
 pub mod tuning;
+
+pub use monitor::{Event, Monitor, NullMonitor, TextMonitor};

--- a/src/utils/monitor.rs
+++ b/src/utils/monitor.rs
@@ -29,6 +29,57 @@ use std::fs::File;
 use std::io::{BufWriter, Write};
 use std::time::{Duration, Instant};
 
+use crate::preconditioner::stats::ParIluIterSample;
+
+pub enum Event<'a> {
+    IluSetupBegin { opts_hash: u64 },
+    IluSetupIter { sample: &'a ParIluIterSample },
+    IluSetupEnd { iters: u32, converged: bool, setup_time_s: f64 },
+}
+
+pub trait Monitor: Send + Sync {
+    fn on_event(&self, ev: Event<'_>);
+}
+
+pub struct NullMonitor;
+impl Monitor for NullMonitor {
+    fn on_event(&self, _: Event<'_>) {}
+}
+
+pub struct TextMonitor {
+    pub rank0: bool,
+}
+
+impl Monitor for TextMonitor {
+    fn on_event(&self, ev: Event<'_>) {
+        #[cfg(feature = "logging")]
+        if self.rank0 {
+            match ev {
+                Event::IluSetupBegin { opts_hash } =>
+                    log::info!("ILU: setup begin (opts={:016x})", opts_hash),
+                Event::IluSetupIter { sample } => log::info!(
+                    "ILU: it {:>3}  corr(L)={:.3e}  corr(U)={:.3e}  res≈{:.3e}  maxΔpivot={:.3e}",
+                    sample.iter,
+                    sample.rel_corr_L,
+                    sample.rel_corr_U,
+                    sample.rel_residual,
+                    sample.max_pivot_rel
+                ),
+                Event::IluSetupEnd {
+                    iters,
+                    converged,
+                    setup_time_s,
+                } => log::info!(
+                    "ILU: setup end iters={} converged={} time={:.3}s",
+                    iters,
+                    converged,
+                    setup_time_s
+                ),
+            }
+        }
+    }
+}
+
 /// Convergence statistics computed from iteration history.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConvergenceStats {


### PR DESCRIPTION
## Summary
- add lightweight ParILU iteration sample and history containers
- introduce generic Monitor API with text sink for ILU setup
- print ILU setup banner and expose ParILU history accessors
- add basic unit test for history buffer and monitor events

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b69a478b1883299c1638f71bb55edb