### PR TITLE
Add Poisson matrix generator and ILU single-rank test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1008,7 +1008,7 @@ dependencies = [
 
 [[package]]
 name = "kryst"
-version = "2.3.0"
+version = "2.4.0"
 dependencies = [
  "approx",
  "bitflags 2.9.1",
@@ -1021,6 +1021,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "once_cell",
+ "oorandom",
  "parking_lot",
  "proptest",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tempfile = "3.20.0"
 once_cell = "1"
 smallvec = "1.13"
 parking_lot = { version = "0.12", optional = true }
+oorandom = "11"
 
 [dev-dependencies]
 rand = "0.8"

--- a/src/matrix/utils.rs
+++ b/src/matrix/utils.rs
@@ -6,6 +6,7 @@
 use crate::error::KError;
 use crate::matrix::sparse::CsrMatrix;
 use faer::Mat;
+use oorandom::Rand64;
 
 #[cfg(feature = "rayon")]
 use rayon::prelude::*;
@@ -171,7 +172,9 @@ pub fn spgemm_with_drop_tol(
             // The accumulator already holds the full sum for j0; skip any duplicates
             let sum = acc[j0];
             // advance read past all instances of j0
-            while read < row_tail && cols[read] == j0 { read += 1; }
+            while read < row_tail && cols[read] == j0 {
+                read += 1;
+            }
             // reset for next row
             acc[j0] = 0.0;
             mark[j0] = usize::MAX;
@@ -420,6 +423,88 @@ pub fn compute_adaptive_threshold(a: &Mat<f64>, base_threshold: f64) -> f64 {
     // Scale threshold based on anisotropy: higher anisotropy -> lower threshold
     let scaling_factor = (1.0 + avg_anisotropy.log10()).max(0.5).min(2.0);
     base_threshold * scaling_factor
+}
+
+/// Generate a 2D Poisson matrix on an `n_x` by `n_y` grid using the 5-point stencil.
+///
+/// The resulting matrix is SPD with size `(n_x*n_y)`.
+pub fn poisson_2d(n_x: usize, n_y: usize) -> CsrMatrix<f64> {
+    let n = n_x * n_y;
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx = Vec::new();
+    let mut vals = Vec::new();
+    row_ptr.push(0);
+    for j in 0..n_y {
+        for i in 0..n_x {
+            let idx = j * n_x + i;
+            if j > 0 {
+                col_idx.push(idx - n_x);
+                vals.push(-1.0);
+            }
+            if i > 0 {
+                col_idx.push(idx - 1);
+                vals.push(-1.0);
+            }
+            col_idx.push(idx);
+            vals.push(4.0);
+            if i + 1 < n_x {
+                col_idx.push(idx + 1);
+                vals.push(-1.0);
+            }
+            if j + 1 < n_y {
+                col_idx.push(idx + n_x);
+                vals.push(-1.0);
+            }
+            row_ptr.push(col_idx.len());
+        }
+    }
+    CsrMatrix::from_csr(n, n, row_ptr, col_idx, vals)
+}
+
+/// Generate a random symmetric positive definite banded matrix.
+///
+/// `bandwidth` controls the half-bandwidth; larger values yield denser matrices.
+pub fn random_spd(n: usize, bandwidth: usize) -> CsrMatrix<f64> {
+    let mut rng = Rand64::new(0);
+    let mut entries: Vec<(usize, usize, f64)> = Vec::new();
+    let mut diag = vec![0.0f64; n];
+
+    for i in 0..n {
+        let j_start = i.saturating_sub(bandwidth);
+        let j_end = usize::min(n - 1, i + bandwidth);
+        for j in j_start..=j_end {
+            if i == j {
+                continue;
+            }
+            let v = rng.rand_float() - 0.5;
+            entries.push((i, j, v));
+            entries.push((j, i, v));
+            diag[i] += v.abs();
+            diag[j] += v.abs();
+        }
+    }
+
+    for i in 0..n {
+        entries.push((i, i, diag[i] + 1.0));
+    }
+
+    entries.sort_by(|a, b| (a.0, a.1).cmp(&(b.0, b.1)));
+
+    let mut row_ptr = vec![0usize];
+    let mut col_idx = Vec::with_capacity(entries.len());
+    let mut vals = Vec::with_capacity(entries.len());
+    let mut current_row = 0usize;
+    for (i, j, v) in entries {
+        while i > current_row {
+            row_ptr.push(col_idx.len());
+            current_row += 1;
+        }
+        col_idx.push(j);
+        vals.push(v);
+    }
+    row_ptr.push(col_idx.len());
+
+    CsrMatrix::from_csr(n, n, row_ptr, col_idx, vals)
 }
 
 #[cfg(test)]

--- a/src/preconditioner/tests/ilu_csr.rs
+++ b/src/preconditioner/tests/ilu_csr.rs
@@ -1,9 +1,10 @@
 use crate::matrix::sparse::CsrMatrix;
-use crate::preconditioner::Preconditioner;
+use crate::matrix::utils::poisson_2d;
 use crate::preconditioner::ilu_csr::{
-    IluCsr, IluCsrConfig, IluKind, PivotStrategy, IlutParams, PivotPolicy, Pivoting,
-    ReorderingOptions, ReorderingKind,
+    IluCsr, IluCsrConfig, IluKind, IlutParams, PivotPolicy, PivotStrategy, Pivoting,
+    ReorderingKind, ReorderingOptions,
 };
+use crate::preconditioner::Preconditioner;
 
 fn tridiag_csr(n: usize, a: f64, b: f64, c: f64) -> CsrMatrix<f64> {
     // main diag b, subdiag a, superdiag c
@@ -25,6 +26,49 @@ fn tridiag_csr(n: usize, a: f64, b: f64, c: f64) -> CsrMatrix<f64> {
         row_ptr.push(col_idx.len());
     }
     CsrMatrix::from_csr(n, n, row_ptr, col_idx, vals)
+}
+
+#[test]
+fn ilu0_single_rank_matches_serial_ref() {
+    use crate::preconditioner::PcSide;
+    use oorandom::Rand64;
+
+    let a = poisson_2d(10, 10);
+
+    let cfg_serial = IluCsrConfig {
+        kind: IluKind::Ilu0,
+        pivot: PivotStrategy::DiagonalPerturbation,
+        pivot_threshold: 1e-12,
+        diag_perturb_factor: 1e-10,
+        level_sched: false,
+        numeric_update_fixed: true,
+        logging: 0,
+        reordering: ReorderingOptions::default(),
+    };
+    let mut cfg_par = cfg_serial.clone();
+    cfg_par.level_sched = cfg!(feature = "rayon");
+
+    let mut ilu_ref = IluCsr::new_with_config(cfg_serial);
+    ilu_ref.setup(&a).unwrap();
+    let mut ilu_par = IluCsr::new_with_config(cfg_par);
+    ilu_par.setup(&a).unwrap();
+
+    let mut rng = Rand64::new(123);
+    for _ in 0..4 {
+        let b: Vec<f64> = (0..a.nrows()).map(|_| rng.rand_float() - 0.5).collect();
+        let mut y_ref = vec![0.0; b.len()];
+        let mut y_par = vec![0.0; b.len()];
+        ilu_ref.apply(PcSide::Left, &b, &mut y_ref).unwrap();
+        ilu_par.apply(PcSide::Left, &b, &mut y_par).unwrap();
+        let num = y_ref
+            .iter()
+            .zip(&y_par)
+            .map(|(a, b)| (a - b) * (a - b))
+            .sum::<f64>()
+            .sqrt();
+        let den = y_ref.iter().map(|a| a * a).sum::<f64>().sqrt().max(1e-30);
+        assert!(num / den < 5e-14, "relative diff {}", num / den);
+    }
 }
 
 #[test]
@@ -191,12 +235,17 @@ fn ilu0_with_rcm_setup() {
         level_sched: false,
         numeric_update_fixed: true,
         logging: 0,
-        reordering: ReorderingOptions { kind: ReorderingKind::Rcm, symmetric: true, deterministic: true },
+        reordering: ReorderingOptions {
+            kind: ReorderingKind::Rcm,
+            symmetric: true,
+            deterministic: true,
+        },
     };
     let mut pc = IluCsr::new_with_config(cfg);
     pc.setup(&a).unwrap();
     let x = vec![1.0; n];
     let mut y = vec![0.0; n];
-    pc.apply(crate::preconditioner::PcSide::Left, &x, &mut y).unwrap();
+    pc.apply(crate::preconditioner::PcSide::Left, &x, &mut y)
+        .unwrap();
     assert!(y.iter().all(|v| v.is_finite()));
 }

--- a/src/utils/metrics.rs
+++ b/src/utils/metrics.rs
@@ -36,7 +36,10 @@ mod enabled {
     impl<'a> SolveTimer<'a> {
         #[inline]
         pub fn start(ctrs: &'a Counters) -> Self {
-            Self { start: Instant::now(), ctrs }
+            Self {
+                start: Instant::now(),
+                ctrs,
+            }
         }
 
         #[inline]
@@ -65,19 +68,61 @@ mod disabled {
 
     pub struct Counters;
     impl Counters {
-        pub const fn new() -> Self { Self }
-        pub fn snapshot(&self) -> (u64, u64, u64) { (0, 0, 0) }
+        pub const fn new() -> Self {
+            Self
+        }
+        pub fn snapshot(&self) -> (u64, u64, u64) {
+            (0, 0, 0)
+        }
     }
 
-    pub struct SolveTimer<'a> { _p: core::marker::PhantomData<&'a ()> }
+    pub struct SolveTimer<'a> {
+        _p: core::marker::PhantomData<&'a ()>,
+    }
     impl<'a> SolveTimer<'a> {
         #[inline]
-        pub fn start(_: &'a Counters) -> Self { Self { _p: core::marker::PhantomData } }
+        pub fn start(_: &'a Counters) -> Self {
+            Self {
+                _p: core::marker::PhantomData,
+            }
+        }
         #[inline]
-        pub fn elapsed(&self) -> Duration { Duration::ZERO }
+        pub fn elapsed(&self) -> Duration {
+            Duration::ZERO
+        }
     }
-    impl<'a> Drop for SolveTimer<'a> { fn drop(&mut self) {} }
+    impl<'a> Drop for SolveTimer<'a> {
+        fn drop(&mut self) {}
+    }
 }
 
 #[cfg(not(feature = "metrics"))]
 pub use disabled::*;
+
+/// Estimate the error of a preconditioner using random Rademacher probes.
+///
+/// The supplied closure should compute `M^{-1} A z` for an input vector `z`.
+/// The function returns the maximum sampled value of `|| (I - M^{-1}A) z ||_2 / ||z||_2`.
+pub fn proxy_operator_error<M: Fn(&[f64], &mut [f64])>(
+    apply_m_inv_a: M,
+    n: usize,
+    samples: usize,
+    seed: u64,
+) -> f64 {
+    let mut rng = oorandom::Rand64::new(seed.into());
+    let mut z = vec![0.0f64; n];
+    let mut w = vec![0.0f64; n];
+    let mut worst = 0.0f64;
+    for _ in 0..samples {
+        for i in 0..n {
+            z[i] = if rng.rand_u64() & 1 == 1 { 1.0 } else { -1.0 };
+        }
+        apply_m_inv_a(&z, &mut w);
+        for i in 0..n {
+            w[i] = z[i] - w[i];
+        }
+        let r = (w.iter().map(|x| x * x).sum::<f64>()).sqrt() / (n as f64).sqrt();
+        worst = worst.max(r);
+    }
+    worst
+}


### PR DESCRIPTION
## Summary
- add 2D Poisson and random SPD matrix generators
- expose `proxy_operator_error` utility for probing preconditioners
- test ParILU(0) against serial reference on a 10x10 Poisson problem

## Testing
- `cargo +nightly test --lib ilu0_single_rank_matches_serial_ref -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_68b70c967e6c8329855c281e960300c6