### PR TITLE
Add doc audit ensuring distributed docs mention MPI

### DIFF
--- a/tests/doc_audit.rs
+++ b/tests/doc_audit.rs
@@ -1,0 +1,15 @@
+#[test]
+fn no_distributed_claims_without_mpi() {
+    #[cfg(not(feature = "mpi"))]
+    {
+        let readme = include_str!("../README.md").to_lowercase();
+        for line in readme.lines() {
+            if line.contains("distributed") {
+                assert!(
+                    line.contains("mpi"),
+                    "Line mentions distributed without stating `mpi`: {line}"
+                );
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add regression test that checks README lines about distributed features mention the `mpi` feature when MPI support is disabled

## Testing
- `cargo test --no-default-features --features logging --test doc_audit`


------
https://chatgpt.com/codex/tasks/task_e_68b72a2dea748329965836e97ef69535