### PR TITLE
Restrict ILU to left-side usage and mark Schur drop tolerance as reserved

### DIFF
--- a/src/algebra/scalar.rs
+++ b/src/algebra/scalar.rs
@@ -116,3 +116,11 @@ impl Scalar for f64 {
         self
     }
 }
+
+pub trait RealField: private::Sealed + Copy + 'static {}
+impl RealField for f64 {}
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for f64 {}
+}

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -123,6 +123,7 @@ pub struct PcOptions {
     pub ilu_level_of_fill: Option<usize>,
     pub ilu_max_fill_per_row: Option<usize>,
     pub ilu_offdiag_drop_tolerance: Option<f64>,
+    /// Reserved for future Schur complement preconditioners; not yet implemented.
     pub ilu_schur_drop_tolerance: Option<f64>,
     pub ilu_reordering_type: Option<String>,
     pub ilu_triangular_solve: Option<String>,

--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -1047,7 +1047,12 @@ impl Preconditioner for IluCsr {
         }
     }
 
-    fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+    fn apply(&self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        if !matches!(side, PcSide::Left) {
+            return Err(KError::InvalidInput(
+                "IluCsr supports PcSide::Left only; Right/Symmetric not implemented".into(),
+            ));
+        }
         self.apply_op(Op::NoTrans, x, y)
     }
 
@@ -1134,7 +1139,7 @@ impl Preconditioner for IluCsr {
             supports_transpose: true,
             supports_conj_trans: false,
             is_spd: false,
-            side_restriction: None,
+            side_restriction: Some(PcSide::Left),
         }
     }
 }

--- a/src/preconditioner/ilu_options.rs
+++ b/src/preconditioner/ilu_options.rs
@@ -236,6 +236,16 @@ impl IluOptions {
             ));
         }
 
+        // Schur complement options are not yet implemented.
+        if self.schur.enable || self.schur.droptol_s != SchurConfig::default().droptol_s {
+            #[cfg(feature = "logging")]
+            if self.logging_level > 0 {
+                log::warn!(
+                    "schur_drop_tolerance is reserved for future use and will be ignored"
+                );
+            }
+        }
+
         // Derived behavior #1: ILUK/ILUT imply ParILU unless explicitly set.
         let mut it = self.iterative_setup.clone();
         if matches!(self.kind, IluKind::ILUK { .. } | IluKind::ILUT { .. })

--- a/src/preconditioner/tests/direct_apply.rs
+++ b/src/preconditioner/tests/direct_apply.rs
@@ -61,3 +61,21 @@ fn builders_sor_and_chebyshev_object_safe() {
     cheb.apply(PcSide::Left, &x, &mut z).unwrap();
     assert!(z.iter().all(|v| v.is_finite()));
 }
+
+#[test]
+fn ilu_right_side_errors() {
+    use crate::matrix::op::CsrOp;
+    let csr = CsrMatrix::identity(3);
+    let op = CsrOp::new(Arc::new(csr));
+    let mut pc = b::build_ilu0().expect("build_ilu0 should succeed");
+    pc.setup(&op as &dyn LinOp<S = f64>).unwrap();
+    let x = vec![1.0; 3];
+    let mut y = vec![0.0; 3];
+    let err = pc.apply(PcSide::Right, &x, &mut y).unwrap_err();
+    match err {
+        crate::error::KError::InvalidInput(msg) => {
+            assert!(msg.to_lowercase().contains("left only"))
+        }
+        _ => panic!("expected InvalidInput error"),
+    }
+}


### PR DESCRIPTION
## Summary
- mark `schur_drop_tolerance` option as reserved for future Schur-complement preconditioners
- add sealed `RealField` trait and enforce ILU preconditioner only applies on `PcSide::Left`
- extend ILU preconditioner capabilities and add unit test for right-side error

## Testing
- `cargo test` *(fails: build stalled due to heavy dependency compilation)*

------
https://chatgpt.com/codex/tasks/task_e_68b72fbe8ddc832992f6aacd893509d1