### PR TITLE
Add configurable row truncation and cap validation for AMG

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -18,12 +18,14 @@ mod coarsen;
 mod prolong;
 mod rap_ops;
 mod coarse_solver;
+mod row_filter;
 
 use strength::Strength;
 use coarsen::{AggAlgo, build_aggregates};
 use prolong::{TentativeP, Pcsr, smooth_tentative_sa, smooth_sa_values_only};
 use rap_ops::{CsrPattern, rap_symbolic, rap_numeric};
 use coarse_solver::{CoarseSolve, CoarseSolver, CoarseDenseLu};
+use row_filter::{RowFilter, apply_filter_to_csr_values_in_place};
 
 // ===== Public enums (kept compatible with your old file) =====================
 
@@ -121,6 +123,9 @@ pub struct AMGConfig {
     pub truncation_factor: f64,       // 0 => no truncation
     pub max_elements_per_row: usize,  // 0 => unlimited
     pub interpolation_truncation: f64,
+    pub rap_truncation_abs: f64,
+    pub rap_max_elements_per_row: usize,
+    pub keep_pivot_in_rap: bool,
     pub grid_relax_type: [RelaxType; 4],   // [Fine, Down, Up, Coarsest]
     pub num_grid_sweeps: [usize; 4],      // [Fine, Down, Up, Coarsest]
     // legacy shims
@@ -158,6 +163,9 @@ impl Default for AMGConfig {
             truncation_factor: 0.0,
             max_elements_per_row: 0,
             interpolation_truncation: 0.0,
+            rap_truncation_abs: 0.0,
+            rap_max_elements_per_row: 0,
+            keep_pivot_in_rap: true,
             grid_relax_type: [RelaxType::GaussSeidel; 4],
             num_grid_sweeps: [1; 4],
             pre_sweeps: 1,
@@ -207,7 +215,12 @@ impl AMGBuilder {
     pub fn max_coarse_size(mut self, v: usize) -> Self { self.cfg.max_coarse_size = v; self }
     pub fn min_coarse_size(mut self, v: usize) -> Self { self.cfg.min_coarse_size = v; self }
     pub fn truncation_factor(mut self, v: f64) -> Self { self.cfg.truncation_factor = v; self }
-    pub fn interpolation_truncation(mut self, v: f64) -> Self { self.cfg.interpolation_truncation = v; self }
+    pub fn interpolation_drop_abs(mut self, v: f64) -> Self { self.cfg.interpolation_truncation = v; self }
+    pub fn interpolation_cap(mut self, k: usize) -> Self { self.cfg.max_elements_per_row = k; self }
+    pub fn rap_drop_abs(mut self, v: f64) -> Self { self.cfg.rap_truncation_abs = v; self }
+    pub fn rap_cap(mut self, k: usize) -> Self { self.cfg.rap_max_elements_per_row = k; self }
+    pub fn keep_pivot_in_rap(mut self, yes: bool) -> Self { self.cfg.keep_pivot_in_rap = yes; self }
+    pub fn interpolation_truncation(self, v: f64) -> Self { self.interpolation_drop_abs(v) }
     pub fn smoothing_sweeps(mut self, pre: usize, post: usize) -> Self {
         self.cfg.pre_sweeps = pre;
         self.cfg.post_sweeps = post;
@@ -292,6 +305,16 @@ fn validate_relax_policy(cfg: &AMGConfig, coarse_solver: CoarseSolve) -> Result<
                 i
             )));
         }
+    }
+    Ok(())
+}
+
+fn validate_truncation_and_caps(cfg: &AMGConfig) -> Result<(), KError> {
+    if !(0.0..1.0).contains(&cfg.truncation_factor) {
+        return Err(KError::InvalidInput("truncation_factor must satisfy 0 ≤ τ_rel < 1".into()));
+    }
+    if cfg.interpolation_truncation < 0.0 || cfg.rap_truncation_abs < 0.0 {
+        return Err(KError::InvalidInput("absolute drop tolerances must be ≥ 0".into()));
     }
     Ok(())
 }
@@ -457,6 +480,15 @@ impl AMG {
                     &h.levels[l].p,
                     &mut vals,
                 );
+                {
+                    let mut rf = |row: usize| RowFilter {
+                        tau_abs: self.cfg.rap_truncation_abs,
+                        tau_rel: self.cfg.truncation_factor,
+                        k_max: self.cfg.rap_max_elements_per_row,
+                        must_keep: if self.cfg.keep_pivot_in_rap { Some(row) } else { None },
+                    };
+                    apply_filter_to_csr_values_in_place(pat.nrows, &pat.row_ptr, &pat.col_idx, &mut vals, &mut rf);
+                }
                 h.levels[l + 1].a = CsrMatrix::from_csr(
                     h.levels[l + 1].a.nrows(),
                     h.levels[l + 1].a.ncols(),
@@ -636,6 +668,7 @@ impl AMG {
 impl Preconditioner for AMG {
     fn setup(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
         validate_relax_policy(&self.cfg, self.cfg.coarse_solve)?;
+        validate_truncation_and_caps(&self.cfg)?;
         // Convert to CSR via the new matrix layer entry point.
         let csr = csr_from_linop(op, self.cfg.drop_tol)?;
         let sid = op.structure_id();
@@ -681,6 +714,7 @@ impl Preconditioner for AMG {
     fn supports_numeric_update(&self) -> bool { true }
 
     fn update_numeric(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        validate_truncation_and_caps(&self.cfg)?;
         let csr = csr_from_linop(op, self.cfg.drop_tol)?;
         self.refresh_numeric(&csr)?;
         self.csr = Some(csr);
@@ -691,6 +725,7 @@ impl Preconditioner for AMG {
 
     fn update_symbolic(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
         validate_relax_policy(&self.cfg, self.cfg.coarse_solve)?;
+        validate_truncation_and_caps(&self.cfg)?;
         let csr = csr_from_linop(op, self.cfg.drop_tol)?;
         self.build_symbolic(&csr)?;
         self.csr = Some(csr);
@@ -748,6 +783,7 @@ fn build_hierarchy(fine: &CsrMatrix<f64>, cfg: &AMGConfig) -> Result<AmgHierarch
             cfg.jacobi_omega,
             cfg.interpolation_truncation,
             cfg.max_elements_per_row,
+            cfg.truncation_factor,
         );
         // Build owned CSR for P and R
         let p = CsrMatrix::from_csr(p_csr.m, p_csr.n, p_csr.row_ptr.clone(), p_csr.col_idx.clone(), p_csr.vals.clone());
@@ -759,6 +795,15 @@ fn build_hierarchy(fine: &CsrMatrix<f64>, cfg: &AMGConfig) -> Result<AmgHierarch
         let pat = rap_symbolic(&r, &a_cur, &p);
         let mut a_coarse_vals = vec![0.0; pat.col_idx.len()];
         rap_numeric(&pat, &r, &a_cur, &p, &mut a_coarse_vals);
+        {
+            let mut rf = |row: usize| RowFilter {
+                tau_abs: cfg.rap_truncation_abs,
+                tau_rel: cfg.truncation_factor,
+                k_max: cfg.rap_max_elements_per_row,
+                must_keep: if cfg.keep_pivot_in_rap { Some(row) } else { None },
+            };
+            apply_filter_to_csr_values_in_place(pat.nrows, &pat.row_ptr, &pat.col_idx, &mut a_coarse_vals, &mut rf);
+        }
         let a_coarse = CsrMatrix::from_csr(pat.nrows, pat.ncols, pat.row_ptr.clone(), pat.col_idx.clone(), a_coarse_vals);
         let diag_inv_coarse = diag_inv_from_csr(&a_coarse)?;
 
@@ -1189,6 +1234,18 @@ mod tests {
         cfg.num_grid_sweeps[RelaxPhase::Coarsest.ix()] = 1;
         let err = validate_relax_policy(&cfg, cfg.coarse_solve).unwrap_err();
         assert!(matches!(err, KError::InvalidInput(_)));
+
+        let mut cfg = AMGConfig::default();
+        cfg.truncation_factor = 1.2;
+        assert!(validate_truncation_and_caps(&cfg).is_err());
+        cfg.truncation_factor = -0.1;
+        assert!(validate_truncation_and_caps(&cfg).is_err());
+        cfg.truncation_factor = 0.0;
+        cfg.interpolation_truncation = -1.0;
+        assert!(validate_truncation_and_caps(&cfg).is_err());
+        cfg.interpolation_truncation = 0.0;
+        cfg.rap_truncation_abs = -1.0;
+        assert!(validate_truncation_and_caps(&cfg).is_err());
     }
 
     #[test]

--- a/src/preconditioner/amg/prolong.rs
+++ b/src/preconditioner/amg/prolong.rs
@@ -1,6 +1,7 @@
 #![allow(dead_code)]
 
 use crate::matrix::sparse::CsrMatrix;
+use super::row_filter::{RowFilter, filter_row_by_truncation};
 
 #[derive(Clone, Debug)]
 pub struct TentativeP {
@@ -32,6 +33,7 @@ pub fn smooth_tentative_sa(
     omega: f64,
     drop_tol: f64,
     max_per_row: usize,
+    trunc_rel: f64,
 ) -> Pcsr {
     let m = a.nrows();
     let ncoarse = tp.n_coarse;
@@ -72,17 +74,15 @@ pub fn smooth_tentative_sa(
             }
         }
 
-        // Drop small and cap per row
-        let mut keep: Vec<(usize, f64)> = acc_cols.iter().zip(acc_vals.iter())
-            .filter_map(|(&c, &v)| if v.abs() >= drop_tol { Some((c, v)) } else { None })
-            .collect();
-        if max_per_row > 0 && keep.len() > max_per_row {
-            keep.select_nth_unstable_by(max_per_row, |a, b| b.1.abs().partial_cmp(&a.1.abs()).unwrap());
-            keep.truncate(max_per_row);
+        let mut cols: Vec<usize> = acc_cols.clone();
+        let mut vs: Vec<f64> = acc_vals.clone();
+        let rf = RowFilter { tau_abs: drop_tol, tau_rel: trunc_rel, k_max: max_per_row, must_keep: Some(myc) };
+        filter_row_by_truncation(&mut cols, &mut vs, rf);
+        if cols.is_empty() {
+            cols.push(myc);
+            vs.push(1.0);
         }
-        keep.sort_by_key(|(c, _)| *c);
-
-        for (c, v) in keep {
+        for (c, v) in cols.into_iter().zip(vs.into_iter()) {
             col_idx.push(c);
             vals.push(v);
         }
@@ -148,4 +148,44 @@ pub fn smooth_sa_values_only(
         }
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::matrix::sparse::CsrMatrix;
+
+    #[test]
+    fn own_aggregate_kept() {
+        let a = CsrMatrix::from_csr(
+            2,
+            2,
+            vec![0, 2, 4],
+            vec![0, 1, 0, 1],
+            vec![1.0, 0.5, 0.5, 1.0],
+        );
+        let tp = TentativeP { agg_of: vec![0, 1], n_coarse: 2 };
+        let d_inv = vec![1.0, 1.0];
+        let p = smooth_tentative_sa(&a, &d_inv, &tp, 1.0, 10.0, 0, 0.0);
+        assert_eq!(p.col_idx, vec![0, 1]);
+    }
+
+    #[test]
+    fn drop_tol_prunes_but_keeps_self() {
+        let a = CsrMatrix::from_csr(
+            2,
+            2,
+            vec![0, 2, 4],
+            vec![0, 1, 0, 1],
+            vec![1.0, 0.5, 0.5, 1.0],
+        );
+        let tp = TentativeP { agg_of: vec![0, 1], n_coarse: 2 };
+        let d_inv = vec![1.0, 1.0];
+        // drop_tol=0 -> keep all
+        let p_full = smooth_tentative_sa(&a, &d_inv, &tp, 1.0, 0.0, 0, 0.0);
+        assert_eq!(p_full.col_idx, vec![0, 1, 0, 1]);
+        // drop_tol large -> only own aggregates
+        let p_drop = smooth_tentative_sa(&a, &d_inv, &tp, 1.0, 1.0, 0, 0.0);
+        assert_eq!(p_drop.col_idx, vec![0, 1]);
+    }
 }

--- a/src/preconditioner/amg/row_filter.rs
+++ b/src/preconditioner/amg/row_filter.rs
@@ -1,0 +1,192 @@
+use std::cmp::Ordering;
+
+#[derive(Clone, Copy)]
+pub struct RowFilter {
+    pub tau_abs: f64,      // absolute drop (>= 0)
+    pub tau_rel: f64,      // relative truncation in [0,1)
+    pub k_max: usize,      // cap (0 => unlimited)
+    pub must_keep: Option<usize>, // column index to force-keep
+}
+
+/// In-place filter of a single row according to absolute drop, relative truncation, and cap.
+/// `cols` and `vals` are parallel arrays. Upon return, they are sorted by column index.
+pub fn filter_row_by_truncation(cols: &mut Vec<usize>, vals: &mut Vec<f64>, rf: RowFilter) {
+    debug_assert_eq!(cols.len(), vals.len());
+
+    // 1) Absolute drop
+    if rf.tau_abs > 0.0 {
+        let mut w = 0usize;
+        for i in 0..cols.len() {
+            let keep = vals[i].abs() >= rf.tau_abs || rf.must_keep.map_or(false, |c| c == cols[i]);
+            if keep {
+                cols[w] = cols[i];
+                vals[w] = vals[i];
+                w += 1;
+            }
+        }
+        cols.truncate(w);
+        vals.truncate(w);
+    }
+
+    // 2) Relative truncation
+    if rf.tau_rel > 0.0 && !vals.is_empty() {
+        // sort indices by ascending |v| with column tiebreaker for determinism
+        let mut idx: Vec<usize> = (0..vals.len()).collect();
+        idx.sort_unstable_by(|&i, &j| {
+            let ai = vals[i].abs().partial_cmp(&vals[j].abs()).unwrap_or(Ordering::Equal);
+            if ai == Ordering::Equal {
+                cols[i].cmp(&cols[j])
+            } else {
+                ai
+            }
+        });
+        let total: f64 = vals.iter().map(|v| v.abs()).sum();
+        let mut dropped_sum = 0.0;
+        let mut drop_mask = vec![false; vals.len()];
+
+        for &i in &idx {
+            if rf.must_keep.map_or(false, |c| cols[i] == c) {
+                continue;
+            }
+            let allow = rf.tau_rel * total;
+            if dropped_sum + vals[i].abs() <= allow {
+                drop_mask[i] = true;
+                dropped_sum += vals[i].abs();
+            } else {
+                break;
+            }
+        }
+        let mut w = 0usize;
+        for i in 0..cols.len() {
+            if !drop_mask[i] {
+                cols[w] = cols[i];
+                vals[w] = vals[i];
+                w += 1;
+            }
+        }
+        cols.truncate(w);
+        vals.truncate(w);
+    }
+
+    // 3) Cap
+    if rf.k_max > 0 && vals.len() > rf.k_max {
+        let mut idx: Vec<usize> = (0..vals.len()).collect();
+        idx.select_nth_unstable_by(rf.k_max, |&i, &j| {
+            vals[j].abs().partial_cmp(&vals[i].abs()).unwrap_or(Ordering::Equal)
+        });
+        idx.truncate(rf.k_max);
+        let mut keep = vec![false; vals.len()];
+        for &i in &idx { keep[i] = true; }
+        if let Some(mk) = rf.must_keep {
+            if let Some(pos) = cols.iter().position(|&c| c == mk) {
+                if !keep[pos] {
+                    // find smallest among kept
+                    let mut smallest: Option<usize> = None;
+                    for &i in &idx {
+                        if smallest.map_or(true, |s: usize| vals[i].abs() < vals[s].abs()) {
+                            smallest = Some(i);
+                        }
+                    }
+                    if let Some(s) = smallest { keep[s] = false; }
+                    keep[pos] = true;
+                }
+            }
+        }
+        let mut w = 0usize;
+        for i in 0..cols.len() {
+            if keep[i] {
+                cols[w] = cols[i];
+                vals[w] = vals[i];
+                w += 1;
+            }
+        }
+        cols.truncate(w);
+        vals.truncate(w);
+    }
+
+    // final sort by column index
+    let mut pairs: Vec<(usize, f64)> = cols.iter().cloned().zip(vals.iter().cloned()).collect();
+    pairs.sort_unstable_by_key(|(c, _)| *c);
+    for (i, (c, v)) in pairs.into_iter().enumerate() {
+        cols[i] = c;
+        vals[i] = v;
+    }
+}
+
+/// Apply row-wise filtering to an existing CSR matrix values slice, zeroing dropped entries.
+pub fn apply_filter_to_csr_values_in_place(
+    nrows: usize,
+    row_ptr: &[usize],
+    col_idx: &[usize],
+    vals: &mut [f64],
+    mut rf_for_row: impl FnMut(usize) -> RowFilter,
+) {
+    for i in 0..nrows {
+        let rs = row_ptr[i];
+        let re = row_ptr[i + 1];
+        if rs == re { continue; }
+        let mut cols: Vec<usize> = col_idx[rs..re].to_vec();
+        let mut vs: Vec<f64> = vals[rs..re].to_vec();
+        let rf = rf_for_row(i);
+        filter_row_by_truncation(&mut cols, &mut vs, rf);
+        let mut keep_pos = 0usize;
+        for p in rs..re {
+            let c = col_idx[p];
+            while keep_pos < cols.len() && cols[keep_pos] < c { keep_pos += 1; }
+            if keep_pos < cols.len() && cols[keep_pos] == c {
+                vals[p] = vs[keep_pos];
+            } else {
+                vals[p] = 0.0;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn abs_drop_and_must_keep() {
+        let mut cols = vec![0, 1];
+        let mut vals = vec![1e-3, 2.0];
+        let rf = RowFilter { tau_abs: 0.1, tau_rel: 0.0, k_max: 0, must_keep: Some(0) };
+        filter_row_by_truncation(&mut cols, &mut vals, rf);
+        assert_eq!(cols, vec![0, 1]);
+    }
+
+    #[test]
+    fn relative_truncation() {
+        let mut cols = vec![0, 1, 2];
+        let mut vals = vec![0.2, 0.3, 0.5];
+        let rf = RowFilter { tau_abs: 0.0, tau_rel: 0.25, k_max: 0, must_keep: None };
+        filter_row_by_truncation(&mut cols, &mut vals, rf);
+        assert_eq!(cols, vec![1, 2]);
+    }
+
+    #[test]
+    fn cap_with_must_keep() {
+        let mut cols = vec![0, 1, 2];
+        let mut vals = vec![1.0, 0.9, 0.8];
+        let rf = RowFilter { tau_abs: 0.0, tau_rel: 0.0, k_max: 2, must_keep: Some(2) };
+        filter_row_by_truncation(&mut cols, &mut vals, rf);
+        assert_eq!(cols, vec![0, 2]);
+    }
+
+    #[test]
+    fn apply_filter_zeroes_dropped() {
+        let nrows = 2;
+        let row_ptr = vec![0, 3, 5];
+        let col_idx = vec![0, 1, 2, 0, 1];
+        let mut vals = vec![10.0, 1e-3, 0.2, 3.0, 4.0];
+        apply_filter_to_csr_values_in_place(
+            nrows,
+            &row_ptr,
+            &col_idx,
+            &mut vals,
+            |row| RowFilter { tau_abs: 0.5, tau_rel: 0.0, k_max: 0, must_keep: Some(row) },
+        );
+        assert_eq!(vals, vec![10.0, 0.0, 0.0, 3.0, 4.0]);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add shared row filtering utility applying absolute/relative truncation and row caps
- extend AMGConfig with RAP truncation controls and validation
- apply truncation consistently to smoothed aggregation P and RAP coarse operators

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_68b7875803948329bde126a89d2a7b0d