### PR TITLE
Ensure deterministic AMG operations

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -1,6 +1,5 @@
 #![allow(dead_code)]
 
-use std::collections::BTreeMap;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
@@ -14,19 +13,19 @@ use faer::Mat;
 use rayon::prelude::*;
 
 // New sparse SA/RS submodules
-mod strength;
+mod coarse_solver;
 mod coarsen;
 mod prolong;
 mod rap_ops;
-mod coarse_solver;
 mod row_filter;
+mod strength;
 
+use coarse_solver::{CoarseDenseLu, CoarseSolve, CoarseSolver};
+use coarsen::{build_aggregates, AggAlgo};
+use prolong::{smooth_sa_values_only, smooth_tentative_sa, Pcsr, TentativeP};
+use rap_ops::{rap_numeric, rap_symbolic, CsrPattern};
+use row_filter::{apply_filter_to_csr_values_in_place, RowFilter};
 use strength::Strength;
-use coarsen::{AggAlgo, build_aggregates};
-use prolong::{TentativeP, Pcsr, smooth_tentative_sa, smooth_sa_values_only};
-use rap_ops::{CsrPattern, rap_symbolic, rap_numeric};
-use coarse_solver::{CoarseSolve, CoarseSolver, CoarseDenseLu};
-use row_filter::{RowFilter, apply_filter_to_csr_values_in_place};
 
 // ===== Public enums (kept compatible with your old file) =====================
 
@@ -116,36 +115,36 @@ pub fn get_relax_counts() -> [usize; 4] {
 
 #[derive(Clone, Debug)]
 pub struct AMGConfig {
-    pub max_levels: usize,            // HYPRE default: 25
-    pub strong_threshold: f64,        // HYPRE default: 0.25
-    pub coarse_threshold: usize,      // HYPRE default: 9
-    pub max_coarse_size: usize,       // HYPRE default: 9
-    pub min_coarse_size: usize,       // HYPRE minimum: 1
-    pub truncation_factor: f64,       // 0 => no truncation
-    pub max_elements_per_row: usize,  // 0 => unlimited
+    pub max_levels: usize,           // HYPRE default: 25
+    pub strong_threshold: f64,       // HYPRE default: 0.25
+    pub coarse_threshold: usize,     // HYPRE default: 9
+    pub max_coarse_size: usize,      // HYPRE default: 9
+    pub min_coarse_size: usize,      // HYPRE minimum: 1
+    pub truncation_factor: f64,      // 0 => no truncation
+    pub max_elements_per_row: usize, // 0 => unlimited
     pub interpolation_truncation: f64,
     pub rap_truncation_abs: f64,
     pub rap_max_elements_per_row: usize,
     pub keep_pivot_in_rap: bool,
-    pub grid_relax_type: [RelaxType; 4],   // [Fine, Down, Up, Coarsest]
-    pub num_grid_sweeps: [usize; 4],      // [Fine, Down, Up, Coarsest]
+    pub grid_relax_type: [RelaxType; 4], // [Fine, Down, Up, Coarsest]
+    pub num_grid_sweeps: [usize; 4],     // [Fine, Down, Up, Coarsest]
     // legacy shims
-    pub pre_sweeps: usize,            // HYPRE default: 1
-    pub post_sweeps: usize,           // HYPRE default: 1
-    pub coarsen_type: CoarsenType,    // HYPRE default: HMIS
-    pub interp_type: InterpType,      // robust: Extended/Standard
-    pub relax_type: RelaxType,        // HYPRE default: Gauss-Seidel (we implement Jacobi)
+    pub pre_sweeps: usize,         // HYPRE default: 1
+    pub post_sweeps: usize,        // HYPRE default: 1
+    pub coarsen_type: CoarsenType, // HYPRE default: HMIS
+    pub interp_type: InterpType,   // robust: Extended/Standard
+    pub relax_type: RelaxType,     // HYPRE default: Gauss-Seidel (we implement Jacobi)
     pub logging_level: usize,
     pub print_level: usize,
-    pub tolerance: f64,               // for coarse direct solve (CG)
+    pub tolerance: f64, // for coarse direct solve (CG)
     pub max_iterations: usize,
     pub min_iterations: usize,
     pub ieee_checks: bool,
     pub optimize_workspace: bool,
     pub jacobi_omega: f64,
     pub chebyshev_degree: usize,
-    pub drop_tol: f64,                // NEW: used for dense->CSR conversion
-    pub stats_eps: f64,                // threshold for effective nnz reporting
+    pub drop_tol: f64,  // NEW: used for dense->CSR conversion
+    pub stats_eps: f64, // threshold for effective nnz reporting
     // New SA/RS controls
     pub normalize_strength: bool,
     pub coarse_solve: CoarseSolve,
@@ -211,20 +210,57 @@ pub struct AMGBuilder {
 
 impl AMGBuilder {
     pub fn new() -> Self {
-        Self { cfg: AMGConfig::default() }
+        Self {
+            cfg: AMGConfig::default(),
+        }
     }
-    pub fn max_levels(mut self, v: usize) -> Self { self.cfg.max_levels = v; self }
-    pub fn strong_threshold(mut self, v: f64) -> Self { self.cfg.strong_threshold = v; self }
-    pub fn coarse_threshold(mut self, v: usize) -> Self { self.cfg.coarse_threshold = v; self }
-    pub fn max_coarse_size(mut self, v: usize) -> Self { self.cfg.max_coarse_size = v; self }
-    pub fn min_coarse_size(mut self, v: usize) -> Self { self.cfg.min_coarse_size = v; self }
-    pub fn truncation_factor(mut self, v: f64) -> Self { self.cfg.truncation_factor = v; self }
-    pub fn interpolation_drop_abs(mut self, v: f64) -> Self { self.cfg.interpolation_truncation = v; self }
-    pub fn interpolation_cap(mut self, k: usize) -> Self { self.cfg.max_elements_per_row = k; self }
-    pub fn rap_drop_abs(mut self, v: f64) -> Self { self.cfg.rap_truncation_abs = v; self }
-    pub fn rap_cap(mut self, k: usize) -> Self { self.cfg.rap_max_elements_per_row = k; self }
-    pub fn keep_pivot_in_rap(mut self, yes: bool) -> Self { self.cfg.keep_pivot_in_rap = yes; self }
-    pub fn interpolation_truncation(self, v: f64) -> Self { self.interpolation_drop_abs(v) }
+    pub fn max_levels(mut self, v: usize) -> Self {
+        self.cfg.max_levels = v;
+        self
+    }
+    pub fn strong_threshold(mut self, v: f64) -> Self {
+        self.cfg.strong_threshold = v;
+        self
+    }
+    pub fn coarse_threshold(mut self, v: usize) -> Self {
+        self.cfg.coarse_threshold = v;
+        self
+    }
+    pub fn max_coarse_size(mut self, v: usize) -> Self {
+        self.cfg.max_coarse_size = v;
+        self
+    }
+    pub fn min_coarse_size(mut self, v: usize) -> Self {
+        self.cfg.min_coarse_size = v;
+        self
+    }
+    pub fn truncation_factor(mut self, v: f64) -> Self {
+        self.cfg.truncation_factor = v;
+        self
+    }
+    pub fn interpolation_drop_abs(mut self, v: f64) -> Self {
+        self.cfg.interpolation_truncation = v;
+        self
+    }
+    pub fn interpolation_cap(mut self, k: usize) -> Self {
+        self.cfg.max_elements_per_row = k;
+        self
+    }
+    pub fn rap_drop_abs(mut self, v: f64) -> Self {
+        self.cfg.rap_truncation_abs = v;
+        self
+    }
+    pub fn rap_cap(mut self, k: usize) -> Self {
+        self.cfg.rap_max_elements_per_row = k;
+        self
+    }
+    pub fn keep_pivot_in_rap(mut self, yes: bool) -> Self {
+        self.cfg.keep_pivot_in_rap = yes;
+        self
+    }
+    pub fn interpolation_truncation(self, v: f64) -> Self {
+        self.interpolation_drop_abs(v)
+    }
     pub fn smoothing_sweeps(mut self, pre: usize, post: usize) -> Self {
         self.cfg.pre_sweeps = pre;
         self.cfg.post_sweeps = post;
@@ -234,8 +270,14 @@ impl AMGBuilder {
         // leave Coarsest as-is
         self
     }
-    pub fn coarsening_type(mut self, v: CoarsenType) -> Self { self.cfg.coarsen_type = v; self }
-    pub fn interpolation_type(mut self, v: InterpType) -> Self { self.cfg.interp_type = v; self }
+    pub fn coarsening_type(mut self, v: CoarsenType) -> Self {
+        self.cfg.coarsen_type = v;
+        self
+    }
+    pub fn interpolation_type(mut self, v: InterpType) -> Self {
+        self.cfg.interp_type = v;
+        self
+    }
     pub fn relaxation_type(mut self, v: RelaxType) -> Self {
         self.cfg.relax_type = v;
         for ph in RelaxPhase::ALL {
@@ -264,25 +306,50 @@ impl AMGBuilder {
         }
         self
     }
-    pub fn enable_logging(mut self) -> Self { self.cfg.logging_level = 1; self }
-    pub fn logging_level(mut self, lvl: usize) -> Self { self.cfg.logging_level = lvl; self }
-    pub fn enable_printing(mut self) -> Self { self.cfg.print_level = 1; self }
-    pub fn print_level(mut self, lvl: usize) -> Self { self.cfg.print_level = lvl; self }
-    pub fn jacobi_omega(mut self, w: f64) -> Self { self.cfg.jacobi_omega = w; self }
-    pub fn chebyshev_degree(mut self, k: usize) -> Self { self.cfg.chebyshev_degree = k; self }
+    pub fn enable_logging(mut self) -> Self {
+        self.cfg.logging_level = 1;
+        self
+    }
+    pub fn logging_level(mut self, lvl: usize) -> Self {
+        self.cfg.logging_level = lvl;
+        self
+    }
+    pub fn enable_printing(mut self) -> Self {
+        self.cfg.print_level = 1;
+        self
+    }
+    pub fn print_level(mut self, lvl: usize) -> Self {
+        self.cfg.print_level = lvl;
+        self
+    }
+    pub fn jacobi_omega(mut self, w: f64) -> Self {
+        self.cfg.jacobi_omega = w;
+        self
+    }
+    pub fn chebyshev_degree(mut self, k: usize) -> Self {
+        self.cfg.chebyshev_degree = k;
+        self
+    }
     pub fn drop_tolerance(mut self, t: f64) -> Self {
         self.cfg.drop_tol = t;
         self.cfg.stats_eps = t;
         self
     }
-    pub fn stats_eps(mut self, t: f64) -> Self { self.cfg.stats_eps = t; self }
+    pub fn stats_eps(mut self, t: f64) -> Self {
+        self.cfg.stats_eps = t;
+        self
+    }
 
     pub fn build(self, _matrix: &Mat<f64>) -> Result<AMG, KError> {
         Ok(AMG::with_config(self.cfg))
     }
 }
 
-impl Default for AMGBuilder { fn default() -> Self { Self::new() } }
+impl Default for AMGBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
 
 // ===== Workspace, levels & hierarchy ========================================
 
@@ -320,10 +387,14 @@ fn validate_relax_policy(cfg: &AMGConfig, coarse_solver: CoarseSolve) -> Result<
 
 fn validate_truncation_and_caps(cfg: &AMGConfig) -> Result<(), KError> {
     if !(0.0..1.0).contains(&cfg.truncation_factor) {
-        return Err(KError::InvalidInput("truncation_factor must satisfy 0 ≤ τ_rel < 1".into()));
+        return Err(KError::InvalidInput(
+            "truncation_factor must satisfy 0 ≤ τ_rel < 1".into(),
+        ));
     }
     if cfg.interpolation_truncation < 0.0 || cfg.rap_truncation_abs < 0.0 {
-        return Err(KError::InvalidInput("absolute drop tolerances must be ≥ 0".into()));
+        return Err(KError::InvalidInput(
+            "absolute drop tolerances must be ≥ 0".into(),
+        ));
     }
     Ok(())
 }
@@ -348,7 +419,11 @@ impl AMGWorkspace {
         }
     }
     fn ensure(&mut self, n: usize) {
-        let grow = |v: &mut Vec<f64>, n: usize| if v.len() < n { v.resize(n, 0.0) };
+        let grow = |v: &mut Vec<f64>, n: usize| {
+            if v.len() < n {
+                v.resize(n, 0.0)
+            }
+        };
         grow(&mut self.temp, n);
         grow(&mut self.work, n);
         grow(&mut self.residual, n);
@@ -390,8 +465,12 @@ struct AmgHierarchy {
 }
 
 impl AmgHierarchy {
-    fn finest(&self) -> &AMGLevel { &self.levels[0] }
-    fn coarsest_ix(&self) -> usize { self.levels.len() - 1 }
+    fn finest(&self) -> &AMGLevel {
+        &self.levels[0]
+    }
+    fn coarsest_ix(&self) -> usize {
+        self.levels.len() - 1
+    }
 }
 
 // ===== Main AMG object =======================================================
@@ -424,8 +503,15 @@ impl AMG {
     pub fn new(_matrix: &Mat<f64>, _max_levels: usize, _coarsening_threshold: f64) -> Self {
         AMG::default()
     }
-    pub fn builder() -> AMGBuilder { AMGBuilder::new() }
-    pub fn with_config(cfg: AMGConfig) -> Self { Self { cfg, ..Default::default() } }
+    pub fn builder() -> AMGBuilder {
+        AMGBuilder::new()
+    }
+    pub fn with_config(cfg: AMGConfig) -> Self {
+        Self {
+            cfg,
+            ..Default::default()
+        }
+    }
 
     // ---- Setup paths --------------------------------------------------------
 
@@ -454,7 +540,10 @@ impl AMG {
         // Recompute P_l values, R_l values, and A_{l+1} values using fixed patterns
         for l in 0..h.coarsest_ix() {
             // Recompute P_l values in-place using SA smoother with fixed pattern
-            let tp = TentativeP { agg_of: h.levels[l].agg_of.clone(), n_coarse: h.levels[l+1].a.nrows() };
+            let tp = TentativeP {
+                agg_of: h.levels[l].agg_of.clone(),
+                n_coarse: h.levels[l + 1].a.nrows(),
+            };
             let d_inv = &h.levels[l].diag_inv;
             // Recompute P values under fixed pattern without borrowing P mutably during computation
             let pr = h.levels[l].p.row_ptr().to_vec();
@@ -495,9 +584,19 @@ impl AMG {
                         tau_abs: self.cfg.rap_truncation_abs,
                         tau_rel: self.cfg.truncation_factor,
                         k_max: self.cfg.rap_max_elements_per_row,
-                        must_keep: if self.cfg.keep_pivot_in_rap { Some(row) } else { None },
+                        must_keep: if self.cfg.keep_pivot_in_rap {
+                            Some(row)
+                        } else {
+                            None
+                        },
                     };
-                    apply_filter_to_csr_values_in_place(pat.nrows, &pat.row_ptr, &pat.col_idx, &mut vals, &mut rf);
+                    apply_filter_to_csr_values_in_place(
+                        pat.nrows,
+                        &pat.row_ptr,
+                        &pat.col_idx,
+                        &mut vals,
+                        &mut rf,
+                    );
                 }
                 h.levels[l + 1].a = CsrMatrix::from_csr(
                     h.levels[l + 1].a.nrows(),
@@ -535,7 +634,9 @@ impl AMG {
         iters: usize,
         ws: &mut AMGWorkspace,
     ) -> Result<(), KError> {
-        if iters == 0 { return Ok(()); }
+        if iters == 0 {
+            return Ok(());
+        }
         let n = a.nrows();
         if diag_inv.len() != n || r.len() != n || z.len() != n {
             return Err(KError::InvalidInput("Jacobi: dimension mismatch".into()));
@@ -580,8 +681,13 @@ impl AMG {
             RELAX_CALL_COUNTS[phase.ix()].fetch_add(1, Ordering::SeqCst);
         }
         match pol.kind[phase.ix()] {
-            RelaxType::Jacobi => Self::jacobi_smooth_sparse(pol.omega, a, diag_inv, rhs, sol, k, ws),
-            other => Err(KError::InvalidInput(format!("RelaxType {:?} not yet supported", other))),
+            RelaxType::Jacobi => {
+                Self::jacobi_smooth_sparse(pol.omega, a, diag_inv, rhs, sol, k, ws)
+            }
+            other => Err(KError::InvalidInput(format!(
+                "RelaxType {:?} not yet supported",
+                other
+            ))),
         }
     }
 
@@ -595,13 +701,19 @@ impl AMG {
         ws: &mut AMGWorkspace,
         mut cyc: Option<&mut CycleTimings>,
     ) -> Result<(), KError> {
-        let h = self.state.as_ref().ok_or_else(|| KError::InvalidInput("AMG not set up".into()))?;
+        let h = self
+            .state
+            .as_ref()
+            .ok_or_else(|| KError::InvalidInput("AMG not set up".into()))?;
         let lc = h.coarsest_ix();
 
         let a = &h.levels[level].a;
         let d = &h.levels[level].diag_inv;
         let pol = &h.policy;
-        let mut lv = CycleLevelTiming { level, ..Default::default() };
+        let mut lv = CycleLevelTiming {
+            level,
+            ..Default::default()
+        };
         let prof = cyc.is_some();
 
         if level == lc {
@@ -632,7 +744,11 @@ impl AMG {
         ws.ensure(n);
 
         // Pre-smooth
-        let phase_pre = if level == 0 { RelaxPhase::Fine } else { RelaxPhase::Down };
+        let phase_pre = if level == 0 {
+            RelaxPhase::Fine
+        } else {
+            RelaxPhase::Down
+        };
         with_timing(prof, &mut lv.pre_smooth, || {
             Self::apply_relax(pol, phase_pre, RelaxWhere::Pre, a, d, rhs, sol, ws)
         })?;
@@ -643,9 +759,12 @@ impl AMG {
         })?;
         with_timing(prof, &mut lv.residual_axpy, || {
             #[cfg(feature = "rayon")]
-            ws.residual[..n].par_iter_mut().enumerate().for_each(|(i, ri)| {
-                *ri = rhs[i] - ws.work[i];
-            });
+            ws.residual[..n]
+                .par_iter_mut()
+                .enumerate()
+                .for_each(|(i, ri)| {
+                    *ri = rhs[i] - ws.work[i];
+                });
             #[cfg(not(feature = "rayon"))]
             for i in 0..n {
                 ws.residual[i] = rhs[i] - ws.work[i];
@@ -673,7 +792,13 @@ impl AMG {
             ws.fine_corr[..n].fill(0.0);
         } else {
             let mut zc = vec![0.0; nc];
-            self.v_cycle_profiled(level + 1, &local_coarse[..nc], &mut zc, ws, cyc.as_deref_mut())?;
+            self.v_cycle_profiled(
+                level + 1,
+                &local_coarse[..nc],
+                &mut zc,
+                ws,
+                cyc.as_deref_mut(),
+            )?;
             with_timing(prof, &mut lv.prolong, || {
                 ws.fine_corr[..n].fill(0.0);
                 p.spmv_scaled(1.0, &zc, 0.0, &mut ws.fine_corr[..n])
@@ -685,7 +810,11 @@ impl AMG {
         ws.coarse_rhs = local_coarse;
 
         // Post-smooth
-        let phase_post = if level == 0 { RelaxPhase::Fine } else { RelaxPhase::Up };
+        let phase_post = if level == 0 {
+            RelaxPhase::Fine
+        } else {
+            RelaxPhase::Up
+        };
         with_timing(prof, &mut lv.post_smooth, || {
             Self::apply_relax(pol, phase_post, RelaxWhere::Post, a, d, rhs, sol, ws)
         })?;
@@ -751,10 +880,15 @@ impl Preconditioner for AMG {
     fn apply(&self, _side: PcSide, r: &[f64], z: &mut [f64]) -> Result<(), KError> {
         if r.len() != z.len() {
             return Err(KError::InvalidInput(format!(
-                "AMG.apply: r/z size mismatch: {} vs {}", r.len(), z.len()
+                "AMG.apply: r/z size mismatch: {} vs {}",
+                r.len(),
+                z.len()
             )));
         }
-        let h = self.state.as_ref().ok_or_else(|| KError::InvalidInput("AMG not set up".into()))?;
+        let h = self
+            .state
+            .as_ref()
+            .ok_or_else(|| KError::InvalidInput("AMG not set up".into()))?;
         if h.levels.is_empty() {
             // Fallback Jacobi with diagonal of input matrix if hierarchy missing
             let a = self
@@ -787,7 +921,9 @@ impl Preconditioner for AMG {
         }
     }
 
-    fn supports_numeric_update(&self) -> bool { true }
+    fn supports_numeric_update(&self) -> bool {
+        true
+    }
 
     fn update_numeric(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
         validate_truncation_and_caps(&self.cfg)?;
@@ -927,11 +1063,21 @@ fn build_hierarchy(
         );
         // R = P^T pattern and values
         let (r_row_ptr, r_col_idx, r_vals, p2r_pos) =
-            with_timing(do_stats, &mut lt.restrict, || transpose_csr_with_pos(&p_csr));
-        let r = CsrMatrix::from_csr(p_csr.n, p_csr.m, r_row_ptr.clone(), r_col_idx.clone(), r_vals.clone());
+            with_timing(do_stats, &mut lt.restrict, || {
+                transpose_csr_with_pos(&p_csr)
+            });
+        let r = CsrMatrix::from_csr(
+            p_csr.n,
+            p_csr.m,
+            r_row_ptr.clone(),
+            r_col_idx.clone(),
+            r_vals.clone(),
+        );
 
         // 4) Coarse operator A_c symbolic and numeric
-        let pat = with_timing(do_stats, &mut lt.rap_symbolic, || rap_symbolic(&r, &a_cur, &p));
+        let pat = with_timing(do_stats, &mut lt.rap_symbolic, || {
+            rap_symbolic(&r, &a_cur, &p)
+        });
         let mut a_coarse_vals = vec![0.0; pat.col_idx.len()];
         with_timing(do_stats, &mut lt.rap_numeric, || {
             rap_numeric(&pat, &r, &a_cur, &p, &mut a_coarse_vals);
@@ -941,7 +1087,11 @@ fn build_hierarchy(
                 tau_abs: cfg.rap_truncation_abs,
                 tau_rel: cfg.truncation_factor,
                 k_max: cfg.rap_max_elements_per_row,
-                must_keep: if cfg.keep_pivot_in_rap { Some(row) } else { None },
+                must_keep: if cfg.keep_pivot_in_rap {
+                    Some(row)
+                } else {
+                    None
+                },
             };
             apply_filter_to_csr_values_in_place(
                 pat.nrows,
@@ -958,9 +1108,7 @@ fn build_hierarchy(
             pat.col_idx.clone(),
             a_coarse_vals,
         );
-        let diag_inv_coarse = with_timing(do_stats, &mut lt.diag, || {
-            diag_inv_from_csr(&a_coarse)
-        })?;
+        let diag_inv_coarse = with_timing(do_stats, &mut lt.diag, || diag_inv_from_csr(&a_coarse))?;
         lt.total = lt.strength
             + lt.aggregate
             + lt.prolong
@@ -1074,7 +1222,10 @@ fn diag_inv_from_csr(a: &CsrMatrix<f64>) -> Result<Vec<f64>, KError> {
             }
         }
         if aii.abs() < 1e-14 {
-            return Err(KError::SolveError(format!("near-zero diagonal at row {}", i)));
+            return Err(KError::SolveError(format!(
+                "near-zero diagonal at row {}",
+                i
+            )));
         }
         d[i] = 1.0 / aii;
     }
@@ -1088,31 +1239,66 @@ fn csr_mul(a: &CsrMatrix<f64>, b: &CsrMatrix<f64>) -> Result<CsrMatrix<f64>, KEr
     }
     let m = a.nrows();
     let n = b.ncols();
+
     let mut row_ptr = Vec::with_capacity(m + 1);
     let mut col_idx: Vec<usize> = Vec::new();
     let mut vals: Vec<f64> = Vec::new();
     row_ptr.push(0);
 
+    let mut tmp_cols: Vec<usize> = Vec::new();
+    let mut tmp_vals: Vec<f64> = Vec::new();
+    let mut order: Vec<usize> = Vec::new();
+
     for i in 0..m {
-        let mut acc: BTreeMap<usize, f64> = BTreeMap::new();
-        for ap in a.row_ptr()[i]..a.row_ptr()[i + 1] {
+        tmp_cols.clear();
+        tmp_vals.clear();
+
+        let ars = a.row_ptr()[i];
+        let are = a.row_ptr()[i + 1];
+        for ap in ars..are {
             let k = a.col_idx()[ap];
-            let a_ik = a.values()[ap];
-            let rs = b.row_ptr()[k];
-            let re = b.row_ptr()[k + 1];
-            for bp in rs..re {
+            let aik = a.values()[ap];
+            let brs = b.row_ptr()[k];
+            let bre = b.row_ptr()[k + 1];
+            for bp in brs..bre {
                 let j = b.col_idx()[bp];
-                let v = a_ik * b.values()[bp];
-                *acc.entry(j).or_insert(0.0) += v;
+                tmp_cols.push(j);
+                tmp_vals.push(aik * b.values()[bp]);
             }
         }
-        // append in column order
-        for (j, v) in acc.into_iter() {
-            if v.abs() > 0.0 {
-                col_idx.push(j);
-                vals.push(v);
+
+        if tmp_cols.is_empty() {
+            row_ptr.push(col_idx.len());
+            continue;
+        }
+
+        order.clear();
+        order.extend(0..tmp_cols.len());
+        order.sort_unstable_by(|&u, &v| match tmp_cols[u].cmp(&tmp_cols[v]) {
+            std::cmp::Ordering::Equal => u.cmp(&v),
+            o => o,
+        });
+
+        let mut run_col = tmp_cols[order[0]];
+        let mut acc = 0.0f64;
+        for &idx in &order {
+            let c = tmp_cols[idx];
+            if c == run_col {
+                acc += tmp_vals[idx];
+            } else {
+                if acc != 0.0 {
+                    col_idx.push(run_col);
+                    vals.push(acc);
+                }
+                run_col = c;
+                acc = tmp_vals[idx];
             }
         }
+        if acc != 0.0 {
+            col_idx.push(run_col);
+            vals.push(acc);
+        }
+
         row_ptr.push(col_idx.len());
     }
 
@@ -1120,7 +1306,11 @@ fn csr_mul(a: &CsrMatrix<f64>, b: &CsrMatrix<f64>) -> Result<CsrMatrix<f64>, KEr
 }
 
 /// RAP = R * A * P
-fn rap(r: &CsrMatrix<f64>, a: &CsrMatrix<f64>, p: &CsrMatrix<f64>) -> Result<CsrMatrix<f64>, KError> {
+fn rap(
+    r: &CsrMatrix<f64>,
+    a: &CsrMatrix<f64>,
+    p: &CsrMatrix<f64>,
+) -> Result<CsrMatrix<f64>, KError> {
     let ap = csr_mul(a, p)?;
     csr_mul(r, &ap)
 }
@@ -1130,20 +1320,39 @@ fn rap(r: &CsrMatrix<f64>, a: &CsrMatrix<f64>, p: &CsrMatrix<f64>) -> Result<Csr
 fn compute_anisotropy(a: &Mat<f64>) -> Vec<f64> {
     let n = a.nrows();
     #[cfg(feature = "rayon")]
-    return (0..n).into_par_iter().map(|i| {
-        let diag = a[(i, i)];
-        let mut max_off: f64 = 0.0;
-        for j in 0..n { if i != j { max_off = max_off.max(a[(i, j)].abs()); } }
-        if diag.abs() > 1e-14 { max_off / diag.abs() } else { 0.0 }
-    }).collect();
+    return (0..n)
+        .into_par_iter()
+        .map(|i| {
+            let diag = a[(i, i)];
+            let mut max_off: f64 = 0.0;
+            for j in 0..n {
+                if i != j {
+                    max_off = max_off.max(a[(i, j)].abs());
+                }
+            }
+            if diag.abs() > 1e-14 {
+                max_off / diag.abs()
+            } else {
+                0.0
+            }
+        })
+        .collect();
     #[cfg(not(feature = "rayon"))]
     {
         let mut out = vec![0.0; n];
         for i in 0..n {
             let diag = a[(i, i)];
             let mut max_off: f64 = 0.0;
-            for j in 0..n { if i != j { max_off = max_off.max(a[(i, j)].abs()); } }
-            out[i] = if diag.abs() > 1e-14 { max_off / diag.abs() } else { 0.0 };
+            for j in 0..n {
+                if i != j {
+                    max_off = max_off.max(a[(i, j)].abs());
+                }
+            }
+            out[i] = if diag.abs() > 1e-14 {
+                max_off / diag.abs()
+            } else {
+                0.0
+            };
         }
         out
     }
@@ -1151,7 +1360,11 @@ fn compute_anisotropy(a: &Mat<f64>) -> Vec<f64> {
 
 fn compute_adaptive_threshold(a: &Mat<f64>, base_threshold: f64) -> f64 {
     let anis = compute_anisotropy(a);
-    let avg = if anis.is_empty() { 1.0 } else { anis.iter().sum::<f64>() / anis.len() as f64 };
+    let avg = if anis.is_empty() {
+        1.0
+    } else {
+        anis.iter().sum::<f64>() / anis.len() as f64
+    };
     base_threshold * (1.0 + avg.max(0.5))
 }
 
@@ -1160,14 +1373,20 @@ fn compute_strength_matrix(a: &Mat<f64>, thr: f64) -> Mat<f64> {
     let n = a.nrows();
     let mut s = Mat::<f64>::zeros(n, n);
     let mut diag = vec![0.0; n];
-    for i in 0..n { diag[i] = a[(i, i)].abs(); }
+    for i in 0..n {
+        diag[i] = a[(i, i)].abs();
+    }
     for i in 0..n {
         for j in 0..n {
-            if i == j { continue; }
+            if i == j {
+                continue;
+            }
             let denom = (diag[i] * diag[j]).sqrt();
             if denom > 1e-14 {
                 let st = a[(i, j)].abs() / denom;
-                if st > thr { s[(i, j)] = st; }
+                if st > thr {
+                    s[(i, j)] = st;
+                }
             }
         }
     }
@@ -1180,18 +1399,31 @@ fn pairwise_aggregation(s: &Mat<f64>) -> Vec<usize> {
     let mut vis = vec![false; n];
     let mut id = 0usize;
     for i in 0..n {
-        if vis[i] { continue; }
+        if vis[i] {
+            continue;
+        }
         let mut best = None;
         let mut bestv = 0.0;
         for j in 0..n {
-            if i == j || vis[j] { continue; }
+            if i == j || vis[j] {
+                continue;
+            }
             let v = s[(i, j)];
-            if v > bestv { bestv = v; best = Some(j); }
+            if v > bestv {
+                bestv = v;
+                best = Some(j);
+            }
         }
         if let Some(j) = best {
-            agg[i] = id; agg[j] = id; vis[i] = true; vis[j] = true; id += 1;
+            agg[i] = id;
+            agg[j] = id;
+            vis[i] = true;
+            vis[j] = true;
+            id += 1;
         } else {
-            agg[i] = id; vis[i] = true; id += 1;
+            agg[i] = id;
+            vis[i] = true;
+            id += 1;
         }
     }
     agg
@@ -1207,7 +1439,9 @@ fn build_coarse_graph(s: &Mat<f64>, agg: &[usize]) -> Mat<f64> {
             let ai = agg[i];
             let aj = agg[j];
             let v = s[(i, j)];
-            if v != 0.0 { cg[(ai, aj)] += v; }
+            if v != 0.0 {
+                cg[(ai, aj)] += v;
+            }
         }
     }
     cg
@@ -1238,17 +1472,29 @@ fn greedy_aggregation(s: &Mat<f64>) -> Vec<usize> {
     let mut order: Vec<(f64, usize)> = (0..n)
         .map(|i| ((0..n).map(|j| s[(i, j)]).sum::<f64>(), i))
         .collect();
-    order.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+    order.sort_by(|a, b| match b.0.total_cmp(&a.0) {
+        std::cmp::Ordering::Equal => a.1.cmp(&b.1),
+        o => o,
+    });
 
     for &(_, seed) in &order {
-        if agg[seed] != usize::MAX { continue; }
+        if agg[seed] != usize::MAX {
+            continue;
+        }
         agg[seed] = next;
         // pick strongest distinct neighbors
-        let mut neigh: Vec<(f64, usize)> =
-            (0..n).filter(|&j| j != seed && agg[j] == usize::MAX).map(|j| (s[(seed, j)], j)).collect();
-        neigh.sort_by(|a, b| b.0.partial_cmp(&a.0).unwrap());
+        let mut neigh: Vec<(f64, usize)> = (0..n)
+            .filter(|&j| j != seed && agg[j] == usize::MAX)
+            .map(|j| (s[(seed, j)], j))
+            .collect();
+        neigh.sort_by(|a, b| match b.0.total_cmp(&a.0) {
+            std::cmp::Ordering::Equal => a.1.cmp(&b.1),
+            o => o,
+        });
         for &(_, j) in neigh.iter() {
-            if (0..n).filter(|&i| agg[i] == next).count() >= max_sz { break; }
+            if (0..n).filter(|&i| agg[i] == next).count() >= max_sz {
+                break;
+            }
             if s[(seed, j)] > 0.1 && agg[j] == usize::MAX {
                 agg[j] = next;
             }
@@ -1264,7 +1510,9 @@ fn construct_prolongation(_a: &Mat<f64>, aggregates: &[usize]) -> Mat<f64> {
     let max_id = *aggregates.iter().max().unwrap_or(&0);
     let nc = max_id + 1;
     let mut p = Mat::<f64>::zeros(n, nc);
-    for (i, &g) in aggregates.iter().enumerate() { p[(i, g)] = 1.0; }
+    for (i, &g) in aggregates.iter().enumerate() {
+        p[(i, g)] = 1.0;
+    }
     p
 }
 
@@ -1284,17 +1532,29 @@ fn minimize_energy(p: &mut Mat<f64>, _a: &Mat<f64>) {
     let (m, n) = (p.nrows(), p.ncols());
     for i in 0..m {
         let mut norm2 = 0.0;
-        for j in 0..n { norm2 += p[(i, j)] * p[(i, j)]; }
+        for j in 0..n {
+            norm2 += p[(i, j)] * p[(i, j)];
+        }
         let s = if norm2 > 1e-14 { norm2.sqrt() } else { 1.0 };
-        for j in 0..n { p[(i, j)] /= s; }
+        for j in 0..n {
+            p[(i, j)] /= s;
+        }
     }
 }
 
 // ===== Small sparse CG for coarsest level ===================================
 
-fn cg_sparse(a: &CsrMatrix<f64>, b: &[f64], x: &mut [f64], tol: f64, maxit: usize) -> Result<(), KError> {
+fn cg_sparse(
+    a: &CsrMatrix<f64>,
+    b: &[f64],
+    x: &mut [f64],
+    tol: f64,
+    maxit: usize,
+) -> Result<(), KError> {
     let n = a.nrows();
-    if n == 0 { return Ok(()); }
+    if n == 0 {
+        return Ok(());
+    }
     x.fill(0.0);
 
     let mut r = b.to_vec();
@@ -1307,27 +1567,49 @@ fn cg_sparse(a: &CsrMatrix<f64>, b: &[f64], x: &mut [f64], tol: f64, maxit: usiz
     for _ in 0..maxit {
         a.spmv_scaled(1.0, &p, 0.0, &mut ap)?;
         let denom = dot(&p, &ap);
-        if denom.abs() < 1e-30 { break; }
+        if denom.abs() < 1e-30 {
+            break;
+        }
         let alpha = rsold / denom;
 
         #[cfg(feature = "rayon")]
-        { x.par_iter_mut().zip(p.par_iter()).for_each(|(xi, &pi)| *xi += alpha * pi); }
+        {
+            x.par_iter_mut()
+                .zip(p.par_iter())
+                .for_each(|(xi, &pi)| *xi += alpha * pi);
+        }
         #[cfg(not(feature = "rayon"))]
-        for i in 0..n { x[i] += alpha * p[i]; }
+        for i in 0..n {
+            x[i] += alpha * p[i];
+        }
 
         #[cfg(feature = "rayon")]
-        { r.par_iter_mut().zip(ap.par_iter()).for_each(|(ri, &api)| *ri -= alpha * api); }
+        {
+            r.par_iter_mut()
+                .zip(ap.par_iter())
+                .for_each(|(ri, &api)| *ri -= alpha * api);
+        }
         #[cfg(not(feature = "rayon"))]
-        for i in 0..n { r[i] -= alpha * ap[i]; }
+        for i in 0..n {
+            r[i] -= alpha * ap[i];
+        }
 
         let rsnew = dot(&r, &r);
-        if rsnew.sqrt() < atol { break; }
+        if rsnew.sqrt() < atol {
+            break;
+        }
         let beta = rsnew / rsold;
 
         #[cfg(feature = "rayon")]
-        { p.par_iter_mut().zip(r.par_iter()).for_each(|(pi, &ri)| *pi = ri + beta * *pi); }
+        {
+            p.par_iter_mut()
+                .zip(r.par_iter())
+                .for_each(|(pi, &ri)| *pi = ri + beta * *pi);
+        }
         #[cfg(not(feature = "rayon"))]
-        for i in 0..n { p[i] = r[i] + beta * p[i]; }
+        for i in 0..n {
+            p[i] = r[i] + beta * p[i];
+        }
 
         rsold = rsnew;
     }
@@ -1336,8 +1618,11 @@ fn cg_sparse(a: &CsrMatrix<f64>, b: &[f64], x: &mut [f64], tol: f64, maxit: usiz
 
 #[inline]
 fn dot(x: &[f64], y: &[f64]) -> f64 {
-    #[cfg(feature = "rayon")] { x.par_iter().zip(y.par_iter()).map(|(a,b)| a*b).sum() }
-    #[cfg(not(feature = "rayon"))] { x.iter().zip(y.iter()).map(|(a,b)| a*b).sum() }
+    let mut s = 0.0;
+    for i in 0..x.len() {
+        s += x[i] * y[i];
+    }
+    s
 }
 
 // ===== Helpers for transpose mapping and stats ==============================
@@ -1428,7 +1713,9 @@ struct AmgRuntime {
 }
 
 fn operator_complexity_estimate(levels: &[AMGLevel]) -> f64 {
-    if levels.is_empty() { return 0.0; }
+    if levels.is_empty() {
+        return 0.0;
+    }
     let nnz0 = levels[0].a.nnz() as f64;
     let nnz_sum: f64 = levels.iter().map(|l| l.a.nnz() as f64).sum();
     nnz_sum / nnz0
@@ -1469,9 +1756,7 @@ fn print_setup_tables(stats: &AmgStats) {
         );
     }
     if !stats.setup.per_level.is_empty() {
-        println!(
-            "Setup timings (ms): level | strength agg prolon restr symRAP numRAP diag total"
-        );
+        println!("Setup timings (ms): level | strength agg prolon restr symRAP numRAP diag total");
         let ms = |d: Duration| (d.as_secs_f64() * 1e3).round() as u64;
         for (i, lt) in stats.setup.per_level.iter().enumerate() {
             println!(
@@ -1516,9 +1801,13 @@ fn print_cycle_table(c: &CycleTimings) {
 }
 
 #[inline]
-fn tic() -> Instant { Instant::now() }
+fn tic() -> Instant {
+    Instant::now()
+}
 #[inline]
-fn toc(t0: Instant) -> Duration { t0.elapsed() }
+fn toc(t0: Instant) -> Duration {
+    t0.elapsed()
+}
 
 fn max_row_sum_abs(a: &CsrMatrix<f64>) -> f64 {
     let n = a.nrows();
@@ -1580,14 +1869,19 @@ fn transpose_csr_with_pos(p: &Pcsr) -> (Vec<usize>, Vec<usize>, Vec<f64>, Vec<us
     let (m, n) = (p.m, p.n);
     let nnz = p.col_idx.len();
     let mut r_row_counts = vec![0usize; n + 1];
-    for &cj in &p.col_idx { r_row_counts[cj + 1] += 1; }
-    for i in 0..n { r_row_counts[i + 1] += r_row_counts[i]; }
+    for &cj in &p.col_idx {
+        r_row_counts[cj + 1] += 1;
+    }
+    for i in 0..n {
+        r_row_counts[i + 1] += r_row_counts[i];
+    }
     let mut r_col_idx = vec![0usize; nnz];
     let mut r_vals = vec![0.0f64; nnz];
     let mut r_row_next = r_row_counts.clone();
     let mut p2r_pos = vec![0usize; nnz];
     for i in 0..m {
-        let rs = p.row_ptr[i]; let re = p.row_ptr[i+1];
+        let rs = p.row_ptr[i];
+        let re = p.row_ptr[i + 1];
         for pi in rs..re {
             let cj = p.col_idx[pi];
             let dest = r_row_next[cj];
@@ -1621,9 +1915,20 @@ mod tests {
     fn phase_selection_logic() {
         reset_relax_counts();
         let levels = vec![identity_level(), identity_level(), identity_level()];
-        let policy = RelaxPolicy { kind: [RelaxType::Jacobi; 4], sweeps: [1, 1, 1, 0], omega: 1.0 };
-        let hier = AmgHierarchy { levels, policy, coarse_solve: CoarseSolve::DirectDense };
-        let amg = AMG { state: Some(hier), ..Default::default() };
+        let policy = RelaxPolicy {
+            kind: [RelaxType::Jacobi; 4],
+            sweeps: [1, 1, 1, 0],
+            omega: 1.0,
+        };
+        let hier = AmgHierarchy {
+            levels,
+            policy,
+            coarse_solve: CoarseSolve::DirectDense,
+        };
+        let amg = AMG {
+            state: Some(hier),
+            ..Default::default()
+        };
         let rhs = [1.0];
         let mut sol = [0.0];
         amg.apply(PcSide::Left, &rhs, &mut sol).unwrap();
@@ -1662,7 +1967,10 @@ mod tests {
 
     #[test]
     fn legacy_shim_populates_arrays() {
-        let amg = AMG::builder().smoothing_sweeps(2, 3).build(&Mat::<f64>::zeros(0, 0)).unwrap();
+        let amg = AMG::builder()
+            .smoothing_sweeps(2, 3)
+            .build(&Mat::<f64>::zeros(0, 0))
+            .unwrap();
         assert_eq!(amg.cfg.num_grid_sweeps, [2, 2, 3, 1]);
     }
 }

--- a/src/preconditioner/amg/row_filter.rs
+++ b/src/preconditioner/amg/row_filter.rs
@@ -2,9 +2,9 @@ use std::cmp::Ordering;
 
 #[derive(Clone, Copy)]
 pub struct RowFilter {
-    pub tau_abs: f64,      // absolute drop (>= 0)
-    pub tau_rel: f64,      // relative truncation in [0,1)
-    pub k_max: usize,      // cap (0 => unlimited)
+    pub tau_abs: f64,             // absolute drop (>= 0)
+    pub tau_rel: f64,             // relative truncation in [0,1)
+    pub k_max: usize,             // cap (0 => unlimited)
     pub must_keep: Option<usize>, // column index to force-keep
 }
 
@@ -32,13 +32,9 @@ pub fn filter_row_by_truncation(cols: &mut Vec<usize>, vals: &mut Vec<f64>, rf: 
     if rf.tau_rel > 0.0 && !vals.is_empty() {
         // sort indices by ascending |v| with column tiebreaker for determinism
         let mut idx: Vec<usize> = (0..vals.len()).collect();
-        idx.sort_unstable_by(|&i, &j| {
-            let ai = vals[i].abs().partial_cmp(&vals[j].abs()).unwrap_or(Ordering::Equal);
-            if ai == Ordering::Equal {
-                cols[i].cmp(&cols[j])
-            } else {
-                ai
-            }
+        idx.sort_unstable_by(|&i, &j| match vals[i].abs().total_cmp(&vals[j].abs()) {
+            Ordering::Equal => cols[i].cmp(&cols[j]),
+            o => o,
         });
         let total: f64 = vals.iter().map(|v| v.abs()).sum();
         let mut dropped_sum = 0.0;
@@ -70,24 +66,31 @@ pub fn filter_row_by_truncation(cols: &mut Vec<usize>, vals: &mut Vec<f64>, rf: 
 
     // 3) Cap
     if rf.k_max > 0 && vals.len() > rf.k_max {
-        let mut idx: Vec<usize> = (0..vals.len()).collect();
-        idx.select_nth_unstable_by(rf.k_max, |&i, &j| {
-            vals[j].abs().partial_cmp(&vals[i].abs()).unwrap_or(Ordering::Equal)
+        let mut order: Vec<usize> = (0..vals.len()).collect();
+        order.sort_unstable_by(|&i, &j| match vals[j].abs().total_cmp(&vals[i].abs()) {
+            Ordering::Equal => cols[i].cmp(&cols[j]),
+            o => o,
         });
-        idx.truncate(rf.k_max);
         let mut keep = vec![false; vals.len()];
-        for &i in &idx { keep[i] = true; }
+        for &idx in order.iter().take(rf.k_max) {
+            keep[idx] = true;
+        }
         if let Some(mk) = rf.must_keep {
             if let Some(pos) = cols.iter().position(|&c| c == mk) {
                 if !keep[pos] {
-                    // find smallest among kept
-                    let mut smallest: Option<usize> = None;
-                    for &i in &idx {
-                        if smallest.map_or(true, |s: usize| vals[i].abs() < vals[s].abs()) {
-                            smallest = Some(i);
+                    let mut replace: Option<usize> = None;
+                    for &idx in order.iter().take(rf.k_max) {
+                        if replace.map_or(true, |r| {
+                            let cmp_mag = vals[idx].abs().total_cmp(&vals[r].abs());
+                            cmp_mag == Ordering::Less
+                                || (cmp_mag == Ordering::Equal && cols[idx] > cols[r])
+                        }) {
+                            replace = Some(idx);
                         }
                     }
-                    if let Some(s) = smallest { keep[s] = false; }
+                    if let Some(ridx) = replace {
+                        keep[ridx] = false;
+                    }
                     keep[pos] = true;
                 }
             }
@@ -124,7 +127,9 @@ pub fn apply_filter_to_csr_values_in_place(
     for i in 0..nrows {
         let rs = row_ptr[i];
         let re = row_ptr[i + 1];
-        if rs == re { continue; }
+        if rs == re {
+            continue;
+        }
         let mut cols: Vec<usize> = col_idx[rs..re].to_vec();
         let mut vs: Vec<f64> = vals[rs..re].to_vec();
         let rf = rf_for_row(i);
@@ -132,7 +137,9 @@ pub fn apply_filter_to_csr_values_in_place(
         let mut keep_pos = 0usize;
         for p in rs..re {
             let c = col_idx[p];
-            while keep_pos < cols.len() && cols[keep_pos] < c { keep_pos += 1; }
+            while keep_pos < cols.len() && cols[keep_pos] < c {
+                keep_pos += 1;
+            }
             if keep_pos < cols.len() && cols[keep_pos] == c {
                 vals[p] = vs[keep_pos];
             } else {
@@ -150,7 +157,12 @@ mod tests {
     fn abs_drop_and_must_keep() {
         let mut cols = vec![0, 1];
         let mut vals = vec![1e-3, 2.0];
-        let rf = RowFilter { tau_abs: 0.1, tau_rel: 0.0, k_max: 0, must_keep: Some(0) };
+        let rf = RowFilter {
+            tau_abs: 0.1,
+            tau_rel: 0.0,
+            k_max: 0,
+            must_keep: Some(0),
+        };
         filter_row_by_truncation(&mut cols, &mut vals, rf);
         assert_eq!(cols, vec![0, 1]);
     }
@@ -159,7 +171,12 @@ mod tests {
     fn relative_truncation() {
         let mut cols = vec![0, 1, 2];
         let mut vals = vec![0.2, 0.3, 0.5];
-        let rf = RowFilter { tau_abs: 0.0, tau_rel: 0.25, k_max: 0, must_keep: None };
+        let rf = RowFilter {
+            tau_abs: 0.0,
+            tau_rel: 0.25,
+            k_max: 0,
+            must_keep: None,
+        };
         filter_row_by_truncation(&mut cols, &mut vals, rf);
         assert_eq!(cols, vec![1, 2]);
     }
@@ -168,7 +185,12 @@ mod tests {
     fn cap_with_must_keep() {
         let mut cols = vec![0, 1, 2];
         let mut vals = vec![1.0, 0.9, 0.8];
-        let rf = RowFilter { tau_abs: 0.0, tau_rel: 0.0, k_max: 2, must_keep: Some(2) };
+        let rf = RowFilter {
+            tau_abs: 0.0,
+            tau_rel: 0.0,
+            k_max: 2,
+            must_keep: Some(2),
+        };
         filter_row_by_truncation(&mut cols, &mut vals, rf);
         assert_eq!(cols, vec![0, 2]);
     }
@@ -179,14 +201,14 @@ mod tests {
         let row_ptr = vec![0, 3, 5];
         let col_idx = vec![0, 1, 2, 0, 1];
         let mut vals = vec![10.0, 1e-3, 0.2, 3.0, 4.0];
-        apply_filter_to_csr_values_in_place(
-            nrows,
-            &row_ptr,
-            &col_idx,
-            &mut vals,
-            |row| RowFilter { tau_abs: 0.5, tau_rel: 0.0, k_max: 0, must_keep: Some(row) },
-        );
+        apply_filter_to_csr_values_in_place(nrows, &row_ptr, &col_idx, &mut vals, |row| {
+            RowFilter {
+                tau_abs: 0.5,
+                tau_rel: 0.0,
+                k_max: 0,
+                must_keep: Some(row),
+            }
+        });
         assert_eq!(vals, vec![10.0, 0.0, 0.0, 3.0, 4.0]);
     }
 }
-


### PR DESCRIPTION
## Summary
- replace CSR multiplication with deterministic gather-sort-compress implementation
- use stable ordering for aggregation and row filtering
- compute dot products sequentially for reproducible reductions

## Testing
- `cargo test 2>&1 | tee /tmp/test.log` (partial run)
- `cargo test --test amg_stats 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68b78df404dc8329a179ce2b5d5da198