### PR TITLE
Deterministic MIS coarsening with aggressive controls

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -14,14 +14,14 @@ use rayon::prelude::*;
 
 // New sparse SA/RS submodules
 mod coarse_solver;
-mod coarsen;
+pub mod coarsen;
 mod prolong;
 mod rap_ops;
 mod row_filter;
-mod strength;
+pub mod strength;
 
 use coarse_solver::{CoarseDenseLu, CoarseSolve, CoarseSolver};
-use coarsen::{build_aggregates, AggAlgo};
+use coarsen::{build_aggregates, AggAlgo, AggOpts};
 use prolong::{smooth_sa_values_only, smooth_tentative_sa, Pcsr, TentativeP};
 use rap_ops::{rap_numeric, rap_symbolic, CsrPattern};
 use row_filter::{apply_filter_to_csr_values_in_place, RowFilter};
@@ -151,6 +151,9 @@ pub struct AMGConfig {
     pub ilu_drop_tol: f64,
     pub ilu_fill_per_row: usize,
     pub max_operator_complexity: Option<f64>,
+    pub agg_num_levels: usize,
+    pub aggressive_mis_k: usize,
+    pub max_strong_per_row: Option<usize>,
 }
 
 impl Default for AMGConfig {
@@ -190,6 +193,9 @@ impl Default for AMGConfig {
             ilu_drop_tol: 1e-2,
             ilu_fill_per_row: 0,
             max_operator_complexity: None,
+            agg_num_levels: 1,
+            aggressive_mis_k: 2,
+            max_strong_per_row: None,
         };
         cfg.grid_relax_type = [
             cfg.relax_type,
@@ -272,6 +278,18 @@ impl AMGBuilder {
     }
     pub fn coarsening_type(mut self, v: CoarsenType) -> Self {
         self.cfg.coarsen_type = v;
+        self
+    }
+    pub fn agg_num_levels(mut self, v: usize) -> Self {
+        self.cfg.agg_num_levels = v;
+        self
+    }
+    pub fn aggressive_mis_k(mut self, v: usize) -> Self {
+        self.cfg.aggressive_mis_k = v;
+        self
+    }
+    pub fn max_strong_per_row(mut self, k: usize) -> Self {
+        self.cfg.max_strong_per_row = Some(k);
         self
     }
     pub fn interpolation_type(mut self, v: InterpType) -> Self {
@@ -1012,7 +1030,7 @@ fn build_hierarchy(
     }
 
     // Drive coarsening: build levels 0..L (inclusive L is coarsest)
-    for _level in 0..cfg.max_levels {
+    for level in 0..cfg.max_levels {
         let n = a_cur.nrows();
         if n <= cfg.coarse_threshold || n <= cfg.min_coarse_size {
             break;
@@ -1025,6 +1043,11 @@ fn build_hierarchy(
             Strength::from_csr(&a_cur, cfg.strong_threshold, cfg.normalize_strength)
         });
         // 2) Aggregates
+        let mis_k = if level < cfg.agg_num_levels {
+            cfg.aggressive_mis_k.max(2)
+        } else {
+            1
+        };
         let agg = with_timing(do_stats, &mut lt.aggregate, || {
             build_aggregates(
                 &s,
@@ -1032,8 +1055,9 @@ fn build_hierarchy(
                     CoarsenType::RS => AggAlgo::RSGreedy,
                     CoarsenType::HMIS => AggAlgo::HMIS,
                     CoarsenType::PMIS => AggAlgo::PMIS,
-                    CoarsenType::Falgout => AggAlgo::HMIS,
+                    CoarsenType::Falgout => AggAlgo::Falgout,
                 },
+                &AggOpts { mis_k, cap_per_row: cfg.max_strong_per_row },
             )
         });
         let tp = TentativeP {

--- a/src/preconditioner/amg/coarsen.rs
+++ b/src/preconditioner/amg/coarsen.rs
@@ -1,51 +1,233 @@
 use super::strength::Strength;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum AggAlgo { PMIS, HMIS, RSGreedy }
-
-/// Build aggregates from a strength graph. Returns fine -> aggregate id.
-pub fn build_aggregates(s: &Strength, algo: AggAlgo) -> Vec<usize> {
-    match algo {
-        AggAlgo::RSGreedy => rs_greedy(s),
-        AggAlgo::PMIS | AggAlgo::HMIS => rs_greedy(s), // placeholder: robust greedy default
-    }
+pub enum AggAlgo {
+    PMIS,
+    HMIS,
+    Falgout,
+    RSGreedy,
 }
 
-/// Simple greedy aggregation: each unassigned node seeds an aggregate and we
-/// attach its strongest neighbors up to a small cap.
+pub struct AggOpts {
+    pub mis_k: usize,
+    pub cap_per_row: Option<usize>,
+}
+
+/// Deterministic MIS-k on an undirected graph.
+fn mis_k(s: &Strength, k: usize, prio: &[u64]) -> Vec<bool> {
+    assert!(k >= 1);
+    let n = s.row_ptr.len() - 1;
+    let mut removed = vec![false; n];
+    let mut seed = vec![false; n];
+    let mut order: Vec<usize> = (0..n).collect();
+    order.sort_unstable_by(|&a, &b| prio[b].cmp(&prio[a]).then_with(|| b.cmp(&a)));
+    let mut q = Vec::<usize>::new();
+    let mut vis = vec![usize::MAX; n];
+    let mut tick = 0usize;
+    for &u in &order {
+        if removed[u] {
+            continue;
+        }
+        seed[u] = true;
+        tick += 1;
+        q.clear();
+        vis[u] = 0;
+        q.push(u);
+        while let Some(x) = q.pop() {
+            removed[x] = true;
+            let depth = vis[x];
+            if depth == k {
+                continue;
+            }
+            let rs = s.row_ptr[x];
+            let re = s.row_ptr[x + 1];
+            for &v in &s.col_idx[rs..re] {
+                if vis[v] != tick && vis[v] > depth + 1 {
+                    vis[v] = depth + 1;
+                    q.push(v);
+                }
+            }
+        }
+    }
+    seed
+}
+
+#[inline]
+fn prio_degree(i: usize, deg: usize) -> u64 {
+    ((deg as u64) << 32) | (u32::MAX as u64 - i as u64)
+}
+
+#[inline]
+fn prio_hmis(i: usize, deg1: usize, deg2: usize) -> u64 {
+    ((deg2 as u64) << 42) | ((deg1 as u64) << 32) | (u32::MAX as u64 - i as u64)
+}
+
+fn aggregates_from_seeds(s: &Strength, is_seed: &[bool]) -> Vec<usize> {
+    let n = s.row_ptr.len() - 1;
+    let mut agg = vec![usize::MAX; n];
+    let mut next = 0usize;
+    for i in 0..n {
+        if is_seed[i] {
+            agg[i] = next;
+            next += 1;
+        }
+    }
+    for i in 0..n {
+        if agg[i] != usize::MAX {
+            continue;
+        }
+        let rs = s.row_ptr[i];
+        let re = s.row_ptr[i + 1];
+        let mut best: Option<usize> = None;
+        for &j in &s.col_idx[rs..re] {
+            if is_seed[j] {
+                best = Some(match best {
+                    Some(b) => b.min(j),
+                    None => j,
+                });
+            }
+        }
+        if let Some(seed) = best {
+            agg[i] = agg[seed];
+            continue;
+        }
+        'twohop: {
+            for &j in &s.col_idx[rs..re] {
+                let rs2 = s.row_ptr[j];
+                let re2 = s.row_ptr[j + 1];
+                for &k in &s.col_idx[rs2..re2] {
+                    if is_seed[k] {
+                        agg[i] = agg[k];
+                        break 'twohop;
+                    }
+                }
+            }
+        }
+        if agg[i] == usize::MAX {
+            agg[i] = {
+                let id = next;
+                next += 1;
+                id
+            };
+        }
+    }
+    agg
+}
+
+/// Build aggregates from a strength graph. Returns fine -> aggregate id.
+pub fn build_aggregates(s_in: &Strength, algo: AggAlgo, opts: &AggOpts) -> Vec<usize> {
+    let mut s = s_in.symmetrize();
+    if let Some(k) = opts.cap_per_row {
+        s = s.capped(k);
+    }
+    let n = s.row_ptr.len() - 1;
+
+    if matches!(algo, AggAlgo::RSGreedy) {
+        return rs_greedy(&s);
+    }
+
+    let mut deg1 = vec![0usize; n];
+    let mut deg2 = vec![0usize; n];
+    for i in 0..n {
+        let rs = s.row_ptr[i];
+        let re = s.row_ptr[i + 1];
+        let di = re - rs;
+        deg1[i] = di;
+        let mut sum = 0usize;
+        for &j in &s.col_idx[rs..re] {
+            sum += s.row_ptr[j + 1] - s.row_ptr[j];
+        }
+        deg2[i] = sum;
+    }
+    let mut prio = vec![0u64; n];
+    match algo {
+        AggAlgo::PMIS | AggAlgo::Falgout => {
+            for i in 0..n {
+                prio[i] = prio_degree(i, deg1[i]);
+            }
+        }
+        AggAlgo::HMIS => {
+            for i in 0..n {
+                prio[i] = prio_hmis(i, deg1[i], deg2[i]);
+            }
+        }
+        AggAlgo::RSGreedy => {}
+    }
+    let mut is_seed = mis_k(&s, opts.mis_k.max(1), &prio);
+
+    if matches!(algo, AggAlgo::Falgout) {
+        for i in 0..n {
+            if is_seed[i] {
+                continue;
+            }
+            let rs = s.row_ptr[i];
+            let re = s.row_ptr[i + 1];
+            let mut has = false;
+            for &j in &s.col_idx[rs..re] {
+                if is_seed[j] {
+                    has = true;
+                    break;
+                }
+            }
+            if !has {
+                let mut best = i;
+                let mut bestp = prio[i];
+                for &j in &s.col_idx[rs..re] {
+                    if prio[j] > bestp {
+                        best = j;
+                        bestp = prio[j];
+                    }
+                }
+                is_seed[best] = true;
+            }
+        }
+    }
+
+    aggregates_from_seeds(&s, &is_seed)
+}
+
+// Legacy greedy aggregator kept for compatibility.
 fn rs_greedy(s: &Strength) -> Vec<usize> {
     let n = s.row_ptr.len() - 1;
     let mut agg = vec![usize::MAX; n];
     let mut next = 0usize;
     let max_sz = 4usize;
-
-    // Order nodes by degree descending to seed aggregates on hubs first
     let mut order: Vec<(usize, usize)> = (0..n)
         .map(|i| (s.row_ptr[i + 1] - s.row_ptr[i], i))
         .collect();
     order.sort_by(|a, b| b.0.cmp(&a.0));
-
     for &(_, seed) in &order {
-        if agg[seed] != usize::MAX { continue; }
+        if agg[seed] != usize::MAX {
+            continue;
+        }
         agg[seed] = next;
-        // gather neighbors by degree as a simple heuristic
-        let rs = s.row_ptr[seed]; let re = s.row_ptr[seed + 1];
+        let rs = s.row_ptr[seed];
+        let re = s.row_ptr[seed + 1];
         let mut neigh: Vec<(usize, usize)> = s.col_idx[rs..re]
-            .iter().copied()
+            .iter()
+            .copied()
             .filter(|&j| agg[j] == usize::MAX)
             .map(|j| (s.row_ptr[j + 1] - s.row_ptr[j], j))
             .collect();
         neigh.sort_by(|a, b| b.0.cmp(&a.0));
         let mut count = 1usize;
         for &(_, j) in &neigh {
-            if count >= max_sz { break; }
-            agg[j] = next; count += 1;
+            if count >= max_sz {
+                break;
+            }
+            agg[j] = next;
+            count += 1;
         }
         next += 1;
     }
-
-    // Any singleton remainers get their own aggregate
-    for i in 0..n { if agg[i] == usize::MAX { agg[i] = { let id = next; next += 1; id }; } }
+    for i in 0..n {
+        if agg[i] == usize::MAX {
+            agg[i] = {
+                let id = next;
+                next += 1;
+                id
+            };
+        }
+    }
     agg
 }
-

--- a/src/preconditioner/amg/strength.rs
+++ b/src/preconditioner/amg/strength.rs
@@ -10,6 +10,81 @@ impl Strength {
     pub fn from_csr(a: &CsrMatrix<f64>, theta: f64, normalize: bool) -> Self {
         strength_csr(a, theta, normalize)
     }
+
+    /// Optional per-row cap: keep the first `k` columns in ascending column order.
+    pub fn capped(&self, k: usize) -> Strength {
+        if k == 0 {
+            return self.clone();
+        }
+        let n = self.row_ptr.len() - 1;
+        let mut row_ptr = Vec::with_capacity(n + 1);
+        row_ptr.push(0);
+        let mut col_idx = Vec::with_capacity(self.col_idx.len());
+        for i in 0..n {
+            let rs = self.row_ptr[i];
+            let re = self.row_ptr[i + 1];
+            let take = (re - rs).min(k);
+            col_idx.extend_from_slice(&self.col_idx[rs..rs + take]);
+            row_ptr.push(col_idx.len());
+        }
+        Strength { row_ptr, col_idx }
+    }
+
+    /// Symmetrize the strength graph treating it as undirected.
+    pub fn symmetrize(&self) -> Strength {
+        let n = self.row_ptr.len() - 1;
+        let mut deg = vec![0usize; n];
+        for i in 0..n {
+            for &j in &self.col_idx[self.row_ptr[i]..self.row_ptr[i + 1]] {
+                deg[i] += 1;
+                deg[j] += 1;
+            }
+        }
+        let mut row_ptr = Vec::with_capacity(n + 1);
+        row_ptr.push(0);
+        for i in 0..n {
+            row_ptr.push(row_ptr[i] + deg[i]);
+        }
+        let mut col_idx = vec![usize::MAX; row_ptr[n]];
+        let mut next = vec![0usize; n];
+        for i in 0..n {
+            next[i] = row_ptr[i];
+        }
+        for i in 0..n {
+            for &j in &self.col_idx[self.row_ptr[i]..self.row_ptr[i + 1]] {
+                let pi = next[i];
+                col_idx[pi] = j;
+                next[i] += 1;
+                let pj = next[j];
+                col_idx[pj] = i;
+                next[j] += 1;
+            }
+        }
+        for i in 0..n {
+            let rs = row_ptr[i];
+            let re = row_ptr[i + 1];
+            col_idx[rs..re].sort_unstable();
+            let mut write = rs;
+            let mut last = None;
+            for idx in rs..re {
+                let v = col_idx[idx];
+                if Some(v) != last {
+                    col_idx[write] = v;
+                    write += 1;
+                    last = Some(v);
+                }
+            }
+            let len = write - rs;
+            col_idx.drain(write..re);
+            let delta = (re - rs) - len;
+            if delta > 0 {
+                for r in (i + 1)..=n {
+                    row_ptr[r] -= delta;
+                }
+            }
+        }
+        Strength { row_ptr, col_idx }
+    }
 }
 
 pub fn strength_csr(a: &CsrMatrix<f64>, theta: f64, normalize: bool) -> Strength {
@@ -26,23 +101,33 @@ pub fn strength_csr(a: &CsrMatrix<f64>, theta: f64, normalize: bool) -> Strength
         // |a_ij| / sqrt(|a_ii||a_jj|)
         let mut diag = vec![0.0f64; n];
         for i in 0..n {
-            let rs = rp[i]; let re = rp[i + 1];
+            let rs = rp[i];
+            let re = rp[i + 1];
             let mut aii = 0.0;
             for p in rs..re {
-                if cj[p] == i { aii = vv[p].abs(); break; }
+                if cj[p] == i {
+                    aii = vv[p].abs();
+                    break;
+                }
             }
             diag[i] = aii;
         }
         for i in 0..n {
-            let rs = rp[i]; let re = rp[i + 1];
+            let rs = rp[i];
+            let re = rp[i + 1];
             let mut count = 0usize;
             for p in rs..re {
                 let j = cj[p];
-                if j == i { continue; }
+                if j == i {
+                    continue;
+                }
                 let denom = (diag[i] * diag[j]).sqrt();
                 if denom > 0.0 {
                     let s = vv[p].abs() / denom;
-                    if s >= theta { col_idx.push(j); count += 1; }
+                    if s >= theta {
+                        col_idx.push(j);
+                        count += 1;
+                    }
                 }
             }
             row_ptr.push(row_ptr.last().unwrap() + count);
@@ -50,14 +135,23 @@ pub fn strength_csr(a: &CsrMatrix<f64>, theta: f64, normalize: bool) -> Strength
     } else {
         // |a_ij| >= theta * max_off_i
         for i in 0..n {
-            let rs = rp[i]; let re = rp[i + 1];
+            let rs = rp[i];
+            let re = rp[i + 1];
             let mut max_off = 0.0f64;
-            for p in rs..re { let j = cj[p]; if j != i { max_off = max_off.max(vv[p].abs()); } }
+            for p in rs..re {
+                let j = cj[p];
+                if j != i {
+                    max_off = max_off.max(vv[p].abs());
+                }
+            }
             let thr = theta * max_off;
             let mut count = 0usize;
             for p in rs..re {
                 let j = cj[p];
-                if j != i && vv[p].abs() >= thr { col_idx.push(j); count += 1; }
+                if j != i && vv[p].abs() >= thr {
+                    col_idx.push(j);
+                    count += 1;
+                }
             }
             row_ptr.push(row_ptr.last().unwrap() + count);
         }
@@ -65,4 +159,3 @@ pub fn strength_csr(a: &CsrMatrix<f64>, theta: f64, normalize: bool) -> Strength
 
     Strength { row_ptr, col_idx }
 }
-

--- a/src/preconditioner/tests/coarsen.rs
+++ b/src/preconditioner/tests/coarsen.rs
@@ -1,0 +1,78 @@
+use super::*;
+use crate::preconditioner::amg::coarsen::{build_aggregates, AggAlgo, AggOpts};
+use crate::preconditioner::amg::strength::Strength;
+use std::collections::VecDeque;
+
+fn path_strength(n: usize) -> Strength {
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx = Vec::new();
+    row_ptr.push(0);
+    for i in 0..n {
+        if i > 0 {
+            col_idx.push(i - 1);
+        }
+        if i + 1 < n {
+            col_idx.push(i + 1);
+        }
+        row_ptr.push(col_idx.len());
+    }
+    Strength { row_ptr, col_idx }
+}
+
+fn bfs_dist(s: &Strength, start: usize, goal: usize) -> usize {
+    if start == goal {
+        return 0;
+    }
+    let n = s.row_ptr.len() - 1;
+    let mut dist = vec![usize::MAX; n];
+    let mut q = VecDeque::new();
+    dist[start] = 0;
+    q.push_back(start);
+    while let Some(u) = q.pop_front() {
+        let d = dist[u];
+        let rs = s.row_ptr[u];
+        let re = s.row_ptr[u + 1];
+        for &v in &s.col_idx[rs..re] {
+            if dist[v] == usize::MAX {
+                dist[v] = d + 1;
+                if v == goal {
+                    return dist[v];
+                }
+                q.push_back(v);
+            }
+        }
+    }
+    usize::MAX
+}
+
+#[test]
+fn mis_independence_and_determinism() {
+    let s = path_strength(10);
+    for algo in [AggAlgo::PMIS, AggAlgo::HMIS] {
+        for &k in &[1usize, 2usize] {
+            let opts = AggOpts {
+                mis_k: k,
+                cap_per_row: None,
+            };
+            let agg1 = build_aggregates(&s, algo, &opts);
+            let agg2 = build_aggregates(&s, algo, &opts);
+            assert_eq!(agg1, agg2);
+            let n_coarse = 1 + agg1.iter().copied().max().unwrap_or(0);
+            let mut seeds = Vec::new();
+            let mut seen = vec![false; n_coarse];
+            for (i, &a) in agg1.iter().enumerate() {
+                if !seen[a] {
+                    seeds.push(i);
+                    seen[a] = true;
+                }
+                assert!(a < n_coarse);
+            }
+            for i in 0..seeds.len() {
+                for j in (i + 1)..seeds.len() {
+                    let d = bfs_dist(&s, seeds[i], seeds[j]);
+                    assert!(d > k, "seeds {}/{} too close: {}", seeds[i], seeds[j], d);
+                }
+            }
+        }
+    }
+}

--- a/src/preconditioner/tests/mod.rs
+++ b/src/preconditioner/tests/mod.rs
@@ -50,7 +50,8 @@ fn default_apply_mut_forwards_to_apply() {
     assert_eq!(pc.calls.load(Ordering::Relaxed), 1);
 }
 
-mod legacy_bridge;
+mod coarsen;
 mod direct_apply;
 mod ilu_csr;
 mod ilu_history;
+mod legacy_bridge;


### PR DESCRIPTION
## Summary
- add strength graph helpers for capping and symmetrization
- implement deterministic MIS-k coarsening supporting PMIS, HMIS, and Falgout
- expose aggressive coarsening options in `AMGConfig` and wire into hierarchy builder
- add tests for MIS independence and determinism

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_e_68b79996568c8329bbdb0712655feed1