### PR TITLE
Add classical interpolation framework

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -22,7 +22,17 @@ pub mod strength;
 
 use coarse_solver::{CoarseDenseLu, CoarseSolve, CoarseSolver};
 use coarsen::{build_aggregates, AggAlgo, AggOpts};
-use prolong::{smooth_sa_values_only, smooth_tentative_sa, Pcsr, TentativeP};
+use prolong::{
+    smooth_sa_values_only,
+    smooth_tentative_sa,
+    Pcsr,
+    TentativeP,
+    CFInfo,
+    classical_pattern,
+    classical_values_only,
+    ClassicalParams,
+    ClassicalVariant,
+};
 use rap_ops::{rap_numeric, rap_symbolic, CsrPattern};
 use row_filter::{apply_filter_to_csr_values_in_place, RowFilter};
 use strength::Strength;
@@ -462,6 +472,10 @@ struct AMGLevel {
     diag_inv: Vec<f64>,
     /// fine->coarse aggregate id used to rebuild P values (SA numeric refresh)
     agg_of: Vec<usize>,
+    /// coarse/fine flags for classical interpolation
+    is_c: Vec<bool>,
+    /// CF metadata for classical interpolation
+    cf: Option<CFInfo>,
     /// Mapping from P entry index -> index in R (transpose) values array
     p2r_pos: Vec<usize>,
     /// Symbolic pattern for A_{l+1}
@@ -558,24 +572,52 @@ impl AMG {
         // Recompute P_l values, R_l values, and A_{l+1} values using fixed patterns
         for l in 0..h.coarsest_ix() {
             // Recompute P_l values in-place using SA smoother with fixed pattern
-            let tp = TentativeP {
-                agg_of: h.levels[l].agg_of.clone(),
-                n_coarse: h.levels[l + 1].a.nrows(),
-            };
-            let d_inv = &h.levels[l].diag_inv;
-            // Recompute P values under fixed pattern without borrowing P mutably during computation
             let pr = h.levels[l].p.row_ptr().to_vec();
             let pc = h.levels[l].p.col_idx().to_vec();
             let mut p_new_vals = vec![0.0f64; pc.len()];
-            smooth_sa_values_only(
-                &h.levels[l].a,
-                d_inv,
-                &tp,
-                self.cfg.jacobi_omega,
-                &pr,
-                &pc,
-                &mut p_new_vals,
-            )?;
+            if let Some(ref cf) = h.levels[l].cf {
+                let s = Strength::from_csr(
+                    &h.levels[l].a,
+                    self.cfg.strong_threshold,
+                    self.cfg.normalize_strength,
+                );
+                let s_sym = s.symmetrize();
+                let params = ClassicalParams {
+                    variant: match self.cfg.interp_type {
+                        InterpType::Direct => ClassicalVariant::Direct,
+                        InterpType::Standard | InterpType::Classical | InterpType::Extended => ClassicalVariant::Standard,
+                        _ => ClassicalVariant::Standard,
+                    },
+                    extended: matches!(self.cfg.interp_type, InterpType::Extended),
+                    drop_abs: self.cfg.interpolation_truncation,
+                    trunc_rel: self.cfg.truncation_factor,
+                    cap_row: self.cfg.max_elements_per_row,
+                    keep_at_least_one: true,
+                };
+                classical_values_only(
+                    &h.levels[l].a,
+                    &s_sym,
+                    cf,
+                    &params,
+                    &pr,
+                    &pc,
+                    &mut p_new_vals,
+                )?;
+            } else {
+                let tp = TentativeP {
+                    agg_of: h.levels[l].agg_of.clone(),
+                    n_coarse: h.levels[l + 1].a.nrows(),
+                };
+                smooth_sa_values_only(
+                    &h.levels[l].a,
+                    &h.levels[l].diag_inv,
+                    &tp,
+                    self.cfg.jacobi_omega,
+                    &pr,
+                    &pc,
+                    &mut p_new_vals,
+                )?;
+            }
             h.levels[l].p.values_mut().copy_from_slice(&p_new_vals);
             // Update R values from P via precomputed transpose mapping
             {
@@ -1012,6 +1054,8 @@ fn build_hierarchy(
         p: CsrMatrix::identity(a_cur.nrows()),
         r: CsrMatrix::identity(a_cur.nrows()),
         agg_of: (0..a_cur.nrows()).collect(),
+        is_c: Vec::new(),
+        cf: None,
         p2r_pos: Vec::new(),
         a_next_pat: None,
     };
@@ -1048,7 +1092,7 @@ fn build_hierarchy(
         } else {
             1
         };
-        let agg = with_timing(do_stats, &mut lt.aggregate, || {
+        let (agg, is_c) = with_timing(do_stats, &mut lt.aggregate, || {
             build_aggregates(
                 &s,
                 match cfg.coarsen_type {
@@ -1064,20 +1108,52 @@ fn build_hierarchy(
             n_coarse: 1 + agg.iter().copied().max().unwrap_or(0),
             agg_of: agg.clone(),
         };
-        // 3) Smoothed aggregation P (sparse-only)
-        let p_csr: Pcsr = with_timing(do_stats, &mut lt.prolong, || {
-            let d = diag_inv_from_csr(&a_cur)?;
-            Ok(smooth_tentative_sa(
-                &a_cur,
-                &d,
-                &tp,
-                cfg.jacobi_omega,
-                cfg.interpolation_truncation,
-                cfg.max_elements_per_row,
-                cfg.truncation_factor,
-            ))
+        let s_sym = s.symmetrize();
+        let (p_csr, cf_opt): (Pcsr, Option<CFInfo>) = with_timing(do_stats, &mut lt.prolong, || {
+            if matches!(cfg.interp_type, InterpType::Direct | InterpType::Standard | InterpType::Extended | InterpType::Classical) {
+                let extended = matches!(cfg.interp_type, InterpType::Extended);
+                let (pat, cf) = classical_pattern(&a_cur, &s_sym, &is_c, extended);
+                let mut vals = vec![0.0; pat.col_idx.len()];
+                let params = ClassicalParams {
+                    variant: match cfg.interp_type {
+                        InterpType::Direct => ClassicalVariant::Direct,
+                        InterpType::Standard | InterpType::Classical | InterpType::Extended => ClassicalVariant::Standard,
+                        _ => ClassicalVariant::Standard,
+                    },
+                    extended,
+                    drop_abs: cfg.interpolation_truncation,
+                    trunc_rel: cfg.truncation_factor,
+                    cap_row: cfg.max_elements_per_row,
+                    keep_at_least_one: true,
+                };
+                classical_values_only(
+                    &a_cur,
+                    &s_sym,
+                    &cf,
+                    &params,
+                    &pat.row_ptr,
+                    &pat.col_idx,
+                    &mut vals,
+                )?;
+                let mut p = pat.clone();
+                p.vals = vals;
+                Ok((p, Some(cf)))
+            } else {
+                let d = diag_inv_from_csr(&a_cur)?;
+                Ok((
+                    smooth_tentative_sa(
+                        &a_cur,
+                        &d,
+                        &tp,
+                        cfg.jacobi_omega,
+                        cfg.interpolation_truncation,
+                        cfg.max_elements_per_row,
+                        cfg.truncation_factor,
+                    ),
+                    None,
+                ))
+            }
         })?;
-        // Build owned CSR for P and R
         let p = CsrMatrix::from_csr(
             p_csr.m,
             p_csr.n,
@@ -1149,6 +1225,8 @@ fn build_hierarchy(
             prev.p = p.clone();
             prev.r = r.clone();
             prev.agg_of = tp.agg_of.clone();
+            prev.is_c = is_c.clone();
+            prev.cf = cf_opt.clone();
             prev.p2r_pos = p2r_pos;
             prev.a_next_pat = Some(pat.clone());
         }
@@ -1161,6 +1239,8 @@ fn build_hierarchy(
             r: CsrMatrix::identity(a_cur.nrows()),
             diag_inv: diag_inv_coarse,
             agg_of: (0..a_cur.nrows()).collect(),
+            is_c: Vec::new(),
+            cf: None,
             p2r_pos: Vec::new(),
             a_next_pat: None,
         });

--- a/src/preconditioner/amg/coarsen.rs
+++ b/src/preconditioner/amg/coarsen.rs
@@ -115,7 +115,11 @@ fn aggregates_from_seeds(s: &Strength, is_seed: &[bool]) -> Vec<usize> {
 }
 
 /// Build aggregates from a strength graph. Returns fine -> aggregate id.
-pub fn build_aggregates(s_in: &Strength, algo: AggAlgo, opts: &AggOpts) -> Vec<usize> {
+pub fn build_aggregates(
+    s_in: &Strength,
+    algo: AggAlgo,
+    opts: &AggOpts,
+) -> (Vec<usize>, Vec<bool>) {
     let mut s = s_in.symmetrize();
     if let Some(k) = opts.cap_per_row {
         s = s.capped(k);
@@ -183,7 +187,8 @@ pub fn build_aggregates(s_in: &Strength, algo: AggAlgo, opts: &AggOpts) -> Vec<u
         }
     }
 
-    aggregates_from_seeds(&s, &is_seed)
+    let agg = aggregates_from_seeds(&s, &is_seed);
+    (agg, is_seed)
 }
 
 // Legacy greedy aggregator kept for compatibility.

--- a/src/preconditioner/amg/prolong.rs
+++ b/src/preconditioner/amg/prolong.rs
@@ -2,6 +2,7 @@
 
 use crate::matrix::sparse::CsrMatrix;
 use super::row_filter::{RowFilter, filter_row_by_truncation};
+use super::strength::Strength;
 
 #[derive(Clone, Debug)]
 pub struct TentativeP {
@@ -21,6 +22,320 @@ pub struct Pcsr {
     pub row_ptr: Vec<usize>,
     pub col_idx: Vec<usize>,
     pub vals: Vec<f64>,
+}
+
+// ===== Classical interpolation family =======================================
+
+/// Variants of classical interpolation.
+#[derive(Clone, Copy, Debug)]
+pub enum ClassicalVariant {
+    Direct,
+    Standard,
+    HE,
+}
+
+/// Coarse/fine bookkeeping produced by `classical_pattern`.
+#[derive(Clone, Debug)]
+pub struct CFInfo {
+    pub is_c: Vec<bool>,
+    pub coarse_of: Vec<Option<usize>>, // Some(k) if C, None if F
+}
+
+/// Parameters controlling value computation for the classical family.
+#[derive(Clone, Debug)]
+pub struct ClassicalParams {
+    pub variant: ClassicalVariant,
+    pub extended: bool,
+    pub drop_abs: f64,
+    pub trunc_rel: f64,
+    pub cap_row: usize,
+    pub keep_at_least_one: bool,
+}
+
+fn build_cf_info(is_c: &[bool]) -> CFInfo {
+    let mut coarse_of = vec![None; is_c.len()];
+    let mut k = 0usize;
+    for (i, &c) in is_c.iter().enumerate() {
+        if c {
+            coarse_of[i] = Some(k);
+            k += 1;
+        }
+    }
+    CFInfo { is_c: is_c.to_vec(), coarse_of }
+}
+
+/// Helper: get entry a[i,j] via binary search in row i.
+fn csr_get(a: &CsrMatrix<f64>, i: usize, j: usize) -> Option<f64> {
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+    let rs = rp[i];
+    let re = rp[i + 1];
+    cj[rs..re]
+        .binary_search(&j)
+        .ok()
+        .map(|p| vv[rs + p])
+}
+
+/// Build classical interpolation pattern.
+pub fn classical_pattern(
+    a: &CsrMatrix<f64>,
+    s_sym: &Strength,
+    is_c: &[bool],
+    extended: bool,
+) -> (Pcsr, CFInfo) {
+    let n = a.nrows();
+    let cf = build_cf_info(is_c);
+    let ncoarse = cf.coarse_of.iter().filter_map(|&x| x).max().map(|x| x + 1).unwrap_or(0);
+
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx = Vec::<usize>::new();
+    let mut vals = Vec::<f64>::new();
+    row_ptr.push(0);
+
+    for i in 0..n {
+        if cf.is_c[i] {
+            let k = cf.coarse_of[i].unwrap();
+            col_idx.push(k);
+            vals.push(0.0);
+            row_ptr.push(col_idx.len());
+            continue;
+        }
+
+        let mut cols: Vec<usize> = Vec::new();
+        let rs = s_sym.row_ptr[i];
+        let re = s_sym.row_ptr[i + 1];
+        for &j in &s_sym.col_idx[rs..re] {
+            if cf.is_c[j] {
+                cols.push(cf.coarse_of[j].unwrap());
+            }
+        }
+        if extended {
+            for &j in &s_sym.col_idx[rs..re] {
+                if cf.is_c[j] { continue; }
+                let rj = s_sym.row_ptr[j];
+                let ej = s_sym.row_ptr[j + 1];
+                for &k in &s_sym.col_idx[rj..ej] {
+                    if cf.is_c[k] {
+                        cols.push(cf.coarse_of[k].unwrap());
+                    }
+                }
+            }
+        }
+        cols.sort_unstable();
+        cols.dedup();
+
+        if cols.is_empty() {
+            // weak search in A
+            let rp = a.row_ptr();
+            let cj = a.col_idx();
+            let rs_a = rp[i];
+            let re_a = rp[i + 1];
+            let mut best: Option<usize> = None;
+            let mut bestmag = 0.0;
+            for p in rs_a..re_a {
+                let j = cj[p];
+                if cf.is_c[j] {
+                    let k = cf.coarse_of[j].unwrap();
+                    let v = a.values()[p].abs();
+                    if v > bestmag { bestmag = v; best = Some(k); }
+                }
+            }
+            if let Some(k) = best { cols.push(k); }
+            else if ncoarse > 0 { cols.push(0); }
+        }
+
+        for c in cols {
+            col_idx.push(c);
+            vals.push(0.0);
+        }
+        row_ptr.push(col_idx.len());
+    }
+
+    (Pcsr { m: n, n: ncoarse, row_ptr, col_idx, vals }, cf)
+}
+
+/// For F-neighbor j, distribute influence over its strong C neighbors.
+fn neighbor_distribution_over_C_of(
+    j: usize,
+    a: &CsrMatrix<f64>,
+    s_sym: &Strength,
+    cf: &CFInfo,
+    cols: &mut Vec<usize>,
+    wts: &mut Vec<f64>,
+) {
+    cols.clear();
+    wts.clear();
+    let rs = s_sym.row_ptr[j];
+    let re = s_sym.row_ptr[j + 1];
+    let mut tmp: Vec<(usize, f64)> = Vec::new();
+    let mut sum_neg = 0.0;
+    let mut sum_pos = 0.0;
+    for &nbr in &s_sym.col_idx[rs..re] {
+        if cf.is_c[nbr] {
+            let c = cf.coarse_of[nbr].unwrap();
+            if let Some(v) = csr_get(a, j, nbr) {
+                tmp.push((c, v));
+                if v < 0.0 { sum_neg += -v; } else { sum_pos += v; }
+            }
+        }
+    }
+    if tmp.is_empty() { return; }
+    for (c, v) in tmp {
+        let w = if v < 0.0 { if sum_neg > 0.0 { (-v)/sum_neg } else { 0.0 } } else { if sum_pos > 0.0 { v/sum_pos } else { 0.0 } };
+        cols.push(c);
+        wts.push(w);
+    }
+    let s: f64 = wts.iter().sum();
+    if s > 0.0 { for w in wts.iter_mut() { *w /= s; } }
+    else {
+        let u = 1.0 / (wts.len() as f64);
+        for w in wts.iter_mut() { *w = u; }
+    }
+}
+
+/// Values-only refresh for classical interpolation.
+pub fn classical_values_only(
+    a: &CsrMatrix<f64>,
+    s_sym: &Strength,
+    cf: &CFInfo,
+    params: &ClassicalParams,
+    p_row_ptr: &[usize],
+    p_col_idx: &[usize],
+    out_vals: &mut [f64],
+) -> Result<(), crate::error::KError> {
+    let n = a.nrows();
+    assert_eq!(p_row_ptr.len(), n + 1);
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+    let mut buf_cols = Vec::<usize>::new();
+    let mut buf_wts = Vec::<f64>::new();
+
+    for i in 0..n {
+        let rs_p = p_row_ptr[i];
+        let re_p = p_row_ptr[i + 1];
+        if cf.is_c[i] {
+            for k in rs_p..re_p { out_vals[k] = 0.0; }
+            if let Some(kc) = cf.coarse_of[i] {
+                for k in rs_p..re_p { if p_col_idx[k] == kc { out_vals[k] = 1.0; break; } }
+            }
+            continue;
+        }
+
+        let mut contrib_cols: Vec<usize> = Vec::new();
+        let mut contrib_vals: Vec<f64> = Vec::new();
+
+        let rs = s_sym.row_ptr[i];
+        let re = s_sym.row_ptr[i + 1];
+
+        // Direct part
+        let mut sum_neg = 0.0; let mut sum_pos = 0.0;
+        for &j in &s_sym.col_idx[rs..re] {
+            if cf.is_c[j] {
+                if let Some(aij) = csr_get(a, i, j) {
+                    if params.variant == ClassicalVariant::Direct {
+                        if aij < 0.0 { sum_neg += -aij; } else { sum_pos += aij; }
+                    } else {
+                        let col = cf.coarse_of[j].unwrap();
+                        contrib_cols.push(col);
+                        contrib_vals.push(-aij);
+                    }
+                }
+            }
+        }
+        if params.variant == ClassicalVariant::Direct {
+            for &j in &s_sym.col_idx[rs..re] {
+                if cf.is_c[j] {
+                    if let Some(aij) = csr_get(a, i, j) {
+                        let col = cf.coarse_of[j].unwrap();
+                        let w = if aij < 0.0 {
+                            if sum_neg > 0.0 { (-aij)/sum_neg } else { 0.0 }
+                        } else {
+                            if sum_pos > 0.0 { aij/sum_pos } else { 0.0 }
+                        };
+                        contrib_cols.push(col);
+                        contrib_vals.push(w);
+                    }
+                }
+            }
+        }
+
+        if matches!(params.variant, ClassicalVariant::Standard | ClassicalVariant::HE) {
+            for &j in &s_sym.col_idx[rs..re] {
+                if cf.is_c[j] { continue; }
+                let aij = match csr_get(a, i, j) { Some(v) => v, None => continue };
+                if aij == 0.0 { continue; }
+                neighbor_distribution_over_C_of(j, a, s_sym, cf, &mut buf_cols, &mut buf_wts);
+                let scale = if matches!(params.variant, ClassicalVariant::HE) {
+                    let mut rowsum = 0.0; let mut ajj = 0.0;
+                    let rj = rp[j]; let ej = rp[j + 1];
+                    for p in rj..ej {
+                        let v = vv[p];
+                        if cj[p] == j { ajj = v.abs(); } else { rowsum += v.abs(); }
+                    }
+                    let denom = ajj.max(rowsum).max(1e-30);
+                    (-aij) / denom
+                } else { -aij };
+                for t in 0..buf_cols.len() {
+                    contrib_cols.push(buf_cols[t]);
+                    contrib_vals.push(scale * buf_wts[t]);
+                }
+            }
+
+            // denominator
+            let mut sum_neg_strong = 0.0;
+            for &j in &s_sym.col_idx[rs..re] {
+                if let Some(aij) = csr_get(a, i, j) { if aij < 0.0 { sum_neg_strong += -aij; } }
+            }
+            let mut di = csr_get(a, i, i).unwrap_or(1.0);
+            let di_eff = di - sum_neg_strong;
+            let denom = if di_eff.abs() >= 1e-14 * di.abs().max(1.0) { di_eff } else { di };
+            if denom.abs() < 1e-30 {
+                let mut s = 0.0; for v in &contrib_vals { s += v.abs(); }
+                if s > 0.0 { for v in &mut contrib_vals { *v /= s; } }
+            } else {
+                for v in &mut contrib_vals { *v /= denom; }
+            }
+        }
+
+        if !contrib_cols.is_empty() {
+            let mut idx: Vec<usize> = (0..contrib_cols.len()).collect();
+            idx.sort_unstable_by(|&u,&v| contrib_cols[u].cmp(&contrib_cols[v]));
+            let mut last = contrib_cols[idx[0]];
+            let mut acc = 0.0;
+            let mut cols = Vec::new();
+            let mut vals = Vec::new();
+            for &id in &idx {
+                let c = contrib_cols[id];
+                if c == last { acc += contrib_vals[id]; }
+                else { if acc != 0.0 { cols.push(last); vals.push(acc); } last = c; acc = contrib_vals[id]; }
+            }
+            if acc != 0.0 { cols.push(last); vals.push(acc); }
+
+            let kept_cols = cols.clone();
+            let kept_vals = vals.clone();
+            let mut rf = RowFilter { tau_abs: params.drop_abs, tau_rel: params.trunc_rel, k_max: params.cap_row, must_keep: None };
+            filter_row_by_truncation(&mut cols, &mut vals, rf);
+            if params.keep_at_least_one && cols.is_empty() && !kept_cols.is_empty() {
+                let mut best = 0usize; let mut bestmag = kept_vals[0].abs();
+                for t in 1..kept_cols.len() { let m = kept_vals[t].abs(); if m > bestmag { bestmag = m; best = t; } }
+                cols.push(kept_cols[best]);
+                vals.push(kept_vals[best]);
+            }
+            for k in rs_p..re_p {
+                let c = p_col_idx[k];
+                match cols.binary_search(&c) {
+                    Ok(pos) => out_vals[k] = vals[pos],
+                    Err(_) => out_vals[k] = 0.0,
+                }
+            }
+        } else {
+            for k in rs_p..re_p { out_vals[k] = 0.0; }
+            if rs_p < re_p { out_vals[rs_p] = 1.0; }
+        }
+    }
+    Ok(())
 }
 
 /// Build smoothed aggregation prolongator using one SA sweep.

--- a/src/preconditioner/tests/classical.rs
+++ b/src/preconditioner/tests/classical.rs
@@ -1,0 +1,26 @@
+use super::*;
+use crate::preconditioner::amg::prolong::classical_pattern;
+use crate::preconditioner::amg::strength::Strength;
+use crate::matrix::sparse::CsrMatrix;
+
+#[test]
+fn direct_pattern_basic() {
+    let a = CsrMatrix::from_csr(
+        4,
+        4,
+        vec![0,2,5,8,10],
+        vec![0,1, 0,1,2, 1,2,3, 2,3],
+        vec![2.0,-1.0, -1.0,2.0,-1.0, -1.0,2.0,-1.0, -1.0,2.0],
+    );
+    let s = Strength::from_csr(&a, 0.0, true);
+    let s_sym = s.symmetrize();
+    let is_c = vec![true,false,true,false];
+    let (p, cf) = classical_pattern(&a, &s_sym, &is_c, false);
+    assert_eq!(cf.coarse_of, vec![Some(0), None, Some(1), None]);
+    let r1s = p.row_ptr[1];
+    let r1e = p.row_ptr[2];
+    assert_eq!(&p.col_idx[r1s..r1e], &[0,1]);
+    let r3s = p.row_ptr[3];
+    let r3e = p.row_ptr[4];
+    assert_eq!(&p.col_idx[r3s..r3e], &[1]);
+}

--- a/src/preconditioner/tests/coarsen.rs
+++ b/src/preconditioner/tests/coarsen.rs
@@ -54,8 +54,8 @@ fn mis_independence_and_determinism() {
                 mis_k: k,
                 cap_per_row: None,
             };
-            let agg1 = build_aggregates(&s, algo, &opts);
-            let agg2 = build_aggregates(&s, algo, &opts);
+            let (agg1, _) = build_aggregates(&s, algo, &opts);
+            let (agg2, _) = build_aggregates(&s, algo, &opts);
             assert_eq!(agg1, agg2);
             let n_coarse = 1 + agg1.iter().copied().max().unwrap_or(0);
             let mut seeds = Vec::new();

--- a/src/preconditioner/tests/mod.rs
+++ b/src/preconditioner/tests/mod.rs
@@ -55,3 +55,4 @@ mod direct_apply;
 mod ilu_csr;
 mod ilu_history;
 mod legacy_bridge;
+mod classical;


### PR DESCRIPTION
## Summary
- Implement classical interpolation variants (Direct, Standard, HE) with pattern builder, value computation, and refresh
- Extend coarsening to expose seed information for coarse/fine splits
- Add basic test for classical interpolation pattern

## Testing
- `cargo test --no-default-features --features logging` *(fails: command did not complete in environment)*


------
https://chatgpt.com/codex/tasks/task_e_68b7a3b06d9c83298be820887c555c78