### PR TITLE
Add ParCSR matrix and halo exchange support

### DIFF
--- a/src/matrix/parcsr/halo.rs
+++ b/src/matrix/parcsr/halo.rs
@@ -1,9 +1,81 @@
+use crate::parallel::{Comm, UniverseComm};
+
 /// Communication plan for halo exchanges in distributed matrices.
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone)]
 pub struct HaloPlan {
+    /// Ranks we communicate with. Order is consistent for send/recv.
     pub neighbors: Vec<i32>,
+    /// CSR-style pointer into `send_idx` for each neighbor.
     pub send_ptr: Vec<usize>,
+    /// Local indices of owned entries that need to be sent.
     pub send_idx: Vec<u64>,
+    /// CSR-style pointer into `recv_idx` for each neighbor.
     pub recv_ptr: Vec<usize>,
+    /// Positions in the ghost slice where received values should be unpacked.
     pub recv_idx: Vec<u64>,
+}
+
+impl Default for HaloPlan {
+    fn default() -> Self {
+        Self {
+            neighbors: Vec::new(),
+            send_ptr: vec![0],
+            send_idx: Vec::new(),
+            recv_ptr: vec![0],
+            recv_idx: Vec::new(),
+        }
+    }
+}
+
+impl HaloPlan {
+    /// Start nonblocking halo exchange.
+    ///
+    /// `x_owned` holds the vector owned by the current rank. `send_buf` and
+    /// `recv_buf` must have length matching `send_idx` and `recv_idx`.
+    pub fn begin_exchange<'a>(
+        &'a self,
+        comm: &'a UniverseComm,
+        x_owned: &[f64],
+        send_buf: &'a mut [f64],
+        recv_buf: &'a mut [f64],
+    ) -> Vec<<UniverseComm as Comm>::Request<'a>> {
+        assert_eq!(send_buf.len(), self.send_idx.len());
+        assert_eq!(recv_buf.len(), self.recv_idx.len());
+
+        let mut reqs: Vec<<UniverseComm as Comm>::Request<'a>> = Vec::new();
+
+        // Post receives into disjoint slices of recv_buf
+        let mut tail: &mut [f64] = recv_buf;
+        for (k, &nb) in self.neighbors.iter().enumerate() {
+            let off = self.recv_ptr[k];
+            let cnt = self.recv_ptr[k + 1] - off;
+            if cnt > 0 {
+                let (chunk, rest) = tail.split_at_mut(cnt);
+                reqs.push(comm.irecv_from(chunk, nb));
+                tail = rest;
+            }
+        }
+
+        // Pack and send owned entries needed by neighbors
+        for (p, &idx) in self.send_idx.iter().enumerate() {
+            send_buf[p] = x_owned[idx as usize];
+        }
+        for (k, &nb) in self.neighbors.iter().enumerate() {
+            let off = self.send_ptr[k];
+            let cnt = self.send_ptr[k + 1] - off;
+            if cnt > 0 {
+                reqs.push(comm.isend_to(&send_buf[off..off + cnt], nb));
+            }
+        }
+
+        reqs
+    }
+
+    /// Scatter the received buffer into the ghost slice.
+    pub fn unpack(&self, recv_buf: &[f64], x_ghost: &mut [f64]) {
+        assert_eq!(recv_buf.len(), self.recv_idx.len());
+        for (p, &idx) in self.recv_idx.iter().enumerate() {
+            x_ghost[idx as usize] = recv_buf[p];
+        }
+    }
 }

--- a/src/matrix/parcsr/mat.rs
+++ b/src/matrix/parcsr/mat.rs
@@ -1,0 +1,92 @@
+use super::halo::HaloPlan;
+use crate::error::KError;
+use crate::matrix::sparse::CsrMatrix;
+use crate::parallel::{Comm, UniverseComm};
+
+/// Distributed CSR matrix split into on- and off-process blocks.
+#[derive(Clone)]
+pub struct ParCsrMatrix {
+    pub comm: UniverseComm,
+    pub row_start: usize,
+    pub row_end: usize,
+    pub global_n: usize,
+    pub global_m: usize,
+    pub a_diag: CsrMatrix<f64>,
+    pub a_off: CsrMatrix<f64>,
+    pub colmap_owned: Vec<usize>,
+    pub colmap_ghost: Vec<usize>,
+    pub halo: HaloPlan,
+}
+
+impl ParCsrMatrix {
+    /// Number of locally owned rows.
+    pub fn local_n(&self) -> usize {
+        self.row_end - self.row_start
+    }
+
+    /// y = alpha*A*x + beta*y with two-phase halo exchange.
+    pub fn spmv_scaled(
+        &self,
+        alpha: f64,
+        x_owned: &[f64],
+        beta: f64,
+        y_owned: &mut [f64],
+    ) -> Result<(), KError> {
+        if x_owned.len() != self.local_n() || y_owned.len() != self.local_n() {
+            return Err(KError::InvalidInput(
+                "dimension mismatch in ParCsrMatrix::spmv".into(),
+            ));
+        }
+
+        let mut x_ghost = vec![0.0; self.colmap_ghost.len()];
+        let mut recv_buf = vec![0.0; self.halo.recv_idx.len()];
+        let mut send_buf = vec![0.0; self.halo.send_idx.len()];
+        let mut reqs = self
+            .halo
+            .begin_exchange(&self.comm, x_owned, &mut send_buf, &mut recv_buf);
+
+        self.a_diag.spmv_scaled(alpha, x_owned, beta, y_owned)?;
+
+        self.comm.wait_all(&mut reqs);
+        self.halo.unpack(&recv_buf, &mut x_ghost);
+
+        self.a_off.spmv_scaled(alpha, &x_ghost, 1.0, y_owned)?;
+        Ok(())
+    }
+
+    /// Convenience wrapper for y = A*x.
+    pub fn spmv(&self, x_owned: &[f64], y_owned: &mut [f64]) -> Result<(), KError> {
+        self.spmv_scaled(1.0, x_owned, 0.0, y_owned)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::matrix::sparse::CsrMatrix;
+    use crate::parallel::{NoComm, UniverseComm};
+
+    #[test]
+    fn spmv_local_only() {
+        // A = diag([2, 3])
+        let a_diag = CsrMatrix::from_csr(2, 2, vec![0, 1, 2], vec![0, 1], vec![2.0, 3.0]);
+        let a_off = CsrMatrix::from_csr(2, 0, vec![0, 0, 0], Vec::new(), Vec::new());
+        let halo = HaloPlan::default();
+        let par = ParCsrMatrix {
+            comm: UniverseComm::NoComm(NoComm),
+            row_start: 0,
+            row_end: 2,
+            global_n: 2,
+            global_m: 2,
+            a_diag,
+            a_off,
+            colmap_owned: vec![0, 1],
+            colmap_ghost: Vec::new(),
+            halo,
+        };
+        let x = vec![1.0, 2.0];
+        let mut y = vec![0.0; 2];
+        par.spmv(&x, &mut y).unwrap();
+        assert_eq!(y, vec![2.0, 6.0]);
+    }
+}

--- a/src/matrix/parcsr/mod.rs
+++ b/src/matrix/parcsr/mod.rs
@@ -3,3 +3,7 @@ pub type Local = usize;
 
 pub mod builder;
 pub mod halo;
+pub mod mat;
+
+pub use halo::HaloPlan;
+pub use mat::ParCsrMatrix;


### PR DESCRIPTION
## Summary
- provide HaloPlan with CSR-style send/recv metadata and nonblocking exchange helpers
- introduce ParCsrMatrix with two-phase SpMV using halo exchanges
- add unit test for local ParCSR SpMV

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b7c53b93e08329b397f9923361c0fa