### PR TITLE
Add near-nullspace and multi-function SA support

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -21,17 +21,21 @@ mod rap_ops;
 mod row_filter;
 mod non_galerkin;
 pub mod strength;
+pub(crate) mod strength_nodal;
+pub(crate) mod util;
 
 use coarse_solver::{CoarseDenseLu, CoarseIlu, CoarseSolver};
-use coarsen::{AggAlgo, AggOpts, build_aggregates};
+use coarsen::{AggAlgo, AggOpts, build_aggregates, lift_node_aggregates_to_dofs};
 use prolong::{
     CFInfo, ClassicalParams, ClassicalVariant, Pcsr, TentativeP, classical_pattern,
-    classical_values_only, smooth_sa_values_only, smooth_tentative_sa,
+    classical_values_only, smooth_sa_values_only_multi, smooth_tentative_sa_multi,
 };
 use rap_ops::{CsrPattern, rap_numeric, rap_symbolic};
 use row_filter::{RowFilter, apply_filter_to_csr_values_in_place};
 use non_galerkin::{NgRowFilter, non_galerkin_filter_coarse};
 use strength::Strength;
+use strength_nodal::strength_nodal;
+use util::DofLayout;
 
 // ===== Public enums (kept compatible with your old file) =====================
 
@@ -137,6 +141,17 @@ pub enum NgSymmetry {
     Symmetric,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum NodalMode {
+    Off,
+    Nodal,
+}
+
+#[derive(Clone, Debug)]
+pub struct NearNullspace {
+    pub basis: Vec<Vec<f64>>,
+}
+
 #[derive(Clone, Debug)]
 pub struct NonGalerkin {
     pub enabled: bool,
@@ -202,6 +217,10 @@ pub struct AMGConfig {
     pub fmg_gamma: usize,
     pub fmg_levels_use: Option<usize>,
     pub non_galerkin: NonGalerkin,
+    pub nodal: NodalMode,
+    pub block_size: usize,
+    pub num_functions: usize,
+    pub near_nullspace: Option<NearNullspace>,
 }
 
 impl Default for AMGConfig {
@@ -265,6 +284,10 @@ impl Default for AMGConfig {
                 oc_target: None,
                 oc_max_iter: 4,
             },
+            nodal: NodalMode::Off,
+            block_size: 1,
+            num_functions: 1,
+            near_nullspace: None,
         };
         cfg.grid_relax_type = [
             cfg.relax_type,
@@ -495,6 +518,22 @@ impl AMGBuilder {
         self
     }
 
+    pub fn nodal(mut self, on: bool, block_size: usize) -> Self {
+        self.cfg.nodal = if on { NodalMode::Nodal } else { NodalMode::Off };
+        self.cfg.block_size = block_size.max(1);
+        self
+    }
+
+    pub fn num_functions(mut self, r: usize) -> Self {
+        self.cfg.num_functions = r.max(1);
+        self
+    }
+
+    pub fn near_nullspace(mut self, basis: Vec<Vec<f64>>) -> Self {
+        self.cfg.near_nullspace = Some(NearNullspace { basis });
+        self
+    }
+
     pub fn build(self, _matrix: &Mat<f64>) -> Result<AMG, KError> {
         Ok(AMG::with_config(self.cfg))
     }
@@ -613,6 +652,12 @@ struct AMGLevel {
     cf: Option<CFInfo>,
     /// Mapping from P entry index -> index in R (transpose) values array
     p2r_pos: Vec<usize>,
+    /// number of coarse basis functions per aggregate
+    num_functions: usize,
+    /// DOF layout for nodal aggregation
+    layout: Option<DofLayout>,
+    /// stored near-nullspace basis (optional)
+    nns: Option<Vec<Vec<f64>>>,
     /// Symbolic pattern for A_{l+1}
     a_next_pat: Option<CsrPattern>,
     /// Filtered NG pattern for A_{l+1}
@@ -795,8 +840,11 @@ impl AMG {
                 let tp = TentativeP {
                     agg_of: h.levels[l].agg_of.clone(),
                     n_coarse: h.levels[l + 1].a.nrows(),
+                    num_functions: h.levels[l].num_functions,
+                    nns: h.levels[l].nns.clone(),
+                    comp_of: h.levels[l].layout.as_ref().map(|lay| lay.comp_of.clone()),
                 };
-                smooth_sa_values_only(
+                smooth_sa_values_only_multi(
                     &h.levels[l].a,
                     &h.levels[l].diag_inv,
                     &tp,
@@ -1625,6 +1673,11 @@ fn build_hierarchy(
     } else {
         None
     };
+    let layout0 = if cfg.nodal == NodalMode::Nodal {
+        Some(DofLayout::new(a_cur.nrows(), cfg.block_size))
+    } else {
+        None
+    };
     let l0 = AMGLevel {
         a: a_cur.clone(),
         p: CsrMatrix::identity(a_cur.nrows()),
@@ -1636,6 +1689,9 @@ fn build_hierarchy(
         is_c: Vec::new(),
         cf: None,
         p2r_pos: Vec::new(),
+        num_functions: 1,
+        layout: layout0.clone(),
+        nns: cfg.near_nullspace.as_ref().map(|nns| nns.basis.clone()),
         a_next_pat: None,
         a_next_pat_ng: None,
         rap_full2ng_pos: None,
@@ -1658,6 +1714,11 @@ fn build_hierarchy(
         timings.push(lt0);
     }
 
+    let mut block_size_cur = if cfg.nodal == NodalMode::Nodal {
+        cfg.block_size
+    } else {
+        1
+    };
     // Drive coarsening: build levels 0..L (inclusive L is coarsest)
     for level in 0..cfg.max_levels {
         let n = a_cur.nrows();
@@ -1667,9 +1728,18 @@ fn build_hierarchy(
 
         let mut lt = LevelSetupTiming::default();
 
+        let layout = if cfg.nodal == NodalMode::Nodal {
+            Some(DofLayout::new(n, block_size_cur))
+        } else {
+            None
+        };
         // 1) Strength of connection (sparse)
         let s = with_timing(do_stats, &mut lt.strength, || {
-            Strength::from_csr(&a_cur, cfg.strong_threshold, cfg.normalize_strength)
+            if let Some(ref lay) = layout {
+                strength_nodal(&a_cur, lay, cfg.strong_threshold, cfg.normalize_strength)
+            } else {
+                Strength::from_csr(&a_cur, cfg.strong_threshold, cfg.normalize_strength)
+            }
         });
         // 2) Aggregates
         let mis_k = if level < cfg.agg_num_levels {
@@ -1677,7 +1747,7 @@ fn build_hierarchy(
         } else {
             1
         };
-        let (agg, is_c) = with_timing(do_stats, &mut lt.aggregate, || {
+        let (agg_node, is_c_node) = with_timing(do_stats, &mut lt.aggregate, || {
             build_aggregates(
                 &s,
                 match cfg.coarsen_type {
@@ -1692,9 +1762,40 @@ fn build_hierarchy(
                 },
             )
         });
+        let (agg, is_c) = if let Some(ref lay) = layout {
+            lift_node_aggregates_to_dofs(&agg_node, &is_c_node, lay)
+        } else {
+            (agg_node, is_c_node)
+        };
+        let mut num_functions = cfg.num_functions;
+        let nns_opt = if level == 0 {
+            cfg.near_nullspace.as_ref().map(|nns| {
+                if nns.basis.len() > num_functions {
+                    num_functions = nns.basis.len();
+                }
+                nns.basis.clone()
+            })
+        } else {
+            None
+        };
+        if nns_opt.is_none() {
+            if let Some(ref lay) = layout {
+                if num_functions < lay.block_size {
+                    num_functions = lay.block_size;
+                }
+            }
+        }
+        let comp_opt = if nns_opt.is_none() {
+            layout.as_ref().map(|lay| lay.comp_of.clone())
+        } else {
+            None
+        };
         let tp = TentativeP {
             n_coarse: 1 + agg.iter().copied().max().unwrap_or(0),
             agg_of: agg.clone(),
+            num_functions,
+            nns: nns_opt.clone(),
+            comp_of: comp_opt.clone(),
         };
         let s_sym = s.symmetrize();
         let (p_csr, cf_opt): (Pcsr, Option<CFInfo>) =
@@ -1738,7 +1839,7 @@ fn build_hierarchy(
                 } else {
                     let d = diag_inv_from_csr(&a_cur)?;
                     Ok((
-                        smooth_tentative_sa(
+                        smooth_tentative_sa_multi(
                             &a_cur,
                             &d,
                             &tp,
@@ -1849,6 +1950,9 @@ fn build_hierarchy(
             prev.is_c = is_c.clone();
             prev.cf = cf_opt.clone();
             prev.p2r_pos = p2r_pos;
+            prev.num_functions = tp.num_functions;
+            prev.nns = tp.nns.clone();
+            prev.layout = layout.clone();
             prev.a_next_pat = Some(pat.clone());
             prev.a_next_pat_ng = ng_pat_opt.clone();
             prev.rap_full2ng_pos = map_opt;
@@ -1867,6 +1971,7 @@ fn build_hierarchy(
 
         // Next level (coarser)
         a_cur = a_coarse.clone();
+        block_size_cur = tp.num_functions;
         let l1_inv_coarse = if need_l1 {
             Some(l1_diag_inv(&a_cur))
         } else {
@@ -1893,6 +1998,13 @@ fn build_hierarchy(
             is_c: Vec::new(),
             cf: None,
             p2r_pos: Vec::new(),
+            num_functions: 1,
+            layout: if cfg.nodal == NodalMode::Nodal {
+                Some(DofLayout::new(a_cur.nrows(), block_size_cur))
+            } else {
+                None
+            },
+            nns: None,
             a_next_pat: None,
             a_next_pat_ng: None,
             rap_full2ng_pos: None,
@@ -2960,6 +3072,9 @@ mod tests {
             is_c: Vec::new(),
             cf: None,
             p2r_pos: vec![],
+            num_functions: 1,
+            layout: None,
+            nns: None,
             a_next_pat: None,
             a_next_pat_ng: None,
             rap_full2ng_pos: None,

--- a/src/preconditioner/amg/coarsen.rs
+++ b/src/preconditioner/amg/coarsen.rs
@@ -1,4 +1,5 @@
 use super::strength::Strength;
+use super::util::DofLayout;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum AggAlgo {
@@ -185,6 +186,22 @@ pub fn build_aggregates(s_in: &Strength, algo: AggAlgo, opts: &AggOpts) -> (Vec<
 
     let agg = aggregates_from_seeds(&s, &is_seed);
     (agg, is_seed)
+}
+
+pub fn lift_node_aggregates_to_dofs(
+    agg_node: &[usize],
+    is_c_node: &[bool],
+    layout: &DofLayout,
+) -> (Vec<usize>, Vec<bool>) {
+    let n_dofs = layout.node_of.len();
+    let mut agg_of = vec![0usize; n_dofs];
+    let mut is_c = vec![false; n_dofs];
+    for i in 0..n_dofs {
+        let node = layout.node_of[i];
+        agg_of[i] = agg_node[node];
+        is_c[i] = is_c_node[node];
+    }
+    (agg_of, is_c)
 }
 
 // Legacy greedy aggregator kept for compatibility.

--- a/src/preconditioner/amg/prolong.rs
+++ b/src/preconditioner/amg/prolong.rs
@@ -8,6 +8,9 @@ use crate::matrix::sparse::CsrMatrix;
 pub struct TentativeP {
     pub agg_of: Vec<usize>,
     pub n_coarse: usize,
+    pub num_functions: usize,
+    pub nns: Option<Vec<Vec<f64>>>,
+    pub comp_of: Option<Vec<usize>>,
 }
 
 pub fn tentative_from_aggregates(agg: Vec<usize>) -> TentativeP {
@@ -15,6 +18,9 @@ pub fn tentative_from_aggregates(agg: Vec<usize>) -> TentativeP {
     TentativeP {
         agg_of: agg,
         n_coarse,
+        num_functions: 1,
+        nns: None,
+        comp_of: None,
     }
 }
 
@@ -615,6 +621,164 @@ pub fn smooth_sa_values_only(
     Ok(())
 }
 
+pub fn smooth_tentative_sa_multi(
+    a: &CsrMatrix<f64>,
+    d_inv: &[f64],
+    tp: &TentativeP,
+    omega: f64,
+    drop_tol: f64,
+    max_per_row: usize,
+    trunc_rel: f64,
+) -> Pcsr {
+    let m = a.nrows();
+    let r = tp.num_functions;
+    let ncoarse = tp.n_coarse * r;
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+    let mut row_ptr = Vec::with_capacity(m + 1);
+    let mut col_idx: Vec<usize> = Vec::new();
+    let mut vals: Vec<f64> = Vec::new();
+    row_ptr.push(0);
+    let mut marker: Vec<isize> = vec![-1; ncoarse.min(1024).max(512)];
+    let mut acc_cols: Vec<usize> = Vec::new();
+    let mut acc_vals: Vec<f64> = Vec::new();
+    for i in 0..m {
+        if marker.len() < ncoarse { marker.resize(ncoarse, -1); }
+        acc_cols.clear(); acc_vals.clear();
+        let base = tp.agg_of[i] * r;
+        for alpha in 0..r {
+            let c = base + alpha;
+            marker[c] = acc_cols.len() as isize;
+            acc_cols.push(c);
+            let v0 = if let Some(ref nns) = tp.nns {
+                nns[alpha][i]
+            } else if let Some(ref comp) = tp.comp_of {
+                if comp[i] == alpha { 1.0 } else { 0.0 }
+            } else {
+                if alpha == 0 { 1.0 } else { 0.0 }
+            };
+            acc_vals.push(v0);
+        }
+        let di = d_inv[i];
+        let rs = rp[i]; let re = rp[i+1];
+        for p in rs..re {
+            let j = cj[p]; if j==i { continue; }
+            let gj = tp.agg_of[j] * r;
+            let s = -omega * di * vv[p];
+            for alpha in 0..r {
+                let col = gj + alpha;
+                let t = if let Some(ref nns) = tp.nns {
+                    nns[alpha][j]
+                } else if let Some(ref comp) = tp.comp_of {
+                    if comp[j] == alpha { 1.0 } else { 0.0 }
+                } else {
+                    if alpha == 0 { 1.0 } else { 0.0 }
+                };
+                let val = s * t;
+                let k = marker[col];
+                if k >= 0 { acc_vals[k as usize] += val; } else {
+                    marker[col] = acc_cols.len() as isize;
+                    acc_cols.push(col);
+                    acc_vals.push(val);
+                }
+            }
+        }
+        let mut cols = acc_cols.clone();
+        let mut vs = acc_vals.clone();
+        let rf = RowFilter { tau_abs: drop_tol, tau_rel: trunc_rel, k_max: max_per_row, must_keep: None };
+        filter_row_by_truncation(&mut cols, &mut vs, rf);
+        for alpha in 0..r {
+            let c = base + alpha;
+            if !cols.contains(&c) {
+                let v0 = if let Some(ref nns) = tp.nns {
+                    nns[alpha][i]
+                } else if let Some(ref comp) = tp.comp_of {
+                    if comp[i] == alpha { 1.0 } else { 0.0 }
+                } else {
+                    if alpha == 0 { 1.0 } else { 0.0 }
+                };
+                cols.push(c);
+                vs.push(v0);
+            }
+        }
+        for (c,v) in cols.into_iter().zip(vs.into_iter()) {
+            col_idx.push(c);
+            vals.push(v);
+        }
+        row_ptr.push(col_idx.len());
+        for &c in &acc_cols { marker[c] = -1; }
+    }
+    Pcsr { m, n: ncoarse, row_ptr, col_idx, vals }
+}
+
+pub fn smooth_sa_values_only_multi(
+    a: &CsrMatrix<f64>,
+    d_inv: &[f64],
+    tp: &TentativeP,
+    omega: f64,
+    p_row_ptr: &[usize],
+    p_col_idx: &[usize],
+    out_vals: &mut [f64],
+) -> Result<(), crate::error::KError> {
+    let m = a.nrows();
+    let r = tp.num_functions;
+    assert_eq!(p_row_ptr.len(), m + 1);
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+    let pr = p_row_ptr;
+    let pc = p_col_idx;
+    let mut map_cols: Vec<usize> = Vec::new();
+    let mut map_vals: Vec<f64> = Vec::new();
+    for i in 0..m {
+        map_cols.clear(); map_vals.clear();
+        let base = tp.agg_of[i] * r;
+        for alpha in 0..r {
+            map_cols.push(base + alpha);
+            let v0 = if let Some(ref nns) = tp.nns {
+                nns[alpha][i]
+            } else if let Some(ref comp) = tp.comp_of {
+                if comp[i] == alpha { 1.0 } else { 0.0 }
+            } else {
+                if alpha == 0 { 1.0 } else { 0.0 }
+            };
+            map_vals.push(v0);
+        }
+        let di = d_inv[i];
+        let rs = rp[i]; let re = rp[i+1];
+        for pidx in rs..re {
+            let j = cj[pidx]; if j==i { continue; }
+            let gj = tp.agg_of[j] * r;
+            let s = -omega * di * vv[pidx];
+            for alpha in 0..r {
+                let t = if let Some(ref nns) = tp.nns {
+                    nns[alpha][j]
+                } else if let Some(ref comp) = tp.comp_of {
+                    if comp[j] == alpha { 1.0 } else { 0.0 }
+                } else {
+                    if alpha == 0 { 1.0 } else { 0.0 }
+                };
+                let col = gj + alpha;
+                match map_cols.iter().position(|&c| c==col) {
+                    Some(pos) => { map_vals[pos] += s * t; }
+                    None => { map_cols.push(col); map_vals.push(s*t); }
+                }
+            }
+        }
+        let rs_p = pr[i]; let re_p = pr[i+1];
+        for k in rs_p..re_p {
+            let c = pc[k];
+            if let Some(pos) = map_cols.iter().position(|&cc| cc==c) {
+                out_vals[k] = map_vals[pos];
+            } else {
+                out_vals[k] = 0.0;
+            }
+        }
+    }
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -632,9 +796,12 @@ mod tests {
         let tp = TentativeP {
             agg_of: vec![0, 1],
             n_coarse: 2,
+            num_functions: 1,
+            nns: None,
+            comp_of: None,
         };
         let d_inv = vec![1.0, 1.0];
-        let p = smooth_tentative_sa(&a, &d_inv, &tp, 1.0, 10.0, 0, 0.0);
+        let p = smooth_tentative_sa_multi(&a, &d_inv, &tp, 1.0, 10.0, 0, 0.0);
         assert_eq!(p.col_idx, vec![0, 1]);
     }
 
@@ -650,13 +817,16 @@ mod tests {
         let tp = TentativeP {
             agg_of: vec![0, 1],
             n_coarse: 2,
+            num_functions: 1,
+            nns: None,
+            comp_of: None,
         };
         let d_inv = vec![1.0, 1.0];
         // drop_tol=0 -> keep all
-        let p_full = smooth_tentative_sa(&a, &d_inv, &tp, 1.0, 0.0, 0, 0.0);
+        let p_full = smooth_tentative_sa_multi(&a, &d_inv, &tp, 1.0, 0.0, 0, 0.0);
         assert_eq!(p_full.col_idx, vec![0, 1, 0, 1]);
         // drop_tol large -> only own aggregates
-        let p_drop = smooth_tentative_sa(&a, &d_inv, &tp, 1.0, 1.0, 0, 0.0);
+        let p_drop = smooth_tentative_sa_multi(&a, &d_inv, &tp, 1.0, 1.0, 0, 0.0);
         assert_eq!(p_drop.col_idx, vec![0, 1]);
     }
 }

--- a/src/preconditioner/amg/strength_nodal.rs
+++ b/src/preconditioner/amg/strength_nodal.rs
@@ -1,0 +1,71 @@
+use std::collections::BTreeMap;
+
+use crate::matrix::sparse::CsrMatrix;
+
+use super::strength::Strength;
+use super::util::DofLayout;
+
+pub fn strength_nodal(
+    a: &CsrMatrix<f64>,
+    layout: &DofLayout,
+    theta: f64,
+    normalize: bool,
+) -> Strength {
+    let n = layout.n_nodes;
+    let mut diag = vec![0.0; n];
+    let mut rows: Vec<BTreeMap<usize, f64>> = vec![BTreeMap::new(); n];
+
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+    for i_dof in 0..a.nrows() {
+        let u = layout.node_of[i_dof];
+        let rs = rp[i_dof];
+        let re = rp[i_dof + 1];
+        for p in rs..re {
+            let j_dof = cj[p];
+            let v = vv[p].abs();
+            let w = layout.node_of[j_dof];
+            if u == w {
+                if v > diag[u] {
+                    diag[u] = v;
+                }
+            } else {
+                let e = rows[u].entry(w).or_insert(0.0);
+                if v > *e {
+                    *e = v;
+                }
+            }
+        }
+    }
+
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx = Vec::<usize>::new();
+    row_ptr.push(0);
+    for u in 0..n {
+        let mut count = 0usize;
+        let mut max_off = 0.0;
+        if !normalize {
+            for &blk in rows[u].values() {
+                if blk > max_off {
+                    max_off = blk;
+                }
+            }
+        }
+        for (&w, &blk) in rows[u].iter() {
+            let keep = if normalize {
+                let denom = (diag[u] * diag[w]).sqrt();
+                denom > 0.0 && blk / denom >= theta
+            } else {
+                max_off > 0.0 && blk >= theta * max_off
+            };
+            if keep {
+                col_idx.push(w);
+                count += 1;
+            }
+        }
+        row_ptr.push(row_ptr.last().unwrap() + count);
+    }
+    Strength { row_ptr, col_idx }
+}
+

--- a/src/preconditioner/amg/util.rs
+++ b/src/preconditioner/amg/util.rs
@@ -1,0 +1,29 @@
+use std::vec::Vec;
+
+#[derive(Clone)]
+pub struct DofLayout {
+    pub block_size: usize,
+    pub n_nodes: usize,
+    pub node_of: Vec<usize>,
+    pub comp_of: Vec<usize>,
+}
+
+impl DofLayout {
+    pub fn new(n_dofs: usize, block_size: usize) -> Self {
+        assert!(block_size >= 1 && n_dofs % block_size == 0);
+        let n_nodes = n_dofs / block_size;
+        let mut node_of = vec![0usize; n_dofs];
+        let mut comp_of = vec![0usize; n_dofs];
+        for i in 0..n_dofs {
+            node_of[i] = i / block_size;
+            comp_of[i] = i % block_size;
+        }
+        Self {
+            block_size,
+            n_nodes,
+            node_of,
+            comp_of,
+        }
+    }
+}
+

--- a/src/preconditioner/tests/mod.rs
+++ b/src/preconditioner/tests/mod.rs
@@ -56,3 +56,5 @@ mod direct_apply;
 mod ilu_csr;
 mod ilu_history;
 mod legacy_bridge;
+mod near_nullspace;
+mod nodal;

--- a/src/preconditioner/tests/near_nullspace.rs
+++ b/src/preconditioner/tests/near_nullspace.rs
@@ -1,0 +1,39 @@
+use super::*;
+use crate::preconditioner::amg::prolong::{smooth_tentative_sa_multi, TentativeP};
+use crate::matrix::sparse::CsrMatrix;
+
+#[test]
+fn nns_tentative_reproduces_basis() {
+    let n = 4;
+    let a = CsrMatrix::identity(n);
+    let d_inv = vec![1.0; n];
+    let agg = vec![0, 0, 1, 1];
+    let t0 = vec![1.0; n];
+    let t1 = vec![0.0, 1.0, 0.0, 1.0];
+    let tp = TentativeP {
+        agg_of: agg.clone(),
+        n_coarse: 2,
+        num_functions: 2,
+        nns: Some(vec![t0.clone(), t1.clone()]),
+        comp_of: None,
+    };
+    let p = smooth_tentative_sa_multi(&a, &d_inv, &tp, 0.0, 0.0, 0, 0.0);
+    assert_eq!(p.n, 4);
+    for i in 0..n {
+        let g = agg[i];
+        let rs = p.row_ptr[i];
+        let re = p.row_ptr[i + 1];
+        for alpha in 0..2 {
+            let col = g * 2 + alpha;
+            let mut found = false;
+            for k in rs..re {
+                if p.col_idx[k] == col {
+                    let expected = if alpha == 0 { t0[i] } else { t1[i] };
+                    assert!((p.vals[k] - expected).abs() < 1e-12);
+                    found = true;
+                }
+            }
+            assert!(found);
+        }
+    }
+}

--- a/src/preconditioner/tests/nodal.rs
+++ b/src/preconditioner/tests/nodal.rs
@@ -1,0 +1,17 @@
+use super::*;
+use crate::preconditioner::amg::util::DofLayout;
+use crate::preconditioner::amg::strength_nodal::strength_nodal;
+use crate::preconditioner::amg::coarsen::{build_aggregates, AggAlgo, AggOpts, lift_node_aggregates_to_dofs};
+use crate::matrix::sparse::CsrMatrix;
+
+#[test]
+fn nodal_aggregates_group_dofs() {
+    // 4 DOFs, block_size=2 -> 2 nodes
+    let a = CsrMatrix::identity(4);
+    let layout = DofLayout::new(4, 2);
+    let s = strength_nodal(&a, &layout, 0.0, true);
+    let (agg_node, is_c_node) = build_aggregates(&s, AggAlgo::RSGreedy, &AggOpts { mis_k: 1, cap_per_row: None });
+    let (agg, is_c) = lift_node_aggregates_to_dofs(&agg_node, &is_c_node, &layout);
+    assert_eq!(agg, vec![0,0,1,1]);
+    assert_eq!(is_c, vec![true,true,true,true]);
+}


### PR DESCRIPTION
## Summary
- map fine-scale degrees of freedom to nodal components with `DofLayout`
- build nodal strength graphs and lift node aggregates back to DOFs in the AMG hierarchy
- smooth multi-function prolongation with component-aware basis and add regression tests for nodal aggregation

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_68b7cab086b0832991c69e548a478fab