### PR TITLE
Add AMG-aware deflation preconditioner

### DIFF
--- a/src/matrix/spmv/mod.rs
+++ b/src/matrix/spmv/mod.rs
@@ -1,5 +1,6 @@
 use crate::error::KError;
 use crate::matrix::{csc::CscMatrix, sparse::CsrMatrix};
+use faer::{MatMut, MatRef};
 
 /// y = A * x using CSR; parallel when `rayon` is enabled.
 #[cfg(feature = "rayon")]
@@ -209,6 +210,55 @@ pub fn spmm_csr_block(
             y_cols[r][i] = acc[r];
         }
     }
+    Ok(())
+}
+
+/// Dense sparse matrix-matrix product specialized for small dense blocks.
+///
+/// Computes `Y = A * X` where `A` is CSR and `X`, `Y` are column-major dense
+/// matrices provided as [`MatRef`] and [`MatMut`] respectively. The caller must
+/// zero `Y` prior to invocation if accumulation is not desired.
+pub fn csr_spmm_dense(
+    a: &CsrMatrix<f64>,
+    x: MatRef<'_, f64>,
+    mut y: MatMut<'_, f64>,
+) -> Result<(), KError> {
+    let (m, n) = (a.nrows(), a.ncols());
+    if x.nrows() != n {
+        return Err(KError::InvalidInput(
+            "csr_spmm_dense: column count mismatch".into(),
+        ));
+    }
+    if y.nrows() != m {
+        return Err(KError::InvalidInput(
+            "csr_spmm_dense: row count mismatch".into(),
+        ));
+    }
+    if x.ncols() != y.ncols() {
+        return Err(KError::InvalidInput(
+            "csr_spmm_dense: rhs count mismatch".into(),
+        ));
+    }
+
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+    let k = x.ncols();
+
+    for i in 0..m {
+        // zero the output row explicitly to avoid accumulating stale data.
+        for col in 0..k {
+            y[(i, col)] = 0.0;
+        }
+        for p in rp[i]..rp[i + 1] {
+            let col = cj[p];
+            let val = vv[p];
+            for rhs in 0..k {
+                y[(i, rhs)] += val * x[(col, rhs)];
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -5,7 +5,8 @@ use std::time::{Duration, Instant};
 
 use crate::error::KError;
 use crate::matrix::op::{LinOp, StructureId, ValuesId};
-use crate::matrix::{convert::csr_from_linop, sparse::CsrMatrix};
+use crate::matrix::{convert::csr_from_linop, sparse::CsrMatrix, spmv::csr_spmm_dense};
+use crate::preconditioner::deflation::{AmgCoarseSpace, DeflationOptions, ZSource};
 use crate::preconditioner::{PcCaps, PcSide, Preconditioner};
 use faer::Mat;
 
@@ -1190,6 +1191,69 @@ impl AMG {
         Self {
             cfg,
             ..Default::default()
+        }
+    }
+
+    pub fn extract_coarse_space(&self, opts: &DeflationOptions) -> Result<AmgCoarseSpace, KError> {
+        let state = self
+            .state
+            .as_ref()
+            .ok_or_else(|| KError::InvalidInput("AMG not set up".into()))?;
+        if state.levels.is_empty() {
+            return Err(KError::InvalidInput("AMG hierarchy empty".into()));
+        }
+        match opts.z_source {
+            ZSource::CoarsestIdentity { cap_k } => {
+                let coarse_ix = state.coarsest_ix();
+                let n_coarse = state.levels[coarse_ix].a.nrows();
+                let k_full = n_coarse;
+                let cap = cap_k.unwrap_or(k_full).min(k_full);
+                let mut z = Mat::<f64>::zeros(n_coarse, cap);
+                for i in 0..cap {
+                    z[(i, i)] = 1.0;
+                }
+                let mut current = z;
+                for lvl in (0..coarse_ix).rev() {
+                    let p = &state.levels[lvl].p;
+                    let mut next = Mat::<f64>::zeros(p.nrows(), cap);
+                    csr_spmm_dense(p, current.as_ref(), next.as_mut())?;
+                    current = next;
+                }
+                Ok(AmgCoarseSpace {
+                    z: current,
+                    local_range: None,
+                })
+            }
+            ZSource::NearNullspace => {
+                let finest = &state.levels[0];
+                let basis = finest
+                    .nns
+                    .as_ref()
+                    .ok_or_else(|| KError::InvalidInput("near-nullspace unavailable".into()))?;
+                let k = basis.len();
+                if k == 0 {
+                    return Err(KError::InvalidInput("near-nullspace empty".into()));
+                }
+                let n = finest.a.nrows();
+                let mut z = Mat::<f64>::zeros(n, k);
+                for (j, vec) in basis.iter().enumerate() {
+                    if vec.len() != n {
+                        return Err(KError::InvalidInput(
+                            "near-nullspace vector has wrong length".into(),
+                        ));
+                    }
+                    for i in 0..n {
+                        z[(i, j)] = vec[i];
+                    }
+                }
+                Ok(AmgCoarseSpace {
+                    z,
+                    local_range: None,
+                })
+            }
+            ZSource::External => Err(KError::InvalidInput(
+                "ZSource::External requires user-provided coarse space".into(),
+            )),
         }
     }
 

--- a/src/preconditioner/deflation.rs
+++ b/src/preconditioner/deflation.rs
@@ -1,0 +1,498 @@
+use std::sync::Mutex;
+
+use crate::error::KError;
+use crate::matrix::convert::csr_from_linop;
+use crate::matrix::op::LinOp;
+use crate::matrix::sparse::CsrMatrix;
+use crate::matrix::spmv::csr_spmm_dense;
+use crate::preconditioner::amg::AMG;
+use crate::preconditioner::{FormatHint, PcCaps, PcSide, Preconditioner};
+use faer::{Mat, MatRef};
+
+/// Dense coarse space extracted from an AMG hierarchy or provided externally.
+#[derive(Clone, Debug)]
+pub struct AmgCoarseSpace {
+    /// Column-major storage of the coarse basis vectors.
+    pub z: Mat<f64>,
+    /// Row range owned locally for ParCSR. Serial uses the full matrix.
+    pub local_range: Option<(usize, usize)>,
+}
+
+/// Source for constructing the coarse space.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ZSource {
+    /// Use identity columns on the coarsest grid, prolongated to the finest.
+    CoarsestIdentity { cap_k: Option<usize> },
+    /// Reuse near-nullspace vectors already defined on the finest grid.
+    NearNullspace,
+    /// Provided explicitly by the caller (no extraction performed).
+    External,
+}
+
+/// Configuration knobs for deflation setup.
+#[derive(Clone, Debug)]
+pub struct DeflationOptions {
+    pub z_source: ZSource,
+    pub cond_cap: Option<f64>,
+    pub augment_initial_guess: bool,
+}
+
+impl Default for DeflationOptions {
+    fn default() -> Self {
+        Self {
+            z_source: ZSource::CoarsestIdentity { cap_k: None },
+            cond_cap: None,
+            augment_initial_guess: false,
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct CholeskyFactor {
+    n: usize,
+    data: Vec<f64>,
+}
+
+impl CholeskyFactor {
+    fn decompose(mat: &MatRef<'_, f64>) -> Result<Self, ()> {
+        let n = mat.nrows();
+        if n != mat.ncols() {
+            return Err(());
+        }
+        let mut data = vec![0.0; n * n];
+        for i in 0..n {
+            for j in 0..=i {
+                let mut sum = mat[(i, j)];
+                for k in 0..j {
+                    sum -= data[i * n + k] * data[j * n + k];
+                }
+                if i == j {
+                    if sum <= 0.0 {
+                        return Err(());
+                    }
+                    data[i * n + j] = sum.sqrt();
+                } else {
+                    let piv = data[j * n + j];
+                    if piv == 0.0 {
+                        return Err(());
+                    }
+                    data[i * n + j] = sum / piv;
+                }
+            }
+        }
+        Ok(Self { n, data })
+    }
+
+    fn solve_in_place(&self, rhs: &mut [f64]) {
+        debug_assert_eq!(rhs.len(), self.n);
+        // Forward solve L y = rhs.
+        for i in 0..self.n {
+            let mut acc = rhs[i];
+            for k in 0..i {
+                acc -= self.data[i * self.n + k] * rhs[k];
+            }
+            rhs[i] = acc / self.data[i * self.n + i];
+        }
+        // Backward solve Lᵀ x = y.
+        for i in (0..self.n).rev() {
+            let mut acc = rhs[i];
+            for k in (i + 1)..self.n {
+                acc -= self.data[k * self.n + i] * rhs[k];
+            }
+            rhs[i] = acc / self.data[i * self.n + i];
+        }
+    }
+}
+
+#[derive(Clone, Debug)]
+struct LuFactor {
+    n: usize,
+    lu: Vec<f64>,
+    piv: Vec<usize>,
+}
+
+impl LuFactor {
+    fn decompose(mat: &MatRef<'_, f64>) -> Result<Self, KError> {
+        let n = mat.nrows();
+        if n != mat.ncols() {
+            return Err(KError::InvalidInput("LU requires square matrix".into()));
+        }
+        let mut lu = vec![0.0; n * n];
+        for i in 0..n {
+            for j in 0..n {
+                lu[i * n + j] = mat[(i, j)];
+            }
+        }
+        let mut piv: Vec<usize> = (0..n).collect();
+        for k in 0..n {
+            let mut piv_row = k;
+            let mut max_val = lu[k * n + k].abs();
+            for i in (k + 1)..n {
+                let val = lu[i * n + k].abs();
+                if val > max_val {
+                    max_val = val;
+                    piv_row = i;
+                }
+            }
+            if max_val == 0.0 {
+                return Err(KError::ZeroPivot(k));
+            }
+            if piv_row != k {
+                for j in 0..n {
+                    lu.swap(k * n + j, piv_row * n + j);
+                }
+                piv.swap(k, piv_row);
+            }
+            let pivot = lu[k * n + k];
+            for i in (k + 1)..n {
+                lu[i * n + k] /= pivot;
+                let mult = lu[i * n + k];
+                for j in (k + 1)..n {
+                    lu[i * n + j] -= mult * lu[k * n + j];
+                }
+            }
+        }
+        Ok(Self { n, lu, piv })
+    }
+
+    fn solve_in_place(&self, rhs: &mut [f64]) {
+        debug_assert_eq!(rhs.len(), self.n);
+        // Apply row permutations to rhs.
+        let mut permuted = vec![0.0; self.n];
+        for (i, &p) in self.piv.iter().enumerate() {
+            permuted[i] = rhs[p];
+        }
+        // Forward solve L y = P b (unit diagonal).
+        for i in 0..self.n {
+            let mut acc = permuted[i];
+            for k in 0..i {
+                acc -= self.lu[i * self.n + k] * permuted[k];
+            }
+            permuted[i] = acc;
+        }
+        // Backward solve U x = y.
+        for i in (0..self.n).rev() {
+            let mut acc = permuted[i];
+            for k in (i + 1)..self.n {
+                acc -= self.lu[i * self.n + k] * permuted[k];
+            }
+            permuted[i] = acc / self.lu[i * self.n + i];
+        }
+        rhs.copy_from_slice(&permuted);
+    }
+}
+
+#[derive(Clone, Debug)]
+enum EFactor {
+    Chol(CholeskyFactor),
+    Lu(LuFactor),
+}
+
+#[derive(Default)]
+struct DeflationWorkspace {
+    coarse: Vec<f64>,
+    coarse_sol: Vec<f64>,
+    fine_tmp: Vec<f64>,
+    base_out: Vec<f64>,
+}
+
+impl DeflationWorkspace {
+    fn ensure(&mut self, n: usize, k: usize) {
+        if self.coarse.len() != k {
+            self.coarse.resize(k, 0.0);
+        }
+        if self.coarse_sol.len() != k {
+            self.coarse_sol.resize(k, 0.0);
+        }
+        if self.fine_tmp.len() != n {
+            self.fine_tmp.resize(n, 0.0);
+        }
+        if self.base_out.len() != n {
+            self.base_out.resize(n, 0.0);
+        }
+    }
+}
+
+pub struct DeflationPC<PB> {
+    base: PB,
+    a: CsrMatrix<f64>,
+    z: Mat<f64>,
+    az: Mat<f64>,
+    e: Mat<f64>,
+    e_factor: EFactor,
+    augment_initial_guess: bool,
+    work: Mutex<DeflationWorkspace>,
+}
+
+fn gram_schmidt(z: &Mat<f64>, tol: f64) -> Mat<f64> {
+    let (n, k) = z.shape();
+    let mut kept: Vec<Vec<f64>> = Vec::with_capacity(k);
+    for col in 0..k {
+        let mut v = vec![0.0; n];
+        for i in 0..n {
+            v[i] = z[(i, col)];
+        }
+        for q in &kept {
+            let mut dot = 0.0;
+            for i in 0..n {
+                dot += q[i] * v[i];
+            }
+            for i in 0..n {
+                v[i] -= dot * q[i];
+            }
+        }
+        let mut norm2 = 0.0;
+        for &vi in &v {
+            norm2 += vi * vi;
+        }
+        if norm2.sqrt() > tol {
+            let scale = 1.0 / norm2.sqrt();
+            for vi in &mut v {
+                *vi *= scale;
+            }
+            kept.push(v);
+        }
+    }
+    let cols = kept.len();
+    let mut out = Mat::<f64>::zeros(n, cols);
+    for (j, col) in kept.iter().enumerate() {
+        for i in 0..n {
+            out[(i, j)] = col[i];
+        }
+    }
+    out
+}
+
+fn build_e(z: &Mat<f64>, az: &Mat<f64>) -> Mat<f64> {
+    let k = z.ncols();
+    let mut e = Mat::<f64>::zeros(k, k);
+    for i in 0..k {
+        for j in 0..k {
+            let mut acc = 0.0;
+            for r in 0..z.nrows() {
+                acc += z[(r, i)] * az[(r, j)];
+            }
+            e[(i, j)] = acc;
+        }
+    }
+    e
+}
+
+impl<PB> DeflationPC<PB>
+where
+    PB: Preconditioner,
+{
+    pub fn new(
+        base: PB,
+        a: &CsrMatrix<f64>,
+        coarse: AmgCoarseSpace,
+        opts: &DeflationOptions,
+    ) -> Result<Self, KError> {
+        let n = a.nrows();
+        if coarse.z.nrows() != n {
+            return Err(KError::InvalidInput(
+                "coarse space dimension mismatch".into(),
+            ));
+        }
+        let tol = opts.cond_cap.map(|cap| (1.0 / cap).abs()).unwrap_or(1e-12);
+        let z = gram_schmidt(&coarse.z, tol.max(1e-12));
+        if z.ncols() == 0 {
+            return Err(KError::InvalidInput("coarse space lost all columns".into()));
+        }
+        let k = z.ncols();
+        let mut az = Mat::<f64>::zeros(n, k);
+        csr_spmm_dense(a, z.as_ref(), az.as_mut())?;
+        let e = build_e(&z, &az);
+        let e_factor = match CholeskyFactor::decompose(&e.as_ref()) {
+            Ok(ch) => EFactor::Chol(ch),
+            Err(_) => {
+                let lu = LuFactor::decompose(&e.as_ref())?;
+                EFactor::Lu(lu)
+            }
+        };
+        Ok(Self {
+            base,
+            a: a.clone(),
+            z,
+            az,
+            e,
+            e_factor,
+            augment_initial_guess: opts.augment_initial_guess,
+            work: Mutex::new(DeflationWorkspace::default()),
+        })
+    }
+
+    pub fn coarse_dim(&self) -> usize {
+        self.z.ncols()
+    }
+
+    pub fn fine_dim(&self) -> usize {
+        self.z.nrows()
+    }
+
+    fn solve_e(&self, rhs: &mut [f64]) {
+        match &self.e_factor {
+            EFactor::Chol(ch) => ch.solve_in_place(rhs),
+            EFactor::Lu(lu) => lu.solve_in_place(rhs),
+        }
+    }
+
+    pub fn coarse_initial_guess(&self, b: &[f64], x0: &mut [f64]) -> Result<(), KError> {
+        let n = self.z.nrows();
+        if b.len() != n || x0.len() != n {
+            return Err(KError::InvalidInput(
+                "coarse_initial_guess: dimension mismatch".into(),
+            ));
+        }
+        let k = self.z.ncols();
+        let mut tmp = vec![0.0; k];
+        for j in 0..k {
+            let mut acc = 0.0;
+            for i in 0..n {
+                acc += self.z[(i, j)] * b[i];
+            }
+            tmp[j] = acc;
+        }
+        self.solve_e(&mut tmp);
+        for i in 0..n {
+            let mut acc = 0.0;
+            for j in 0..k {
+                acc += self.z[(i, j)] * tmp[j];
+            }
+            x0[i] = acc;
+        }
+        Ok(())
+    }
+
+    pub fn augment_initial_guess(&self) -> bool {
+        self.augment_initial_guess
+    }
+
+    fn refresh_e(&mut self) -> Result<(), KError> {
+        self.e = build_e(&self.z, &self.az);
+        self.e_factor = match CholeskyFactor::decompose(&self.e.as_ref()) {
+            Ok(ch) => EFactor::Chol(ch),
+            Err(_) => {
+                let lu = LuFactor::decompose(&self.e.as_ref())?;
+                EFactor::Lu(lu)
+            }
+        };
+        Ok(())
+    }
+}
+
+impl<PB> Preconditioner for DeflationPC<PB>
+where
+    PB: Preconditioner,
+{
+    fn setup(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        self.base.setup(op)
+    }
+
+    fn apply(&self, side: PcSide, r: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        let n = self.z.nrows();
+        if r.len() != n || y.len() != n {
+            return Err(KError::InvalidInput(
+                "DeflationPC: dimension mismatch".into(),
+            ));
+        }
+        let k = self.z.ncols();
+        let mut work = self.work.lock().unwrap();
+        work.ensure(n, k);
+        let DeflationWorkspace {
+            coarse,
+            coarse_sol,
+            fine_tmp,
+            base_out,
+        } = &mut *work;
+
+        // t = Zᵀ r
+        for j in 0..k {
+            let mut acc = 0.0;
+            for i in 0..n {
+                acc += self.z[(i, j)] * r[i];
+            }
+            coarse[j] = acc;
+            coarse_sol[j] = acc;
+        }
+        self.solve_e(coarse_sol);
+
+        // y := Z * coarse_sol (coarse correction)
+        for i in 0..n {
+            let mut acc = 0.0;
+            for j in 0..k {
+                acc += self.z[(i, j)] * coarse_sol[j];
+            }
+            y[i] = acc;
+        }
+
+        // fine_tmp = r - A Z y_c (use cached AZ)
+        for i in 0..n {
+            let mut acc = 0.0;
+            for j in 0..k {
+                acc += self.az[(i, j)] * coarse_sol[j];
+            }
+            fine_tmp[i] = r[i] - acc;
+        }
+
+        // base_out = M^{-1} fine_tmp
+        base_out.fill(0.0);
+        self.base.apply(side, fine_tmp, base_out)?;
+
+        for i in 0..n {
+            y[i] += base_out[i];
+        }
+
+        Ok(())
+    }
+
+    fn supports_numeric_update(&self) -> bool {
+        self.base.supports_numeric_update()
+    }
+
+    fn update_numeric(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        self.base.update_numeric(op)?;
+        csr_spmm_dense(&self.a, self.z.as_ref(), self.az.as_mut())?;
+        self.refresh_e()
+    }
+
+    fn update_symbolic(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        self.base.update_symbolic(op)?;
+        let new_a = csr_from_linop(op, 0.0)?;
+        self.a = (*new_a).clone();
+        csr_spmm_dense(&self.a, self.z.as_ref(), self.az.as_mut())?;
+        self.refresh_e()
+    }
+
+    fn required_format(&self) -> FormatHint {
+        self.base.required_format()
+    }
+
+    fn preferred_drop_tol_for_format(&self) -> Option<f64> {
+        self.base.preferred_drop_tol_for_format()
+    }
+
+    fn capabilities(&self) -> PcCaps {
+        let mut caps = self.base.capabilities();
+        if matches!(self.e_factor, EFactor::Chol(_)) && caps.is_spd {
+            caps.is_spd = true;
+        }
+        caps
+    }
+}
+
+pub fn with_amg_deflation<PB: Preconditioner>(
+    base: PB,
+    a: &CsrMatrix<f64>,
+    amg: &AMG,
+    opts: &DeflationOptions,
+) -> Result<DeflationPC<PB>, KError> {
+    let coarse = if matches!(opts.z_source, ZSource::External) {
+        return Err(KError::InvalidInput(
+            "ZSource::External requires explicit coarse space".into(),
+        ));
+    } else {
+        amg.extract_coarse_space(opts)?
+    };
+    DeflationPC::new(base, a, coarse, opts)
+}

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -51,8 +51,7 @@ use std::str::FromStr;
 /// - Left: Solve M⁻¹Ax = M⁻¹b
 /// - Right: Solve AM⁻¹y = b, then x = M⁻¹y  
 /// - Symmetric: Apply both left and right preconditioning (M₁⁻¹AM₂⁻¹)
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
-#[derive(Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
 pub enum PcSide {
     /// Left preconditioning: M⁻¹Ax = M⁻¹b
     #[default]
@@ -75,7 +74,6 @@ impl FromStr for PcSide {
         }
     }
 }
-
 
 /// Matrix operation selector for preconditioner application.
 ///
@@ -378,6 +376,7 @@ pub mod block_jacobi;
 pub mod builders;
 pub mod chain;
 pub mod chebyshev;
+pub mod deflation;
 pub mod direct;
 pub mod ilu;
 pub mod ilu_csr;
@@ -397,6 +396,7 @@ pub use approxinv_csr::{ApproxInvBuilder, ApproxInvKind, ApproxInvParams, FsaiCs
 pub use asm::AdditiveSchwarz;
 pub use chain::PcChain;
 pub use chebyshev::{Chebyshev, ChebyshevPre};
+pub use deflation::{AmgCoarseSpace, DeflationOptions, DeflationPC, ZSource, with_amg_deflation};
 pub use direct::SuperLuDistPc;
 #[cfg(feature = "dense-direct")]
 pub use direct::{LuPc, QrPc};

--- a/src/preconditioner/tests/deflation.rs
+++ b/src/preconditioner/tests/deflation.rs
@@ -1,0 +1,88 @@
+use crate::matrix::sparse::CsrMatrix;
+use crate::preconditioner::amg::{AMGBuilder, RelaxType};
+use crate::preconditioner::{
+    DeflationOptions, DeflationPC, Jacobi, PcSide, Preconditioner, ZSource,
+};
+use faer::Mat;
+
+fn poisson_1d(n: usize) -> CsrMatrix<f64> {
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx = Vec::new();
+    let mut values = Vec::new();
+    row_ptr.push(0);
+    for i in 0..n {
+        if i > 0 {
+            col_idx.push(i - 1);
+            values.push(-1.0);
+        }
+        col_idx.push(i);
+        values.push(2.0);
+        if i + 1 < n {
+            col_idx.push(i + 1);
+            values.push(-1.0);
+        }
+        row_ptr.push(col_idx.len());
+    }
+    CsrMatrix::from_csr(n, n, row_ptr, col_idx, values)
+}
+
+#[test]
+fn extract_coarse_space_identity() {
+    let a = poisson_1d(12);
+    let mut amg = AMGBuilder::new()
+        .relaxation_type(RelaxType::Jacobi)
+        .grid_relax_type_all(RelaxType::Jacobi)
+        .build(&Mat::<f64>::zeros(0, 0))
+        .unwrap();
+    amg.setup(&a).unwrap();
+
+    let opts = DeflationOptions::default();
+    let cs = amg.extract_coarse_space(&opts).unwrap();
+    assert_eq!(cs.z.nrows(), a.nrows());
+    assert!(cs.z.ncols() > 0);
+}
+
+#[test]
+fn deflation_preconditioner_applies() {
+    let a = poisson_1d(10);
+    let mut amg = AMGBuilder::new()
+        .relaxation_type(RelaxType::Jacobi)
+        .grid_relax_type_all(RelaxType::Jacobi)
+        .require_spd(true)
+        .build(&Mat::<f64>::zeros(0, 0))
+        .unwrap();
+    amg.setup(&a).unwrap();
+    let opts = DeflationOptions::default();
+    let cs = amg.extract_coarse_space(&opts).unwrap();
+    let mut def = DeflationPC::new(amg, &a, cs, &opts).unwrap();
+    def.setup(&a).unwrap();
+
+    let rhs: Vec<f64> = (0..a.nrows()).map(|i| (i as f64).sin()).collect();
+    let mut out = vec![0.0; rhs.len()];
+    def.apply(PcSide::Left, &rhs, &mut out).unwrap();
+    assert!(out.iter().all(|v| v.is_finite()));
+    assert_eq!(def.fine_dim(), rhs.len());
+}
+
+#[test]
+fn gram_schmidt_drops_dependent_columns() {
+    let n = 5;
+    let diag = CsrMatrix::from_csr(n, n, (0..=n).collect(), (0..n).collect(), vec![1.0; n]);
+    let mut z = Mat::<f64>::zeros(n, 2);
+    for i in 0..n {
+        z[(i, 0)] = 1.0;
+        z[(i, 1)] = 1.0;
+    }
+    let coarse = crate::preconditioner::AmgCoarseSpace {
+        z,
+        local_range: None,
+    };
+    let opts = DeflationOptions {
+        z_source: ZSource::External,
+        cond_cap: Some(10.0),
+        augment_initial_guess: false,
+    };
+    let jacobi = Jacobi::new();
+    let def = DeflationPC::new(jacobi, &diag, coarse, &opts).unwrap();
+    assert_eq!(def.coarse_dim(), 1);
+}

--- a/src/preconditioner/tests/mod.rs
+++ b/src/preconditioner/tests/mod.rs
@@ -52,6 +52,7 @@ fn default_apply_mut_forwards_to_apply() {
 
 mod classical;
 mod coarsen;
+mod deflation;
 mod direct_apply;
 mod ilu_csr;
 mod ilu_history;


### PR DESCRIPTION
## Summary
- add a CSR×dense helper to reuse sparse-matrix products when building coarse grids
- expose AMG coarse-space extraction and introduce a general deflation preconditioner wrapper
- cover the new deflation workflow with focused unit tests

## Testing
- cargo test deflation -- --nocapture

------
https://chatgpt.com/codex/tasks/task_e_68cf1a05fac483299003b194b34558c3