### PR TITLE
Fix nodal strength normalization and reuse node aggregates

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -33,12 +33,15 @@ pub(crate) mod strength_nodal;
 pub(crate) mod util;
 
 use coarse_solver::{CoarseDenseLu, CoarseIlu, CoarseSolver};
-use coarsen::{AggAlgo, AggOpts, build_aggregates, lift_node_aggregates_to_dofs};
+use coarsen::{
+    AggAlgo, AggOpts, build_aggregates, build_aggregates_nodal, lift_node_aggregates_to_dofs,
+};
 use non_galerkin::{NgRowFilter, non_galerkin_filter_coarse};
 use prolong::{
-    CFInfo, ClassicalParams, ClassicalVariant, Pcsr, TentativeP, adaptive_fit_values_only,
-    classical_pattern, classical_values_only, restrict_samples_to_coarse, sample_low_modes,
-    smooth_sa_values_only, smooth_sa_values_only_multi, smooth_tentative_sa_multi,
+    CFInfo, ClassicalParams, ClassicalVariant, Pcsr, TentativeNodal, TentativeP,
+    adaptive_fit_values_only, classical_pattern, classical_values_only, restrict_samples_to_coarse,
+    sample_low_modes, smooth_sa_values_only, smooth_sa_values_only_mf, smooth_sa_values_only_multi,
+    smooth_tentative_sa_mf, smooth_tentative_sa_multi,
 };
 use rap_ops::{CsrPattern, rap_numeric, rap_symbolic};
 use row_filter::{
@@ -46,7 +49,7 @@ use row_filter::{
     restrict_trials,
 };
 use strength::Strength;
-use strength_nodal::strength_nodal;
+use strength_nodal::strength_nodal_from_csr;
 use util::DofLayout;
 
 // ===== Public enums (kept compatible with your old file) =====================
@@ -1201,6 +1204,8 @@ struct AMGLevel {
     p2r_pos: Vec<usize>,
     /// number of coarse basis functions per aggregate
     num_functions: usize,
+    /// Row-local orthonormalized basis coefficients for nodal SA, length = nrows * num_functions.
+    row_basis: Option<Vec<f64>>,
     /// DOF layout for nodal aggregation
     layout: Option<DofLayout>,
     /// stored near-nullspace basis (optional)
@@ -2173,15 +2178,34 @@ impl AMG {
                     nns: h.levels[l].nns.clone(),
                     comp_of: h.levels[l].layout.as_ref().map(|lay| lay.comp_of.clone()),
                 };
-                smooth_sa_values_only_multi(
-                    &h.levels[l].a,
-                    &h.levels[l].diag_inv,
-                    &tp,
-                    self.cfg.jacobi_omega,
-                    &pr,
-                    &pc,
-                    &mut p_new_vals,
-                )?;
+                if let Some(ref rb) = h.levels[l].row_basis {
+                    let n_agg = 1 + h.levels[l].agg_of.iter().copied().max().unwrap_or(0);
+                    let tn = TentativeNodal {
+                        agg_of: tp.agg_of.clone(),
+                        n_agg,
+                        mfun: tp.num_functions,
+                        row_basis: rb.clone(),
+                    };
+                    smooth_sa_values_only_mf(
+                        &h.levels[l].a,
+                        &h.levels[l].diag_inv,
+                        &tn,
+                        self.cfg.jacobi_omega,
+                        &pr,
+                        &pc,
+                        &mut p_new_vals,
+                    )?;
+                } else {
+                    smooth_sa_values_only_multi(
+                        &h.levels[l].a,
+                        &h.levels[l].diag_inv,
+                        &tp,
+                        self.cfg.jacobi_omega,
+                        &pr,
+                        &pc,
+                        &mut p_new_vals,
+                    )?;
+                }
                 tp_opt = Some(tp);
             }
             let ctx = LevelPostContext {
@@ -4335,6 +4359,7 @@ fn build_hierarchy(
         cf: None,
         p2r_pos: Vec::new(),
         num_functions: 1,
+        row_basis: None,
         layout: layout0.clone(),
         nns: cfg.near_nullspace.as_ref().map(|nns| nns.basis.clone()),
         a_next_pat: None,
@@ -4407,11 +4432,24 @@ fn build_hierarchy(
             None
         };
         // 1) Strength of connection (sparse)
-        let s = with_timing(do_stats, &mut lt.strength, || {
+        let (s, nodal_strength_opt) = with_timing(do_stats, &mut lt.strength, || {
             if let Some(ref lay) = layout {
-                strength_nodal(&a_cur, lay, cfg.strong_threshold, cfg.normalize_strength)
+                let nodal = strength_nodal_from_csr(
+                    &a_cur,
+                    lay.block_size,
+                    cfg.strong_threshold,
+                    cfg.normalize_strength,
+                );
+                let strength = Strength {
+                    row_ptr: nodal.row_ptr.clone(),
+                    col_idx: nodal.col_idx.clone(),
+                };
+                (strength, Some(nodal))
             } else {
-                Strength::from_csr(&a_cur, cfg.strong_threshold, cfg.normalize_strength)
+                (
+                    Strength::from_csr(&a_cur, cfg.strong_threshold, cfg.normalize_strength),
+                    None,
+                )
             }
         });
         // 2) Aggregates
@@ -4420,51 +4458,89 @@ fn build_hierarchy(
         } else {
             1
         };
+        let agg_algo = match cfg.coarsen_type {
+            CoarsenType::RS => AggAlgo::RSGreedy,
+            CoarsenType::HMIS => AggAlgo::HMIS,
+            CoarsenType::PMIS => AggAlgo::PMIS,
+            CoarsenType::Falgout => AggAlgo::Falgout,
+        };
         let (agg_node, is_c_node) = with_timing(do_stats, &mut lt.aggregate, || {
-            build_aggregates(
-                &s,
-                match cfg.coarsen_type {
-                    CoarsenType::RS => AggAlgo::RSGreedy,
-                    CoarsenType::HMIS => AggAlgo::HMIS,
-                    CoarsenType::PMIS => AggAlgo::PMIS,
-                    CoarsenType::Falgout => AggAlgo::Falgout,
-                },
-                &AggOpts {
-                    mis_k,
-                    cap_per_row: cfg.max_strong_per_row,
-                },
-            )
+            match (layout.as_ref(), nodal_strength_opt.as_ref()) {
+                (Some(_), Some(nodal)) => build_aggregates_nodal(
+                    nodal,
+                    agg_algo,
+                    &AggOpts {
+                        mis_k,
+                        cap_per_row: cfg.max_strong_per_row,
+                    },
+                ),
+                _ => build_aggregates(
+                    &s,
+                    agg_algo,
+                    &AggOpts {
+                        mis_k,
+                        cap_per_row: cfg.max_strong_per_row,
+                    },
+                ),
+            }
         });
         let (agg, is_c) = if let Some(ref lay) = layout {
             lift_node_aggregates_to_dofs(&agg_node, &is_c_node, lay)
         } else {
             (agg_node, is_c_node)
         };
-        let mut num_functions = if level == 0 {
-            cfg.num_functions
-        } else {
-            block_size_cur
-        };
-        let nns_opt = if level == 0 {
-            cfg.near_nullspace.as_ref().map(|nns| {
-                if nns.basis.len() > num_functions {
-                    num_functions = nns.basis.len();
+        let mut nns_basis: Vec<Vec<f64>> = if level == 0 {
+            if let Some(ref nns) = cfg.near_nullspace {
+                for (k, vec) in nns.basis.iter().enumerate() {
+                    if vec.len() != n {
+                        return Err(KError::InvalidInput(format!(
+                            "AMG: near-nullspace vector {k} has length {}, expected {n}",
+                            vec.len()
+                        )));
+                    }
                 }
                 nns.basis.clone()
-            })
+            } else {
+                Vec::new()
+            }
         } else {
-            None
+            Vec::new()
         };
-        if nns_opt.is_none()
-            && let Some(ref lay) = layout
-            && num_functions < lay.block_size
-        {
-            num_functions = lay.block_size;
+        let user_supplied_nns = !nns_basis.is_empty();
+        if nns_basis.is_empty() {
+            if let Some(ref lay) = layout {
+                let mut basis = vec![vec![0.0; n]; lay.block_size.max(1)];
+                for i in 0..n {
+                    let comp = lay.comp_of[i];
+                    basis[comp][i] = 1.0;
+                }
+                nns_basis = basis;
+            } else {
+                nns_basis.push(vec![1.0; n]);
+            }
         }
-        let comp_opt = if nns_opt.is_none() {
-            layout.as_ref().map(|lay| lay.comp_of.clone())
+        let mut target_functions = if user_supplied_nns {
+            nns_basis.len().max(1)
+        } else if level == 0 {
+            cfg.num_functions.max(1)
+        } else if let Some(ref lay) = layout {
+            lay.block_size.max(1)
         } else {
+            1
+        };
+        if let Some(ref lay) = layout {
+            target_functions = target_functions.max(lay.block_size.max(1));
+        }
+        target_functions = target_functions.max(nns_basis.len().max(1));
+        while nns_basis.len() < target_functions {
+            nns_basis.push(vec![0.0; n]);
+        }
+        let num_functions = target_functions;
+        let nns_opt = Some(nns_basis.clone());
+        let comp_opt = if user_supplied_nns {
             None
+        } else {
+            layout.as_ref().map(|lay| lay.comp_of.clone())
         };
         let tp = TentativeP {
             n_coarse: 1 + agg.iter().copied().max().unwrap_or(0),
@@ -4475,7 +4551,42 @@ fn build_hierarchy(
         };
         let block_size_next = tp.num_functions.max(1);
         let d = diag_inv_from_csr_cfg(&a_cur, cfg)?;
+        let diag_weights: Vec<f64> = d
+            .iter()
+            .map(|&inv| {
+                if inv.abs() > 0.0 {
+                    (1.0 / inv).abs().max(1e-30)
+                } else {
+                    1.0
+                }
+            })
+            .collect();
+        let mut tn_opt: Option<TentativeNodal> = None;
+        if let Some(_) = layout {
+            let n_agg = tp.n_coarse;
+            let mut rows_per_agg: Vec<Vec<usize>> = vec![Vec::new(); n_agg];
+            for (row, &g) in agg.iter().enumerate() {
+                rows_per_agg[g].push(row);
+            }
+            let mut row_basis_vec = vec![0.0; n * num_functions];
+            for rows in &rows_per_agg {
+                orthonormalize_aggregate(
+                    rows,
+                    &nns_basis,
+                    &diag_weights,
+                    num_functions,
+                    &mut row_basis_vec,
+                );
+            }
+            tn_opt = Some(TentativeNodal {
+                agg_of: agg.clone(),
+                n_agg,
+                mfun: num_functions,
+                row_basis: row_basis_vec,
+            });
+        }
         let s_sym = s.symmetrize();
+        let tn_ref = tn_opt.as_ref();
         let (mut p_csr, cf_opt): (Pcsr, Option<CFInfo>) =
             with_timing(do_stats, &mut lt.prolong, || {
                 if matches!(
@@ -4514,6 +4625,18 @@ fn build_hierarchy(
                     let mut p = pat.clone();
                     p.vals = vals;
                     Ok((p, Some(cf)))
+                } else if let Some(tn) = tn_ref {
+                    Ok((
+                        smooth_tentative_sa_mf(
+                            &a_cur,
+                            &d,
+                            tn,
+                            cfg.jacobi_omega,
+                            cfg.interpolation_truncation,
+                            cfg.max_elements_per_row,
+                        ),
+                        None,
+                    ))
                 } else {
                     Ok((
                         smooth_tentative_sa_multi(
@@ -4529,6 +4652,7 @@ fn build_hierarchy(
                     ))
                 }
             })?;
+        let row_basis_for_level = tn_opt.as_ref().map(|tn| tn.row_basis.clone());
         let ctx = LevelPostContext {
             r: num_functions,
             agg_of: &tp.agg_of,
@@ -4779,6 +4903,7 @@ fn build_hierarchy(
         });
 
         // Replace previous temporary P/R by actual inter-level transfers and agg mapping
+        let mut row_basis_owned = row_basis_for_level;
         if let Some(prev) = levels.last_mut() {
             prev.p = p.clone();
             prev.agg_of = tp.agg_of.clone();
@@ -4786,6 +4911,7 @@ fn build_hierarchy(
             prev.cf = cf_opt.clone();
             prev.p2r_pos = p2r_pos;
             prev.num_functions = tp.num_functions;
+            prev.row_basis = row_basis_owned.take();
             prev.nns = tp.nns.clone();
             prev.layout = layout.clone();
             prev.a_next_pat = Some(pat.clone());
@@ -4821,6 +4947,7 @@ fn build_hierarchy(
             cf: None,
             p2r_pos: Vec::new(),
             num_functions: 1,
+            row_basis: None,
             layout: if cfg.nodal == NodalMode::Nodal {
                 Some(DofLayout::new(a_cur.nrows(), block_size_cur))
             } else {
@@ -5063,6 +5190,53 @@ fn enforce_oc_target(levels: &mut Vec<AMGLevel>, cfg: &mut AMGConfig) -> Result<
 }
 
 // ===== Sparse utilities (local; avoid dense on hot path) ====================
+
+fn orthonormalize_aggregate(
+    rows: &[usize],
+    basis_cols: &[Vec<f64>],
+    weights: &[f64],
+    mfun: usize,
+    row_basis: &mut [f64],
+) {
+    if rows.is_empty() {
+        return;
+    }
+    let mut q_cols: Vec<Vec<f64>> = Vec::new();
+    let limit = basis_cols.len().min(mfun);
+    for f in 0..limit {
+        let mut col: Vec<f64> = rows.iter().map(|&row_idx| basis_cols[f][row_idx]).collect();
+        for prev in 0..q_cols.len() {
+            let mut dot = 0.0;
+            for (local_ix, &row_idx) in rows.iter().enumerate() {
+                let w = weights[row_idx];
+                dot += w * col[local_ix] * q_cols[prev][local_ix];
+            }
+            for local_ix in 0..col.len() {
+                col[local_ix] -= dot * q_cols[prev][local_ix];
+            }
+        }
+        let mut norm_sq = 0.0;
+        for (local_ix, &row_idx) in rows.iter().enumerate() {
+            let w = weights[row_idx];
+            let v = col[local_ix];
+            norm_sq += w * v * v;
+        }
+        if norm_sq <= 1e-24 {
+            continue;
+        }
+        let norm = norm_sq.sqrt();
+        for val in &mut col {
+            *val /= norm;
+        }
+        q_cols.push(col);
+    }
+    for (local_ix, &row_idx) in rows.iter().enumerate() {
+        for f in 0..mfun {
+            let val = q_cols.get(f).map(|col| col[local_ix]).unwrap_or(0.0);
+            row_basis[row_idx * mfun + f] = val;
+        }
+    }
+}
 
 fn l1_diag_inv(a: &CsrMatrix<f64>) -> Vec<f64> {
     let n = a.nrows();
@@ -6578,6 +6752,8 @@ mod tests {
     mod cycle_policy;
     mod fsai_smoother;
     mod mixed_precision;
+    mod nodal_nns;
+    mod nodal_strength;
     mod rank_galerkin;
 
     #[inline]
@@ -6679,6 +6855,7 @@ mod tests {
             cf: None,
             p2r_pos: vec![],
             num_functions: 1,
+            row_basis: None,
             layout: None,
             nns: None,
             a_next_pat: None,
@@ -6713,6 +6890,7 @@ mod tests {
             cf: None,
             p2r_pos: vec![],
             num_functions: 1,
+            row_basis: None,
             layout: None,
             nns: None,
             a_next_pat: None,

--- a/src/preconditioner/amg/coarsen.rs
+++ b/src/preconditioner/amg/coarsen.rs
@@ -1,4 +1,5 @@
 use super::strength::Strength;
+use super::strength_nodal::NodalStrength;
 use super::util::DofLayout;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -186,6 +187,18 @@ pub fn build_aggregates(s_in: &Strength, algo: AggAlgo, opts: &AggOpts) -> (Vec<
 
     let agg = aggregates_from_seeds(&s, &is_seed);
     (agg, is_seed)
+}
+
+pub fn build_aggregates_nodal(
+    s: &NodalStrength,
+    algo: AggAlgo,
+    opts: &AggOpts,
+) -> (Vec<usize>, Vec<bool>) {
+    let strength = Strength {
+        row_ptr: s.row_ptr.clone(),
+        col_idx: s.col_idx.clone(),
+    };
+    build_aggregates(&strength, algo, opts)
 }
 
 pub fn lift_node_aggregates_to_dofs(

--- a/src/preconditioner/amg/prolong.rs
+++ b/src/preconditioner/amg/prolong.rs
@@ -28,6 +28,14 @@ pub fn tentative_from_aggregates(agg: Vec<usize>) -> TentativeP {
 }
 
 #[derive(Clone, Debug)]
+pub struct TentativeNodal {
+    pub agg_of: Vec<usize>,
+    pub n_agg: usize,
+    pub mfun: usize,
+    pub row_basis: Vec<f64>,
+}
+
+#[derive(Clone, Debug)]
 pub struct Pcsr {
     pub m: usize,
     pub n: usize,
@@ -1015,6 +1023,111 @@ pub fn smooth_tentative_sa_multi(
     }
 }
 
+pub fn smooth_tentative_sa_mf(
+    a: &CsrMatrix<f64>,
+    d_inv: &[f64],
+    tn: &TentativeNodal,
+    omega: f64,
+    drop_tol: f64,
+    max_per_row: usize,
+) -> Pcsr {
+    let n = a.nrows();
+    let mfun = tn.mfun;
+    let ncoarse = tn.n_agg * mfun;
+    debug_assert_eq!(tn.agg_of.len(), n);
+    debug_assert_eq!(tn.row_basis.len(), n * mfun);
+
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx: Vec<usize> = Vec::new();
+    let mut vals: Vec<f64> = Vec::new();
+    row_ptr.push(0);
+
+    let mut marker: Vec<isize> = vec![-1; ncoarse.min(4096).max(512)];
+    let mut acc_cols: Vec<usize> = Vec::new();
+    let mut acc_vals: Vec<f64> = Vec::new();
+
+    for i in 0..n {
+        if marker.len() < ncoarse {
+            marker.resize(ncoarse, -1);
+        }
+        acc_cols.clear();
+        acc_vals.clear();
+
+        let gi = tn.agg_of[i];
+        let di = d_inv[i];
+
+        for f in 0..mfun {
+            let c = gi * mfun + f;
+            marker[c] = acc_cols.len() as isize;
+            acc_cols.push(c);
+            acc_vals.push(tn.row_basis[i * mfun + f]);
+        }
+
+        let rs = rp[i];
+        let re = rp[i + 1];
+        for p in rs..re {
+            let j = cj[p];
+            if j == i {
+                continue;
+            }
+            let gj = tn.agg_of[j];
+            let scale = -omega * di * vv[p];
+            for f in 0..mfun {
+                let c = gj * mfun + f;
+                let contrib = scale * tn.row_basis[j * mfun + f];
+                let k = marker[c];
+                if k >= 0 {
+                    acc_vals[k as usize] += contrib;
+                } else {
+                    marker[c] = acc_cols.len() as isize;
+                    acc_cols.push(c);
+                    acc_vals.push(contrib);
+                }
+            }
+        }
+
+        let mut keep: Vec<(usize, f64)> = Vec::with_capacity(acc_cols.len());
+        for (&c, &v) in acc_cols.iter().zip(acc_vals.iter()) {
+            if v.abs() >= drop_tol {
+                keep.push((c, v));
+            }
+        }
+
+        if max_per_row > 0 && keep.len() > max_per_row {
+            keep.select_nth_unstable_by(max_per_row, |a, b| {
+                b.1.abs()
+                    .partial_cmp(&a.1.abs())
+                    .unwrap_or(std::cmp::Ordering::Equal)
+                    .then_with(|| a.0.cmp(&b.0))
+            });
+            keep.truncate(max_per_row);
+        }
+
+        keep.sort_by(|a, b| a.0.cmp(&b.0));
+        for (c, v) in keep {
+            col_idx.push(c);
+            vals.push(v);
+        }
+        row_ptr.push(col_idx.len());
+
+        for &c in &acc_cols {
+            marker[c] = -1;
+        }
+    }
+
+    Pcsr {
+        m: n,
+        n: ncoarse,
+        row_ptr,
+        col_idx,
+        vals,
+    }
+}
+
 pub fn smooth_sa_values_only_multi(
     a: &CsrMatrix<f64>,
     d_inv: &[f64],
@@ -1094,6 +1207,78 @@ pub fn smooth_sa_values_only_multi(
             }
         }
     }
+    Ok(())
+}
+
+pub fn smooth_sa_values_only_mf(
+    a: &CsrMatrix<f64>,
+    d_inv: &[f64],
+    tn: &TentativeNodal,
+    omega: f64,
+    p_row_ptr: &[usize],
+    p_col_idx: &[usize],
+    out_vals: &mut [f64],
+) -> Result<(), KError> {
+    let n = a.nrows();
+    let mfun = tn.mfun;
+    if tn.agg_of.len() != n {
+        return Err(KError::InvalidInput(
+            "smooth_sa_values_only_mf: agg_of length mismatch".into(),
+        ));
+    }
+    if tn.row_basis.len() != n * mfun {
+        return Err(KError::InvalidInput(
+            "smooth_sa_values_only_mf: row_basis length mismatch".into(),
+        ));
+    }
+    if d_inv.len() != n {
+        return Err(KError::InvalidInput(
+            "smooth_sa_values_only_mf: d_inv length mismatch".into(),
+        ));
+    }
+    if p_row_ptr.len() != n + 1 {
+        return Err(KError::InvalidInput(
+            "smooth_sa_values_only_mf: row_ptr length mismatch".into(),
+        ));
+    }
+    if p_col_idx.len() != out_vals.len() {
+        return Err(KError::InvalidInput(
+            "smooth_sa_values_only_mf: values length mismatch".into(),
+        ));
+    }
+
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+
+    for i in 0..n {
+        let gi = tn.agg_of[i];
+        let di = d_inv[i];
+        let rs = rp[i];
+        let re = rp[i + 1];
+        let prs = p_row_ptr[i];
+        let pre = p_row_ptr[i + 1];
+        for k in prs..pre {
+            let c = p_col_idx[k];
+            let g_col = c / mfun;
+            let f_col = c % mfun;
+            let mut value = if g_col == gi {
+                tn.row_basis[i * mfun + f_col]
+            } else {
+                0.0
+            };
+            let mut sum = 0.0;
+            for p in rs..re {
+                let j = cj[p];
+                if j != i && tn.agg_of[j] == g_col {
+                    sum += vv[p] * tn.row_basis[j * mfun + f_col];
+                }
+            }
+            value += -omega * di * sum;
+            out_vals[k] = value;
+        }
+    }
+
     Ok(())
 }
 
@@ -1310,6 +1495,63 @@ mod tests {
             }
             let sum: f64 = first[rs..re].iter().sum();
             assert!((sum - 1.0).abs() < 1e-8);
+        }
+    }
+
+    #[test]
+    fn smooth_tentative_sa_mf_preserves_row_basis_when_omega_zero() {
+        let a = CsrMatrix::from_csr(
+            4,
+            4,
+            vec![0, 1, 2, 3, 4],
+            vec![0, 1, 2, 3],
+            vec![2.0, 3.0, 4.0, 5.0],
+        );
+        let tn = TentativeNodal {
+            agg_of: vec![0, 0, 1, 1],
+            n_agg: 2,
+            mfun: 2,
+            row_basis: vec![
+                1.0, 0.0, // row 0
+                0.0, 1.0, // row 1
+                1.0, 0.0, // row 2
+                0.0, 1.0, // row 3
+            ],
+        };
+        let d_inv = vec![1.0; 4];
+        let p = smooth_tentative_sa_mf(&a, &d_inv, &tn, 0.0, 0.0, 0);
+        assert_eq!(p.m, 4);
+        assert_eq!(p.n, 4);
+        assert_eq!(p.row_ptr, vec![0, 2, 4, 6, 8]);
+        assert_eq!(p.col_idx, vec![0, 1, 0, 1, 2, 3, 2, 3]);
+        assert_eq!(p.vals, vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0]);
+    }
+
+    #[test]
+    fn smooth_sa_values_only_mf_matches_builder() {
+        let a = CsrMatrix::from_csr(
+            4,
+            4,
+            vec![0, 3, 6, 9, 12],
+            vec![0, 1, 2, 0, 1, 3, 1, 2, 3, 0, 2, 3],
+            vec![
+                4.0, -1.0, 0.5, -1.0, 4.0, -0.5, 0.5, -1.0, 4.0, 0.5, -0.5, 4.0,
+            ],
+        );
+        let tn = TentativeNodal {
+            agg_of: vec![0, 0, 1, 1],
+            n_agg: 2,
+            mfun: 2,
+            row_basis: vec![1.0, 0.0, 0.0, 1.0, 1.0, 0.0, 0.0, 1.0],
+        };
+        let d_inv = vec![1.0 / 4.0; 4];
+        let p = smooth_tentative_sa_mf(&a, &d_inv, &tn, 0.8, 0.0, 0);
+        let mut refreshed = vec![0.0; p.vals.len()];
+        smooth_sa_values_only_mf(&a, &d_inv, &tn, 0.8, &p.row_ptr, &p.col_idx, &mut refreshed)
+            .unwrap();
+        assert_eq!(refreshed.len(), p.vals.len());
+        for (a, b) in refreshed.iter().zip(p.vals.iter()) {
+            assert!((a - b).abs() < 1e-12);
         }
     }
 }

--- a/src/preconditioner/amg/strength_nodal.rs
+++ b/src/preconditioner/amg/strength_nodal.rs
@@ -5,66 +5,91 @@ use crate::matrix::sparse::CsrMatrix;
 use super::strength::Strength;
 use super::util::DofLayout;
 
+#[derive(Clone, Debug)]
+pub struct NodalStrength {
+    pub row_ptr: Vec<usize>,
+    pub col_idx: Vec<usize>,
+}
+
+pub fn strength_nodal_from_csr(
+    a: &CsrMatrix<f64>,
+    block_size: usize,
+    theta: f64,
+    normalize: bool,
+) -> NodalStrength {
+    assert!(block_size >= 1, "block_size must be positive");
+    assert_eq!(a.nrows() % block_size, 0, "block_size must divide nrows");
+    let n_nodes = a.nrows() / block_size;
+    let mut diag_sq = vec![0.0; n_nodes];
+    let mut rows: Vec<BTreeMap<usize, f64>> = vec![BTreeMap::new(); n_nodes];
+
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+    for row in 0..a.nrows() {
+        let u = row / block_size;
+        let rs = rp[row];
+        let re = rp[row + 1];
+        for p in rs..re {
+            let j = cj[p];
+            let w = j / block_size;
+            let val_sq = vv[p] * vv[p];
+            if u == w {
+                diag_sq[u] += val_sq;
+            } else {
+                *rows[u].entry(w).or_insert(0.0) += val_sq;
+            }
+        }
+    }
+
+    let diag_norm: Vec<f64> = diag_sq.iter().map(|&s| s.sqrt()).collect();
+
+    let mut row_ptr = Vec::with_capacity(n_nodes + 1);
+    let mut col_idx = Vec::<usize>::new();
+    row_ptr.push(0);
+    for u in 0..n_nodes {
+        let mut max_off = 0.0;
+        if !normalize {
+            for &sq in rows[u].values() {
+                let norm = sq.sqrt();
+                if norm > max_off {
+                    max_off = norm;
+                }
+            }
+        }
+
+        let start_len = col_idx.len();
+        for (&w, &sq) in rows[u].iter() {
+            let norm = sq.sqrt();
+            let keep = if normalize {
+                let denom = diag_norm[u] * diag_norm[w];
+                denom > 0.0 && norm / denom >= theta
+            } else {
+                max_off > 0.0 && norm >= theta * max_off
+            };
+            if keep {
+                col_idx.push(w);
+            }
+        }
+        row_ptr.push(col_idx.len());
+        debug_assert!(
+            row_ptr.last().copied().unwrap() - row_ptr[row_ptr.len() - 2]
+                == col_idx.len() - start_len
+        );
+    }
+
+    NodalStrength { row_ptr, col_idx }
+}
+
 pub fn strength_nodal(
     a: &CsrMatrix<f64>,
     layout: &DofLayout,
     theta: f64,
     normalize: bool,
 ) -> Strength {
-    let n = layout.n_nodes;
-    let mut diag = vec![0.0; n];
-    let mut rows: Vec<BTreeMap<usize, f64>> = vec![BTreeMap::new(); n];
-
-    let rp = a.row_ptr();
-    let cj = a.col_idx();
-    let vv = a.values();
-    for i_dof in 0..a.nrows() {
-        let u = layout.node_of[i_dof];
-        let rs = rp[i_dof];
-        let re = rp[i_dof + 1];
-        for p in rs..re {
-            let j_dof = cj[p];
-            let v = vv[p].abs();
-            let w = layout.node_of[j_dof];
-            if u == w {
-                if v > diag[u] {
-                    diag[u] = v;
-                }
-            } else {
-                let e = rows[u].entry(w).or_insert(0.0);
-                if v > *e {
-                    *e = v;
-                }
-            }
-        }
+    let nodal = strength_nodal_from_csr(a, layout.block_size, theta, normalize);
+    Strength {
+        row_ptr: nodal.row_ptr,
+        col_idx: nodal.col_idx,
     }
-
-    let mut row_ptr = Vec::with_capacity(n + 1);
-    let mut col_idx = Vec::<usize>::new();
-    row_ptr.push(0);
-    for u in 0..n {
-        let mut count = 0usize;
-        let mut max_off = 0.0;
-        if !normalize {
-            for &blk in rows[u].values() {
-                if blk > max_off {
-                    max_off = blk;
-                }
-            }
-        }
-        for (&w, &blk) in rows[u].iter() {
-            let keep = if normalize {
-                let denom = (diag[u] * diag[w]).sqrt();
-                denom > 0.0 && blk / denom >= theta
-            } else {
-                max_off > 0.0 && blk >= theta * max_off
-            };
-            if keep {
-                col_idx.push(w);
-                count += 1;
-            }
-        }
-        row_ptr.push(row_ptr.last().unwrap() + count);
-    }
-    Strength { row_ptr, col_idx }
 }

--- a/src/preconditioner/amg/tests/nodal_nns.rs
+++ b/src/preconditioner/amg/tests/nodal_nns.rs
@@ -1,0 +1,326 @@
+use super::super::AMGBuilder;
+use super::super::prolong::{
+    TentativeNodal, TentativeP, smooth_tentative_sa_mf, smooth_tentative_sa_multi,
+};
+use crate::matrix::sparse::{CsrMatrix, SparseMatrix};
+use crate::preconditioner::Preconditioner;
+use faer::Mat;
+
+fn sample_block_matrix() -> CsrMatrix<f64> {
+    let row_ptr = vec![0, 3, 6, 9, 12];
+    let col_idx = vec![
+        0, 1, 2, // row 0
+        0, 1, 3, // row 1
+        0, 2, 3, // row 2
+        1, 2, 3, // row 3
+    ];
+    let vals = vec![
+        4.0, -1.0, -0.5, // row 0
+        -1.0, 5.0, -1.0, // row 1
+        -0.5, -1.0, 5.0, // row 2
+        -1.0, -0.5, 4.0, // row 3
+    ];
+    CsrMatrix::from_csr(4, 4, row_ptr, col_idx, vals)
+}
+
+#[test]
+fn nodal_row_basis_is_locally_orthonormal() {
+    let _guard = super::relax_lock().lock().unwrap();
+
+    let a = sample_block_matrix();
+
+    let mut amg = AMGBuilder::new()
+        .nodal(true, 2)
+        .num_functions(2)
+        .strong_threshold(0.25)
+        .coarse_threshold(1)
+        .max_coarse_size(1)
+        .max_levels(2)
+        .require_spd(false)
+        .build(&Mat::<f64>::zeros(0, 0))
+        .unwrap();
+    amg.setup(&a).unwrap();
+
+    let h = amg.state.as_ref().unwrap();
+    let level0 = &h.levels[0];
+    assert_eq!(level0.num_functions, 2);
+    let row_basis = level0
+        .row_basis
+        .as_ref()
+        .expect("row_basis populated for nodal level");
+    let agg_of = &level0.agg_of;
+    let diag_inv = &level0.diag_inv;
+    let mut diag = vec![0.0; diag_inv.len()];
+    for (i, &inv) in diag_inv.iter().enumerate() {
+        diag[i] = if inv.abs() > 0.0 { 1.0 / inv } else { 0.0 };
+    }
+    let mfun = level0.num_functions;
+    let n_agg = 1 + agg_of.iter().copied().max().unwrap_or(0);
+    for g in 0..n_agg {
+        let rows: Vec<usize> = agg_of
+            .iter()
+            .enumerate()
+            .filter_map(|(i, &agg)| if agg == g { Some(i) } else { None })
+            .collect();
+        if rows.is_empty() {
+            continue;
+        }
+        let mut gram = vec![0.0f64; mfun * mfun];
+        for (f1, f2) in (0..mfun).flat_map(|i| (0..mfun).map(move |j| (i, j))) {
+            let mut sum = 0.0;
+            for &i in &rows {
+                let w = diag[i].abs().max(1e-30);
+                let v1 = row_basis[i * mfun + f1];
+                let v2 = row_basis[i * mfun + f2];
+                sum += w * v1 * v2;
+            }
+            gram[f1 * mfun + f2] = sum;
+        }
+        for f in 0..mfun {
+            let norm = gram[f * mfun + f];
+            if norm > 1e-9 {
+                assert!(
+                    (norm - 1.0).abs() <= 1e-9,
+                    "aggregate {g} column {f} norm {norm}"
+                );
+            } else {
+                assert!(norm.abs() <= 1e-12);
+            }
+            for f2 in (f + 1)..mfun {
+                let off = gram[f * mfun + f2];
+                assert!(
+                    off.abs() <= 1e-9,
+                    "aggregate {g} columns {f}/{f2} not orthogonal: {off}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn nodal_tentative_is_deterministic() {
+    let _guard = super::relax_lock().lock().unwrap();
+
+    let a = sample_block_matrix();
+
+    let build_once = || {
+        let mut amg = AMGBuilder::new()
+            .nodal(true, 2)
+            .num_functions(2)
+            .strong_threshold(0.25)
+            .coarse_threshold(1)
+            .max_coarse_size(1)
+            .max_levels(2)
+            .require_spd(false)
+            .build(&Mat::<f64>::zeros(0, 0))
+            .unwrap();
+        amg.setup(&a).unwrap();
+        let level0 = &amg.state.as_ref().unwrap().levels[0];
+        (
+            level0.p.row_ptr().to_vec(),
+            level0.p.col_idx().to_vec(),
+            level0.p.values().to_vec(),
+        )
+    };
+
+    let (rp1, ci1, vv1) = build_once();
+    let (rp2, ci2, vv2) = build_once();
+
+    assert_eq!(rp1, rp2, "row_ptr differs between builds");
+    assert_eq!(ci1, ci2, "col_idx differs between builds");
+    assert_eq!(vv1.len(), vv2.len());
+    for (k, (&v1, &v2)) in vv1.iter().zip(vv2.iter()).enumerate() {
+        assert!(
+            (v1 - v2).abs() <= 1e-12,
+            "value mismatch at entry {k}: {v1} vs {v2}"
+        );
+    }
+}
+
+#[test]
+fn restriction_respects_component_modes() {
+    let _guard = super::relax_lock().lock().unwrap();
+
+    let a = sample_block_matrix();
+    let mut amg = AMGBuilder::new()
+        .nodal(true, 2)
+        .num_functions(2)
+        .strong_threshold(0.25)
+        .coarse_threshold(1)
+        .max_coarse_size(1)
+        .max_levels(2)
+        .require_spd(false)
+        .build(&Mat::<f64>::zeros(0, 0))
+        .unwrap();
+    amg.setup(&a).unwrap();
+
+    let state = amg.state.as_ref().unwrap();
+    let level0 = &state.levels[0];
+    let layout = level0
+        .layout
+        .as_ref()
+        .expect("layout present for nodal hierarchy");
+    let mfun = level0.num_functions;
+    assert_eq!(mfun, 2);
+    let mut yc = vec![0.0f64; level0.p.ncols()];
+
+    for k in 0..mfun {
+        let mut phi = vec![0.0f64; a.nrows()];
+        for i in 0..phi.len() {
+            if layout.comp_of[i] == k {
+                phi[i] = 1.0;
+            }
+        }
+        level0.r.spmv(&phi, &mut yc);
+        for (idx, &val) in yc.iter().enumerate() {
+            let comp = idx % mfun;
+            if comp == k {
+                assert!(
+                    val.abs() > 1e-8,
+                    "component {k} lost mass at coarse index {idx}: {val}"
+                );
+            } else {
+                assert!(
+                    val.abs() <= 1e-12,
+                    "component {k} leaked into column {idx} with value {val}"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn scalar_and_nodal_singleton_match() {
+    let _guard = super::relax_lock().lock().unwrap();
+
+    let row_ptr = vec![0, 4, 8, 12, 16];
+    let col_idx = vec![
+        0, 1, 2, 3, // row 0
+        0, 1, 2, 3, // row 1
+        0, 1, 2, 3, // row 2
+        0, 1, 2, 3, // row 3
+    ];
+    let vals = vec![
+        6.0, -1.0, -0.8, -0.2, // row 0
+        -1.0, 5.5, -0.7, -0.4, // row 1
+        -0.8, -0.7, 5.8, -1.1, // row 2
+        -0.2, -0.4, -1.1, 5.2, // row 3
+    ];
+    let a = CsrMatrix::from_csr(4, 4, row_ptr, col_idx, vals);
+    let mut d_inv = vec![0.0f64; a.nrows()];
+    for i in 0..a.nrows() {
+        let mut diag: f64 = 0.0;
+        for p in a.row_ptr()[i]..a.row_ptr()[i + 1] {
+            if a.col_idx()[p] == i {
+                diag = a.values()[p];
+                break;
+            }
+        }
+        assert!(diag.abs() > 1e-12, "diagonal vanished at row {i}");
+        d_inv[i] = 1.0 / diag;
+    }
+
+    let agg_of = vec![0, 0, 1, 1];
+    let tp = TentativeP {
+        agg_of: agg_of.clone(),
+        n_coarse: 2,
+        num_functions: 1,
+        nns: Some(vec![vec![1.0; a.nrows()]]),
+        comp_of: None,
+    };
+    let tn = TentativeNodal {
+        agg_of: agg_of.clone(),
+        n_agg: 2,
+        mfun: 1,
+        row_basis: vec![1.0; a.nrows()],
+    };
+
+    let omega = 0.8;
+    let drop_tol = 0.0;
+    let max_per_row = 0usize;
+    let trunc_rel = 0.0;
+
+    let p_scalar =
+        smooth_tentative_sa_multi(&a, &d_inv, &tp, omega, drop_tol, max_per_row, trunc_rel);
+    let p_nodal = smooth_tentative_sa_mf(&a, &d_inv, &tn, omega, drop_tol, max_per_row);
+
+    assert_eq!(p_scalar.row_ptr, p_nodal.row_ptr);
+    assert_eq!(p_scalar.col_idx, p_nodal.col_idx);
+    assert_eq!(p_scalar.vals.len(), p_nodal.vals.len());
+    for (k, (&vs, &vn)) in p_scalar.vals.iter().zip(p_nodal.vals.iter()).enumerate() {
+        assert!(
+            (vs - vn).abs() <= 1e-12,
+            "entry {k} mismatch: scalar={vs}, nodal={vn}"
+        );
+    }
+}
+
+#[test]
+fn nodal_numeric_refresh_updates_values() {
+    let _guard = super::relax_lock().lock().unwrap();
+
+    let a = sample_block_matrix();
+    let mut amg = AMGBuilder::new()
+        .nodal(true, 2)
+        .num_functions(2)
+        .strong_threshold(0.25)
+        .coarse_threshold(1)
+        .max_coarse_size(1)
+        .max_levels(2)
+        .require_spd(false)
+        .build(&Mat::<f64>::zeros(0, 0))
+        .unwrap();
+    amg.setup(&a).unwrap();
+
+    let state_before = amg.state.as_ref().unwrap();
+    let p_vals_before = state_before.levels[0].p.values().to_vec();
+    let coarse_vals_before = state_before.levels[1].a.values().to_vec();
+    let p_pattern = (
+        state_before.levels[0].p.row_ptr().to_vec(),
+        state_before.levels[0].p.col_idx().to_vec(),
+    );
+
+    let mut a_scaled = a.clone();
+    {
+        let rp = a_scaled.row_ptr().to_vec();
+        let cj = a_scaled.col_idx().to_vec();
+        let nrows = a_scaled.nrows();
+        let vals = a_scaled.values_mut();
+        for i in 0..nrows {
+            for p in rp[i]..rp[i + 1] {
+                if cj[p] == i {
+                    let factor = 1.05 + 0.1 * (i as f64);
+                    vals[p] *= factor;
+                } else {
+                    let factor = 1.1 + 0.05 * ((i + cj[p]) as f64);
+                    vals[p] *= factor;
+                }
+            }
+        }
+    }
+
+    amg.update_numeric(&a_scaled).unwrap();
+
+    let state_after = amg.state.as_ref().unwrap();
+    let p_after = &state_after.levels[0].p;
+    assert_eq!(p_pattern.0, p_after.row_ptr());
+    assert_eq!(p_pattern.1, p_after.col_idx());
+
+    let max_diff_p = p_vals_before
+        .iter()
+        .zip(p_after.values())
+        .map(|(&before, &after)| (before - after).abs())
+        .fold(0.0f64, f64::max);
+
+    let coarse_after = state_after.levels[1].a.values();
+    let max_diff_coarse = coarse_vals_before
+        .iter()
+        .zip(coarse_after.iter())
+        .map(|(&before, &after)| (before - after).abs())
+        .fold(0.0f64, f64::max);
+
+    assert!(
+        max_diff_p > 1e-12 || max_diff_coarse > 1e-12,
+        "numeric refresh did not change P or A_c"
+    );
+}

--- a/src/preconditioner/amg/tests/nodal_strength.rs
+++ b/src/preconditioner/amg/tests/nodal_strength.rs
@@ -1,0 +1,73 @@
+use super::DofLayout;
+use super::coarsen::{
+    AggAlgo, AggOpts, build_aggregates, build_aggregates_nodal, lift_node_aggregates_to_dofs,
+};
+use super::strength_nodal;
+use crate::matrix::sparse::CsrMatrix;
+
+fn make_sample_matrix() -> CsrMatrix<f64> {
+    let row_ptr = vec![0, 2, 5, 8, 10];
+    let col_idx = vec![0, 1, 0, 1, 2, 1, 2, 3, 2, 3];
+    let vals = vec![
+        4.0, -1.0, // row 0
+        -1.0, 4.0, -2.0, // row 1
+        -2.0, 5.0, -3.0, // row 2
+        -3.0, 6.0, // row 3
+    ];
+    CsrMatrix::from_csr(4, 4, row_ptr, col_idx, vals)
+}
+
+#[test]
+fn nodal_strength_frobenius_thresholding() {
+    let a = make_sample_matrix();
+    let nodal = strength_nodal::strength_nodal_from_csr(&a, 2, 0.25, false);
+    assert_eq!(nodal.row_ptr, vec![0, 1, 2]);
+    assert_eq!(nodal.col_idx, vec![1, 0]);
+
+    // Raising the threshold above 1.0 prunes the only neighbor in the unnormalized graph
+    let nodal_strict = strength_nodal::strength_nodal_from_csr(&a, 2, 1.1, false);
+    assert_eq!(nodal_strict.row_ptr, vec![0, 0, 0]);
+    assert!(nodal_strict.col_idx.is_empty());
+}
+
+#[test]
+fn nodal_strength_normalized_scaling() {
+    let a = make_sample_matrix();
+    let nodal = strength_nodal::strength_nodal_from_csr(&a, 2, 0.03, true);
+    assert_eq!(nodal.row_ptr, vec![0, 1, 2]);
+    assert_eq!(nodal.col_idx, vec![1, 0]);
+
+    // Slightly higher threshold should cull the connection once normalized
+    let nodal_high = strength_nodal::strength_nodal_from_csr(&a, 2, 0.04, true);
+    assert_eq!(nodal_high.row_ptr, vec![0, 0, 0]);
+    assert!(nodal_high.col_idx.is_empty());
+}
+
+#[test]
+fn nodal_aggregation_matches_legacy() {
+    let a = make_sample_matrix();
+    let layout = DofLayout::new(a.nrows(), 2);
+    let theta = 0.2;
+    let legacy_strength = strength_nodal::strength_nodal(&a, &layout, theta, false);
+    let opts = AggOpts {
+        mis_k: 1,
+        cap_per_row: None,
+    };
+    let (agg_legacy_nodes, seeds_legacy_nodes) =
+        build_aggregates(&legacy_strength, AggAlgo::PMIS, &opts);
+
+    let nodal_strength = strength_nodal::strength_nodal_from_csr(&a, 2, theta, false);
+    let (agg_nodes, seeds_nodes) = build_aggregates_nodal(&nodal_strength, AggAlgo::PMIS, &opts);
+    assert_eq!(agg_nodes.len(), layout.n_nodes);
+    assert_eq!(seeds_nodes.len(), layout.n_nodes);
+
+    let (agg_from_nodes, seeds_from_nodes) =
+        lift_node_aggregates_to_dofs(&agg_nodes, &seeds_nodes, &layout);
+    assert_eq!(agg_from_nodes, vec![0, 0, 0, 0]);
+    assert_eq!(seeds_from_nodes, vec![true, true, false, false]);
+
+    let (agg_legacy_dof, seeds_legacy_dof) =
+        lift_node_aggregates_to_dofs(&agg_legacy_nodes, &seeds_legacy_nodes, &layout);
+    assert_eq!(agg_legacy_dof, agg_from_nodes);
+    assert_eq!(seeds_legacy_dof, seeds_from_nodes);
+}


### PR DESCRIPTION
## Summary
- use the CSR-based nodal strength graph to drive node-level aggregation before lifting back to DOFs
- correct normalized nodal strength scaling so block couplings are compared against the proper diagonal norms
- update the nodal strength regression to reflect the corrected normalized thresholding behaviour

## Testing
- `cargo test nodal_strength`
- `cargo test nodal_nns --lib`


------
https://chatgpt.com/codex/tasks/task_e_68cf9acb77f08329b9a0ca224d549ca5