### PR TITLE
Implement distributed kernels and memory estimates

### DIFF
--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -467,11 +467,24 @@ impl KernelOp<f64> for DistributedKernel {
         x: &[f64],
         beta: f64,
         y: &mut [f64],
-        _comm: &Self::Comm,
+        comm: &Self::Comm,
     ) -> Result<(), crate::error::KError> {
-        // TODO: Add proper distributed matrix-vector operations
-        // For now, delegate to local operation
-        matrix.mat_vec(alpha, x, beta, y)
+        let mut local = vec![0.0f64; y.len()];
+        matrix.mat_vec(alpha, x, 0.0, &mut local)?;
+        use crate::parallel::Comm as _;
+        comm.allreduce_sum_slice(&mut local);
+        if beta == 0.0 {
+            y.copy_from_slice(&local);
+        } else {
+            let original: Vec<f64> = y.iter().copied().collect();
+            for (out, (accum, orig)) in y
+                .iter_mut()
+                .zip(local.into_iter().zip(original.into_iter()))
+            {
+                *out = accum + beta * orig;
+            }
+        }
+        Ok(())
     }
 
     fn kernel_mat_vec_trans(
@@ -481,10 +494,24 @@ impl KernelOp<f64> for DistributedKernel {
         x: &[f64],
         beta: f64,
         y: &mut [f64],
-        _comm: &Self::Comm,
+        comm: &Self::Comm,
     ) -> Result<(), crate::error::KError> {
-        // TODO: Add proper distributed transpose operations
-        matrix.mat_vec_trans(alpha, x, beta, y)
+        let mut local = vec![0.0f64; y.len()];
+        matrix.mat_vec_trans(alpha, x, 0.0, &mut local)?;
+        use crate::parallel::Comm as _;
+        comm.allreduce_sum_slice(&mut local);
+        if beta == 0.0 {
+            y.copy_from_slice(&local);
+        } else {
+            let original: Vec<f64> = y.iter().copied().collect();
+            for (out, (accum, orig)) in y
+                .iter_mut()
+                .zip(local.into_iter().zip(original.into_iter()))
+            {
+                *out = accum + beta * orig;
+            }
+        }
+        Ok(())
     }
 
     fn kernel_dot(&self, x: &[f64], y: &[f64], comm: &Self::Comm) -> f64 {
@@ -530,6 +557,7 @@ pub trait AmgKernel {
         x: &[f64],
         beta: f64,
         y: &mut [f64],
+        comm: &Self::Comm,
     ) -> Result<(), crate::error::KError>
     where
         M: MatVecOp<f64>;
@@ -577,6 +605,7 @@ impl AmgKernel for LocalAmgKernel {
         x: &[f64],
         beta: f64,
         y: &mut [f64],
+        _comm: &Self::Comm,
     ) -> Result<(), crate::error::KError>
     where
         M: MatVecOp<f64>,
@@ -630,12 +659,27 @@ impl AmgKernel for DistributedAmgKernel {
         x: &[f64],
         beta: f64,
         y: &mut [f64],
+        comm: &Self::Comm,
     ) -> Result<(), crate::error::KError>
     where
         M: MatVecOp<f64>,
     {
-        // For now, delegate to trait method (TODO: implement proper distributed matvec)
-        a.mat_vec(alpha, x, beta, y)
+        let mut local = vec![0.0f64; y.len()];
+        a.mat_vec(alpha, x, 0.0, &mut local)?;
+        use crate::parallel::Comm as _;
+        comm.allreduce_sum_slice(&mut local);
+        if beta == 0.0 {
+            y.copy_from_slice(&local);
+        } else {
+            let original: Vec<f64> = y.iter().copied().collect();
+            for (out, (accum, orig)) in y
+                .iter_mut()
+                .zip(local.into_iter().zip(original.into_iter()))
+            {
+                *out = accum + beta * orig;
+            }
+        }
+        Ok(())
     }
 
     fn dot(&self, x: &[f64], y: &[f64], comm: &Self::Comm) -> f64 {

--- a/src/parallel/mpi_comm.rs
+++ b/src/parallel/mpi_comm.rs
@@ -177,26 +177,34 @@ impl super::Comm for MpiComm {
         }))
     }
 
-    /// Parallel matrix-vector multiplication (currently serial, placeholder for distributed version).
-    ///
-    /// - `a`: The matrix (all rows available on all processes).
-    /// - `x`: The input vector.
-    /// - `y`: The output vector (to be filled with the result).
-    ///
-    /// # Note
-    /// This implementation is currently serial and does not partition the matrix or vector by rank.
-    /// In a true distributed setting, the matrix and vectors should be partitioned and communication
-    /// performed as needed.
     fn parallel_mat_vec(&self, a: &faer::Mat<f64>, x: &[f64], y: &mut [f64]) {
-        // For now, just serial mat-vec. TODO: partition by rank for distributed mat-vec.
         assert_eq!(a.ncols(), x.len());
         assert_eq!(a.nrows(), y.len());
-        for i in 0..a.nrows() {
-            y[i] = 0.0;
-            for j in 0..a.ncols() {
-                y[i] += a[(i, j)] * x[j];
-            }
+        let nrows = a.nrows();
+        let size = self.size.max(1);
+        let rank = self.rank.min(size - 1);
+
+        // Determine the row block owned by this rank (1D block distribution).
+        let base_rows = nrows / size;
+        let remainder = nrows % size;
+        let local_rows = base_rows + usize::from(rank < remainder);
+        let start = rank * base_rows + rank.min(remainder);
+        let end = start + local_rows;
+
+        // Compute local contributions only.
+        for yi in y.iter_mut() {
+            *yi = 0.0;
         }
+        for i in start..end {
+            let mut sum = 0.0;
+            for j in 0..a.ncols() {
+                sum += a[(i, j)] * x[j];
+            }
+            y[i] = sum;
+        }
+
+        // Sum contributions from all ranks so every rank observes the global result.
+        self.allreduce_sum_slice(y);
     }
 
     fn irecv_from<'a>(&'a self, buf: &'a mut [f64], src: i32) -> Self::Request<'a> {

--- a/src/solver/superlu_dist.rs
+++ b/src/solver/superlu_dist.rs
@@ -76,6 +76,9 @@ use faer::MatMut;
 use faer::prelude::*;
 use std::collections::HashMap;
 
+#[cfg(feature = "mpi")]
+use mpi::collective::CommunicatorCollectives;
+
 #[cfg(feature = "logging")]
 use crate::utils::profiling::StageGuard;
 
@@ -1933,13 +1936,92 @@ impl OrderingAlgorithms {
     pub fn mmd_ata_ordering_distributed(
         matrix: &CsrMatrix<f64>,
         comm: &UniverseComm,
-        _distribution: &BlockCyclicDistribution,
+        distribution: &BlockCyclicDistribution,
     ) -> Result<Vec<usize>, KError> {
         let n = matrix.nrows();
 
-        // Step 1: For now, replicate the local matrix pattern on all processes
-        // TODO: Implement proper global pattern assembly with MPI communication
-        let global_pattern = matrix.clone();
+        // Step 1: Assemble the global sparsity pattern across all ranks.
+        let global_pattern = if comm.size() <= 1 {
+            matrix.clone()
+        } else {
+            #[cfg(feature = "mpi")]
+            {
+                match comm {
+                    UniverseComm::Mpi(comm_impl) => {
+                        let global_rows = distribution.global_rows;
+                        let global_cols = distribution.global_cols;
+                        let mut adjacency = vec![Vec::<usize>::new(); global_rows];
+
+                        let rp = matrix.row_ptr();
+                        let ci = matrix.col_idx();
+                        let local_rows = matrix.nrows();
+                        let mut encoded: Vec<usize> = Vec::new();
+                        for local_row in 0..local_rows {
+                            let global_row = distribution.local_to_global_row(local_row);
+                            let start = rp[local_row];
+                            let end = rp[local_row + 1];
+                            encoded.push(global_row);
+                            encoded.push(end - start);
+                            encoded.extend_from_slice(&ci[start..end]);
+                        }
+
+                        let local_len = encoded.len() as i32;
+                        let mut lengths = vec![0i32; comm_impl.size];
+                        comm_impl
+                            .world
+                            .all_gather_into(&local_len, &mut lengths[..]);
+                        let lengths: Vec<usize> = lengths.iter().map(|&l| l as usize).collect();
+                        let max_len = lengths.iter().copied().max().unwrap_or(0);
+
+                        if max_len > 0 {
+                            let mut padded = encoded.clone();
+                            padded.resize(max_len, usize::MAX);
+                            let mut gathered = vec![0usize; max_len * comm_impl.size];
+                            comm_impl
+                                .world
+                                .all_gather_into(&padded[..], &mut gathered[..]);
+
+                            for (rank_idx, &len) in lengths.iter().enumerate() {
+                                let chunk = &gathered[rank_idx * max_len..rank_idx * max_len + len];
+                                let mut idx = 0;
+                                while idx < chunk.len() {
+                                    if idx + 1 >= chunk.len() {
+                                        break;
+                                    }
+                                    let global_row = chunk[idx];
+                                    idx += 1;
+                                    let nnz = chunk[idx];
+                                    idx += 1;
+                                    if idx + nnz > chunk.len() {
+                                        break;
+                                    }
+                                    adjacency[global_row].extend_from_slice(&chunk[idx..idx + nnz]);
+                                    idx += nnz;
+                                }
+                            }
+                        }
+
+                        let mut row_ptr = Vec::with_capacity(global_rows + 1);
+                        let mut col_idx = Vec::new();
+                        row_ptr.push(0);
+                        for cols in adjacency.iter_mut() {
+                            cols.sort_unstable();
+                            cols.dedup();
+                            col_idx.extend_from_slice(cols);
+                            row_ptr.push(col_idx.len());
+                        }
+                        let values = vec![0.0; col_idx.len()];
+                        CsrMatrix::from_csr(global_rows, global_cols, row_ptr, col_idx, values)
+                    }
+                    _ => matrix.clone(),
+                }
+            }
+            #[cfg(not(feature = "mpi"))]
+            {
+                let _ = distribution;
+                matrix.clone()
+            }
+        };
 
         // Step 2: Build A + A^T graph
         let graph = Self::build_ata_graph(&global_pattern);

--- a/src/utils/tuning.rs
+++ b/src/utils/tuning.rs
@@ -97,6 +97,25 @@ pub struct ParameterTuner {
 }
 
 impl ParameterTuner {
+    fn estimate_memory_usage(
+        matrix: &Mat<f64>,
+        rhs: &[f64],
+        solution: &[f64],
+        monitor: Option<&IterationMonitor>,
+    ) -> usize {
+        let elem = std::mem::size_of::<f64>();
+        let matrix_bytes = matrix.nrows() * matrix.ncols() * elem;
+        let vector_bytes = (rhs.len() + solution.len()) * elem;
+        let monitor_bytes = monitor
+            .map(|m| {
+                let stats = m.get_statistics();
+                // Each stored iteration roughly keeps an IterationData structure.
+                stats.total_iterations * std::mem::size_of::<crate::utils::monitor::IterationData>()
+            })
+            .unwrap_or(0);
+        matrix_bytes + vector_bytes + monitor_bytes
+    }
+
     /// Create a new parameter tuner with default ranges.
     pub fn new() -> Self {
         Self {
@@ -357,6 +376,7 @@ impl ParameterTuner {
         }));
 
         let solve_time = solve_start.elapsed();
+        let memory_usage_estimate = Self::estimate_memory_usage(matrix, rhs, &x, monitor.as_ref());
 
         // Check for timeout
         if solve_time > self.max_config_time {
@@ -368,7 +388,7 @@ impl ParameterTuner {
                 solve_time,
                 avg_convergence_rate: f64::INFINITY,
                 setup_time,
-                memory_usage_estimate: None,
+                memory_usage_estimate: Some(memory_usage_estimate),
                 convergence_reason: "Timeout".to_string(),
             });
         }
@@ -423,7 +443,7 @@ impl ParameterTuner {
                             solve_time,
                             avg_convergence_rate: avg_rate,
                             setup_time,
-                            memory_usage_estimate: None, // TODO: Implement memory tracking
+                            memory_usage_estimate: Some(memory_usage_estimate),
                             convergence_reason: reason,
                         })
                     }
@@ -435,7 +455,7 @@ impl ParameterTuner {
                         solve_time,
                         avg_convergence_rate: f64::INFINITY,
                         setup_time,
-                        memory_usage_estimate: None,
+                        memory_usage_estimate: Some(memory_usage_estimate),
                         convergence_reason: format!("Solve error: {e}"),
                     }),
                 }
@@ -448,7 +468,7 @@ impl ParameterTuner {
                 solve_time,
                 avg_convergence_rate: f64::INFINITY,
                 setup_time,
-                memory_usage_estimate: None,
+                memory_usage_estimate: Some(memory_usage_estimate),
                 convergence_reason: "Panic/crash".to_string(),
             }),
         }


### PR DESCRIPTION
## Summary
- partition MPI mat-vec operations across ranks and reduce the results collectively
- upgrade distributed kernel implementations to combine local products across communicators and expose communicator-aware AMG matvecs
- assemble the global SuperLU_DIST sparsity pattern with MPI all-gather and estimate solver memory usage in the tuner

## Testing
- `cargo test` *(fails: preconditioner::amg::tests::preserves_num_functions_across_levels)*

------
https://chatgpt.com/codex/tasks/task_e_68d07f62a0688329bf54addcfe5d29b0