### PR TITLE
Fix FSAI smoother application order

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -2968,8 +2968,8 @@ impl AMG {
         for i in 0..n {
             residual[i] = rhs[i] - work[i];
         }
-        g.spmv_scaled(1.0, residual, 0.0, tmp)?;
-        gt.spmv_scaled(1.0, tmp, 0.0, work)?;
+        gt.spmv_scaled(1.0, residual, 0.0, tmp)?;
+        g.spmv_scaled(1.0, tmp, 0.0, work)?;
         for i in 0..n {
             z[i] += tau * work[i];
         }


### PR DESCRIPTION
## Summary
- correct the order of applying the FSAI factors in the smoother so that G G^T is used

## Testing
- cargo fmt --check

------
https://chatgpt.com/codex/tasks/task_e_68d08ce80fb883298ca838b2b1c0e400