### PR TITLE
Disable PoU weights for restricted ASM

### DIFF
--- a/src/preconditioner/asm.rs
+++ b/src/preconditioner/asm.rs
@@ -1271,7 +1271,7 @@ impl Asm {
         let overlapped = expand_overlap(&adj, &owner_of, self.cfg.overlap);
         let weighting = match (self.cfg.combine, self.cfg.weight_partition_of_unity) {
             (AsmCombine::Additive, true) => Weighting::Uniform,
-            (AsmCombine::Restricted, true) => Weighting::Uniform,
+            (AsmCombine::Restricted, true) => Weighting::None,
             (AsmCombine::Optimized, true) => Weighting::SmoothLinear,
             _ => Weighting::None,
         };


### PR DESCRIPTION
## Summary
- prevent restricted ASM from computing partition-of-unity weights so its core injections remain unscaled

## Testing
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68d08daf7dbc83299eda335b833c0d6c