### PR TITLE
Restore Chebyshev beta recurrence in smoother

### DIFF
--- a/src/preconditioner/chebyshev.rs
+++ b/src/preconditioner/chebyshev.rs
@@ -283,10 +283,10 @@ pub fn chebyshev_smooth_csr(
     }
 
     for _ in 1..deg {
-        for i in 0..n {
-            work_q[i] = d_inv[i] * work_r[i];
-        }
         let beta = 0.25 * delta * delta * alpha;
+        for i in 0..n {
+            work_q[i] = d_inv[i] * work_r[i] + beta * work_q[i];
+        }
         alpha = 1.0 / (theta - beta);
         for i in 0..n {
             z[i] += alpha * work_q[i];


### PR DESCRIPTION
## Summary
- restore the Chebyshev beta recurrence so later smoothing steps combine the residual with the previous direction

## Testing
- `cargo test` *(fails: preconditioner::amg::tests::fsai_smoother::{fsai_damps_high_frequency_mode, pcg_with_fsai_converges}, preconditioner::amg::tests::nodal_nns::{nodal_numeric_refresh_updates_values, nodal_row_basis_is_locally_orthonormal, nodal_tentative_is_deterministic, restriction_respects_component_modes, scalar_and_nodal_singleton_match}, preconditioner::amg::tests::phase_selection_logic`)*

------
https://chatgpt.com/codex/tasks/task_e_68d08eb9dcc88329bfcff79563b1f8e1