### PR TITLE
Fix AMG SPD probe and stabilize tests

### DIFF
--- a/src/preconditioner/amg.rs
+++ b/src/preconditioner/amg.rs
@@ -4188,18 +4188,18 @@ impl AMG {
         }
         let mut x = vec![0.0; n];
         let mut y = vec![0.0; n];
-        let mut ax = vec![0.0; n];
         for t in 0..3 {
             for i in 0..n {
                 x[i] = ((i + 7919 * t) % 127) as f64 - 63.0;
             }
-            h.finest().a.spmv_scaled(1.0, &x, 0.0, &mut ax)?;
             y.fill(0.0);
-            self.apply(PcSide::Left, &ax, &mut y)?;
+            self.apply(PcSide::Left, &x, &mut y)?;
             let qf = x.iter().zip(&y).map(|(a, b)| a * b).sum::<f64>();
+            let x_norm2 = x.iter().map(|v| v * v).sum::<f64>();
+            let tol = 1e-12_f64.max(1e-10 * x_norm2.abs());
             debug_assert!(
-                qf.is_finite() && qf > 0.0,
-                "Preconditioned operator is not SPD"
+                qf.is_finite() && qf > -tol,
+                "Preconditioned operator is not SPD: qf={qf}, tol={tol}"
             );
         }
         Ok(())
@@ -6973,7 +6973,9 @@ mod tests {
 
     #[test]
     fn phase_selection_logic() {
-        let _guard = relax_lock().lock().unwrap();
+        let _guard = relax_lock()
+            .lock()
+            .unwrap_or_else(|poison| poison.into_inner());
         reset_relax_counts();
         let levels = vec![identity_level(), identity_level(), identity_level()];
         let policy = RelaxPolicy {

--- a/src/preconditioner/amg/tests/chebyshev.rs
+++ b/src/preconditioner/amg/tests/chebyshev.rs
@@ -119,7 +119,9 @@ fn chebyshev_recompute_toggle_and_safety() -> Result<(), KError> {
 
 #[test]
 fn pcg_with_chebyshev_smoother_converges() -> Result<(), KError> {
-    let _guard = super::relax_lock().lock().unwrap();
+    let _guard = super::relax_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     let n = 64;
     let a = poisson1d(n);
     let mut amg = AMGBuilder::new()

--- a/src/preconditioner/amg/tests/fsai_smoother.rs
+++ b/src/preconditioner/amg/tests/fsai_smoother.rs
@@ -150,7 +150,9 @@ fn fsai_handles_anisotropy() -> Result<(), KError> {
 
 #[test]
 fn pcg_with_fsai_converges() -> Result<(), KError> {
-    let _guard = super::relax_lock().lock().unwrap();
+    let _guard = super::relax_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
     let n = 64;
     let a = poisson1d(n);
     let mut amg = AMGBuilder::new()

--- a/src/preconditioner/amg/tests/nodal_nns.rs
+++ b/src/preconditioner/amg/tests/nodal_nns.rs
@@ -25,7 +25,9 @@ fn sample_block_matrix() -> CsrMatrix<f64> {
 
 #[test]
 fn nodal_row_basis_is_locally_orthonormal() {
-    let _guard = super::relax_lock().lock().unwrap();
+    let _guard = super::relax_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
 
     let a = sample_block_matrix();
 
@@ -99,7 +101,9 @@ fn nodal_row_basis_is_locally_orthonormal() {
 
 #[test]
 fn nodal_tentative_is_deterministic() {
-    let _guard = super::relax_lock().lock().unwrap();
+    let _guard = super::relax_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
 
     let a = sample_block_matrix();
 
@@ -139,7 +143,9 @@ fn nodal_tentative_is_deterministic() {
 
 #[test]
 fn restriction_respects_component_modes() {
-    let _guard = super::relax_lock().lock().unwrap();
+    let _guard = super::relax_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
 
     let a = sample_block_matrix();
     let mut amg = AMGBuilder::new()
@@ -191,7 +197,9 @@ fn restriction_respects_component_modes() {
 
 #[test]
 fn scalar_and_nodal_singleton_match() {
-    let _guard = super::relax_lock().lock().unwrap();
+    let _guard = super::relax_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
 
     let row_ptr = vec![0, 4, 8, 12, 16];
     let col_idx = vec![
@@ -257,7 +265,9 @@ fn scalar_and_nodal_singleton_match() {
 
 #[test]
 fn nodal_numeric_refresh_updates_values() {
-    let _guard = super::relax_lock().lock().unwrap();
+    let _guard = super::relax_lock()
+        .lock()
+        .unwrap_or_else(|poison| poison.into_inner());
 
     let a = sample_block_matrix();
     let mut amg = AMGBuilder::new()


### PR DESCRIPTION
## Summary
- update the AMG SPD debug probe to check the preconditioner directly with a small numerical tolerance
- make AMG-related tests tolerate poisoned mutexes so a prior failure does not cascade

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d0906c727883298530fc8364064ca5