### PR TITLE
Fix nodal compensation RHS handling

### DIFF
--- a/src/preconditioner/amg/row_filter.rs
+++ b/src/preconditioner/amg/row_filter.rs
@@ -273,10 +273,14 @@ pub fn compensate_nodal_diag(
         }
         let inv = invert_small_matrix(&gram)?;
         let mut diag_updates = vec![0.0; block_size];
+        let mut rhs_diag = vec![0.0; block_size];
+        for q in 0..block_size {
+            rhs_diag[q] = rhs[(q, q)];
+        }
         for q in 0..block_size {
             let mut sum = 0.0;
             for k in 0..block_size {
-                sum += rhs[(q, k)] * inv[k * block_size + q];
+                sum += inv[q * block_size + k] * rhs_diag[k];
             }
             diag_updates[q] = omega * sum;
         }


### PR DESCRIPTION
## Summary
- use only the diagonal entries of the RHS Gram correlation when computing nodal compensation updates
- solve the nodal correction by multiplying the diagonal RHS vector with the Gram matrix inverse

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d094c8162c8329a1bd9cfa967fc494