### PR TITLE
Refresh deflation matrix values during numeric update

### DIFF
--- a/src/preconditioner/deflation.rs
+++ b/src/preconditioner/deflation.rs
@@ -452,6 +452,17 @@ where
 
     fn update_numeric(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
         self.base.update_numeric(op)?;
+        let updated = csr_from_linop(op, 0.0)?;
+        let updated = updated.as_ref();
+        if self.a.row_ptr() != updated.row_ptr() || self.a.col_idx() != updated.col_idx() {
+            return Err(KError::InvalidInput(
+                "deflation numeric update requires unchanged sparsity; call update_symbolic instead"
+                    .into(),
+            ));
+        }
+        self.a
+            .values_mut()
+            .copy_from_slice(updated.values());
         csr_spmm_dense(&self.a, self.z.as_ref(), self.az.as_mut())?;
         self.refresh_e()
     }


### PR DESCRIPTION
## Summary
- refresh the stored CSR matrix values from the incoming operator during numeric updates
- guard against sparsity changes during numeric refresh before recomputing AZ and E

## Testing
- cargo test

------
https://chatgpt.com/codex/tasks/task_e_68d09602ff2c832996418bb0199ec8e0