### PR TITLE
Add async reductions and workspace primitives

### DIFF
--- a/src/context/ksp_context/workspace.rs
+++ b/src/context/ksp_context/workspace.rs
@@ -14,6 +14,8 @@ pub struct Workspace {
     pub sn: Vec<f64>,
     pub g: Vec<f64>,
     pub blk_scratch: Vec<f64>,
+    pub block_buf: Option<BlockVec>,
+    pub tsqr: Option<TsqrWorkspace>,
     // Shared communication arenas
     pub send_arena: crate::utils::buffer_pool::BufferPool<u8>,
     pub recv_arena: crate::utils::buffer_pool::BufferPool<u8>,
@@ -32,6 +34,74 @@ pub struct GmresSpec {
     pub block_s: usize,
 }
 
+/// Column-major storage reused for block Krylov vectors.
+#[derive(Debug, Clone)]
+pub struct BlockVec {
+    data: Vec<f64>,
+    n: usize,
+    p: usize,
+}
+
+impl BlockVec {
+    pub fn new(n: usize, p: usize) -> Self {
+        Self {
+            data: vec![0.0; n.saturating_mul(p)],
+            n,
+            p,
+        }
+    }
+
+    #[inline]
+    pub fn nrows(&self) -> usize {
+        self.n
+    }
+
+    #[inline]
+    pub fn ncols(&self) -> usize {
+        self.p
+    }
+
+    #[inline]
+    pub fn col(&self, j: usize) -> &[f64] {
+        let offset = j * self.n;
+        &self.data[offset..offset + self.n]
+    }
+
+    #[inline]
+    pub fn col_mut(&mut self, j: usize) -> &mut [f64] {
+        let offset = j * self.n;
+        &mut self.data[offset..offset + self.n]
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[f64] {
+        &self.data
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [f64] {
+        &mut self.data
+    }
+}
+
+/// Scratch buffers for TSQR factorizations.
+#[derive(Debug, Clone)]
+pub struct TsqrWorkspace {
+    pub taus: Vec<f64>,
+    pub rmat: Vec<f64>,
+    pub w_max: usize,
+}
+
+impl TsqrWorkspace {
+    pub fn with_width(w_max: usize) -> Self {
+        Self {
+            taus: vec![0.0; w_max],
+            rmat: vec![0.0; w_max.saturating_mul(w_max)],
+            w_max,
+        }
+    }
+}
+
 impl Workspace {
     pub fn new(n: usize) -> Self {
         let mut ws = Self::default();
@@ -45,6 +115,36 @@ impl Workspace {
     pub fn ensure_comm_bytes(&mut self, max_send: usize, max_recv: usize) {
         self.send_arena.ensure_len(max_send);
         self.recv_arena.ensure_len(max_recv);
+    }
+
+    /// Ensure the reusable block vector has capacity `n x p`.
+    pub fn ensure_block(&mut self, n: usize, p: usize) {
+        if p == 0 {
+            self.block_buf = None;
+            return;
+        }
+        let replace = match self.block_buf {
+            Some(ref buf) if buf.nrows() == n && buf.ncols() >= p => false,
+            _ => true,
+        };
+        if replace {
+            self.block_buf = Some(BlockVec::new(n, p));
+        }
+    }
+
+    /// Ensure the TSQR workspace supports panels up to width `w_max`.
+    pub fn ensure_tsqr(&mut self, w_max: usize) {
+        if w_max == 0 {
+            self.tsqr = None;
+            return;
+        }
+        let replace = match self.tsqr {
+            Some(ref tsqr) if tsqr.w_max >= w_max => false,
+            _ => true,
+        };
+        if replace {
+            self.tsqr = Some(TsqrWorkspace::with_width(w_max));
+        }
     }
 
     #[inline]

--- a/src/solver/common.rs
+++ b/src/solver/common.rs
@@ -1,5 +1,6 @@
 use crate::matrix::op::LinOp;
 use crate::parallel::{Comm, UniverseComm};
+use crate::utils::reduction::{AllreduceHandle, AsyncComm, ReductOptions};
 
 /// Recompute the true residual norm ||r||_2 where r = b - A x.
 ///
@@ -55,4 +56,78 @@ pub fn reported_residual_norm(
             comm.dot(r_true, r_true).sqrt()
         }
     }
+}
+
+/// Handle for a fused pair of asynchronous dot products.
+#[derive(Debug)]
+pub struct AsyncDot2 {
+    pub handle: AllreduceHandle<(f64, f64)>,
+    pub local: (f64, f64),
+}
+
+/// Launch a fused pair of dot products asynchronously.
+pub fn dot2_async<C: AsyncComm + ?Sized>(
+    comm: &C,
+    x1: &[f64],
+    y1: &[f64],
+    x2: &[f64],
+    y2: &[f64],
+    opt: &ReductOptions,
+) -> AsyncDot2 {
+    debug_assert_eq!(x1.len(), y1.len());
+    debug_assert_eq!(x2.len(), y2.len());
+    let mut a = 0.0;
+    let mut b = 0.0;
+    for ((&xi, &yi), (&xj, &yj)) in x1.iter().zip(y1).zip(x2.iter().zip(y2)) {
+        a += xi * yi;
+        b += xj * yj;
+    }
+    let (handle, local) = comm
+        .allreduce2_async(a, b, opt)
+        .expect("async reduction launch");
+    AsyncDot2 { handle, local }
+}
+
+/// Handle for a batch of asynchronous dot products.
+#[derive(Debug)]
+pub struct AsyncDotN {
+    pub handle: AllreduceHandle<Vec<f64>>,
+    pub local: Vec<f64>,
+}
+
+/// Launch multiple dot products asynchronously.
+pub fn dotn_async<C: AsyncComm + ?Sized>(
+    comm: &C,
+    pairs: &[(/*x*/ &[f64], /*y*/ &[f64])],
+    opt: &ReductOptions,
+) -> AsyncDotN {
+    let mut loc = vec![0.0; pairs.len()];
+    for (k, (x, y)) in pairs.iter().enumerate() {
+        debug_assert_eq!(x.len(), y.len());
+        let mut sum = 0.0;
+        for i in 0..x.len() {
+            sum += x[i] * y[i];
+        }
+        loc[k] = sum;
+    }
+    let (handle, local) = comm
+        .allreduce_n_async(loc.clone(), opt)
+        .expect("async reduction launch");
+    AsyncDotN { handle, local }
+}
+
+/// Launch an asynchronous squared-norm reduction.
+pub fn nrm2_async<C: AsyncComm + ?Sized>(
+    comm: &C,
+    x: &[f64],
+    opt: &ReductOptions,
+) -> (AllreduceHandle<(f64, f64)>, f64) {
+    let mut sumsq = 0.0;
+    for &xi in x {
+        sumsq += xi * xi;
+    }
+    let (handle, local) = comm
+        .allreduce2_async(sumsq, 0.0, opt)
+        .expect("async reduction launch");
+    (handle, local.0)
 }

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -10,6 +10,7 @@ pub mod monitor;
 pub mod partition;
 pub mod permutation;
 pub mod profiling;
+pub mod reduction;
 pub mod reordering;
 #[cfg(feature = "tuning")]
 pub mod tuning;

--- a/src/utils/reduction.rs
+++ b/src/utils/reduction.rs
@@ -1,0 +1,503 @@
+use std::sync::mpsc::Receiver;
+
+use crate::error::KError;
+use crate::parallel::Comm;
+#[cfg(feature = "mpi")]
+use mpi::raw::AsRaw;
+
+/// Reduction execution mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReductMode {
+    /// Fast, implementation-defined reduction path.
+    Fast,
+    /// Deterministic tree reductions (future extension).
+    Deterministic,
+}
+
+/// Options that control asynchronous reductions.
+#[derive(Debug, Clone)]
+pub struct ReductOptions {
+    pub mode: ReductMode,
+    pub max_inflight: usize,
+}
+
+impl Default for ReductOptions {
+    fn default() -> Self {
+        Self {
+            mode: ReductMode::Fast,
+            max_inflight: 4,
+        }
+    }
+}
+
+/// State machine for deterministic reductions.
+pub trait DeterministicState<T>: Send {
+    /// Progress the reduction state. Returns `true` when the result is ready.
+    fn progress(&mut self) -> bool;
+    /// Take the final result.
+    fn take(self: Box<Self>) -> T;
+}
+
+/// Handle for a nonblocking allreduce operation.
+pub enum AllreduceHandle<T> {
+    /// Result already available.
+    Ready(T),
+    /// MPI nonblocking reduction.
+    #[cfg(feature = "mpi")]
+    Mpi {
+        req: mpi::ffi::MPI_Request,
+        buf: Vec<f64>,
+        convert: fn(&[f64]) -> T,
+    },
+    /// Shared-memory emulation backed by a channel.
+    Rayon { rx: Receiver<T> },
+    /// Deterministic engine state machine.
+    Deterministic {
+        state: Box<dyn DeterministicState<T>>,
+    },
+}
+
+impl<T> AllreduceHandle<T> {
+    fn new_ready(value: T) -> Self {
+        AllreduceHandle::Ready(value)
+    }
+}
+
+impl<T: std::fmt::Debug> std::fmt::Debug for AllreduceHandle<T> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AllreduceHandle::Ready(val) => f.debug_tuple("Ready").field(val).finish(),
+            #[cfg(feature = "mpi")]
+            AllreduceHandle::Mpi { req, buf, .. } => f
+                .debug_struct("Mpi")
+                .field("request", req)
+                .field("buf", buf)
+                .finish(),
+            AllreduceHandle::Rayon { .. } => f.debug_struct("Rayon").finish(),
+            AllreduceHandle::Deterministic { .. } => f.debug_struct("Deterministic").finish(),
+        }
+    }
+}
+
+/// Trait implemented by communicators that support the asynchronous reductions used by solvers.
+pub trait AllreduceOps {
+    /// Launch a nonblocking reduction of two scalars and return the handle and local contributions.
+    fn allreduce2_async(
+        &self,
+        a: f64,
+        b: f64,
+        opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<(f64, f64)>, (f64, f64)), KError>;
+
+    /// Launch a nonblocking reduction of an arbitrary-length vector of scalars.
+    fn allreduce_n_async(
+        &self,
+        data: Vec<f64>,
+        opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<Vec<f64>>, Vec<f64>), KError>;
+
+    /// Poll a pair reduction and return the result if ready.
+    fn test_pair(h: &mut AllreduceHandle<(f64, f64)>) -> Option<(f64, f64)>;
+
+    /// Poll a vector reduction and return the result if ready.
+    fn test_vec(h: &mut AllreduceHandle<Vec<f64>>) -> Option<Vec<f64>>;
+
+    /// Block until the pair reduction completes.
+    fn wait_pair(h: AllreduceHandle<(f64, f64)>) -> (f64, f64);
+
+    /// Block until the vector reduction completes.
+    fn wait_vec(h: AllreduceHandle<Vec<f64>>) -> Vec<f64>;
+}
+
+/// Trait alias for communicators that support asynchronous reductions.
+pub trait AsyncComm: Comm + AllreduceOps {}
+
+impl<T> AsyncComm for T where T: Comm + AllreduceOps + ?Sized {}
+
+/// Helper used by polling implementations to convert a completed handle into the ready state.
+fn finalize_handle_pair(
+    handle: &mut AllreduceHandle<(f64, f64)>,
+    result: (f64, f64),
+) -> (f64, f64) {
+    *handle = AllreduceHandle::Ready(result);
+    if let AllreduceHandle::Ready(val) = handle {
+        *val
+    } else {
+        unreachable!()
+    }
+}
+
+fn finalize_handle_vec(handle: &mut AllreduceHandle<Vec<f64>>, result: Vec<f64>) -> Vec<f64> {
+    *handle = AllreduceHandle::Ready(result);
+    if let AllreduceHandle::Ready(val) = handle {
+        val.clone()
+    } else {
+        unreachable!()
+    }
+}
+
+/// Convert a raw buffer into a pair.
+fn convert_pair(buf: &[f64]) -> (f64, f64) {
+    debug_assert_eq!(buf.len(), 2);
+    (buf[0], buf[1])
+}
+
+#[cfg(feature = "mpi")]
+fn mpi_test_request(req: &mut mpi::ffi::MPI_Request) -> bool {
+    let mut flag = 0;
+    let rc = unsafe { mpi::ffi::MPI_Test(req, &mut flag, mpi::ffi::RSMPI_STATUS_IGNORE) };
+    debug_assert_eq!(rc, 0);
+    flag != 0
+}
+
+#[cfg(feature = "mpi")]
+fn mpi_wait_request(mut req: mpi::ffi::MPI_Request) {
+    let rc = unsafe { mpi::ffi::MPI_Wait(&mut req, mpi::ffi::RSMPI_STATUS_IGNORE) };
+    debug_assert_eq!(rc, 0);
+}
+
+impl AllreduceOps for crate::parallel::NoComm {
+    fn allreduce2_async(
+        &self,
+        a: f64,
+        b: f64,
+        _opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<(f64, f64)>, (f64, f64)), KError> {
+        let sum = (a, b);
+        Ok((AllreduceHandle::new_ready(sum), sum))
+    }
+
+    fn allreduce_n_async(
+        &self,
+        data: Vec<f64>,
+        _opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<Vec<f64>>, Vec<f64>), KError> {
+        Ok((AllreduceHandle::new_ready(data.clone()), data))
+    }
+
+    fn test_pair(h: &mut AllreduceHandle<(f64, f64)>) -> Option<(f64, f64)> {
+        match h {
+            AllreduceHandle::Ready(val) => Some(*val),
+            _ => None,
+        }
+    }
+
+    fn test_vec(h: &mut AllreduceHandle<Vec<f64>>) -> Option<Vec<f64>> {
+        match h {
+            AllreduceHandle::Ready(val) => Some(val.clone()),
+            _ => None,
+        }
+    }
+
+    fn wait_pair(h: AllreduceHandle<(f64, f64)>) -> (f64, f64) {
+        match h {
+            AllreduceHandle::Ready(val) => val,
+            _ => unreachable!(),
+        }
+    }
+
+    fn wait_vec(h: AllreduceHandle<Vec<f64>>) -> Vec<f64> {
+        match h {
+            AllreduceHandle::Ready(val) => val,
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[cfg(feature = "rayon")]
+impl AllreduceOps for crate::parallel::rayon_comm::RayonComm {
+    fn allreduce2_async(
+        &self,
+        a: f64,
+        b: f64,
+        _opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<(f64, f64)>, (f64, f64)), KError> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let local = (a, b);
+        rayon::spawn_fifo(move || {
+            let _ = tx.send(local);
+        });
+        Ok((AllreduceHandle::Rayon { rx }, local))
+    }
+
+    fn allreduce_n_async(
+        &self,
+        data: Vec<f64>,
+        _opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<Vec<f64>>, Vec<f64>), KError> {
+        let (tx, rx) = std::sync::mpsc::channel();
+        let local = data.clone();
+        rayon::spawn_fifo(move || {
+            let _ = tx.send(data);
+        });
+        Ok((AllreduceHandle::Rayon { rx }, local))
+    }
+
+    fn test_pair(h: &mut AllreduceHandle<(f64, f64)>) -> Option<(f64, f64)> {
+        match h {
+            AllreduceHandle::Ready(val) => Some(*val),
+            AllreduceHandle::Rayon { rx } => rx.try_recv().ok().map(|v| finalize_handle_pair(h, v)),
+            _ => None,
+        }
+    }
+
+    fn test_vec(h: &mut AllreduceHandle<Vec<f64>>) -> Option<Vec<f64>> {
+        match h {
+            AllreduceHandle::Ready(val) => Some(val.clone()),
+            AllreduceHandle::Rayon { rx } => rx.try_recv().ok().map(|v| finalize_handle_vec(h, v)),
+            _ => None,
+        }
+    }
+
+    fn wait_pair(h: AllreduceHandle<(f64, f64)>) -> (f64, f64) {
+        match h {
+            AllreduceHandle::Ready(val) => val,
+            AllreduceHandle::Rayon { rx } => rx.recv().unwrap(),
+            _ => unreachable!(),
+        }
+    }
+
+    fn wait_vec(h: AllreduceHandle<Vec<f64>>) -> Vec<f64> {
+        match h {
+            AllreduceHandle::Ready(val) => val,
+            AllreduceHandle::Rayon { rx } => rx.recv().unwrap(),
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[cfg(feature = "mpi")]
+impl AllreduceOps for crate::parallel::mpi_comm::MpiComm {
+    fn allreduce2_async(
+        &self,
+        a: f64,
+        b: f64,
+        opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<(f64, f64)>, (f64, f64)), KError> {
+        if matches!(opt.mode, ReductMode::Deterministic) {
+            return Err(KError::Unsupported("deterministic reductions"));
+        }
+        let mut buf = vec![a, b];
+        let mut req: mpi::ffi::MPI_Request = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            mpi::ffi::MPI_Iallreduce(
+                buf.as_mut_ptr() as *mut std::ffi::c_void,
+                buf.as_mut_ptr() as *mut std::ffi::c_void,
+                2,
+                mpi::ffi::RSMPI_DOUBLE,
+                mpi::ffi::RSMPI_SUM,
+                self.world.as_raw(),
+                &mut req,
+            )
+        };
+        if rc != 0 {
+            return Err(KError::SolveError(format!("MPI_Iallreduce failed: {}", rc)));
+        }
+        Ok((
+            AllreduceHandle::Mpi {
+                req,
+                buf,
+                convert: convert_pair,
+            },
+            (a, b),
+        ))
+    }
+
+    fn allreduce_n_async(
+        &self,
+        data: Vec<f64>,
+        opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<Vec<f64>>, Vec<f64>), KError> {
+        if matches!(opt.mode, ReductMode::Deterministic) {
+            return Err(KError::Unsupported("deterministic reductions"));
+        }
+        let mut buf = data.clone();
+        let count = buf.len();
+        let mut req: mpi::ffi::MPI_Request = unsafe { std::mem::zeroed() };
+        let rc = unsafe {
+            mpi::ffi::MPI_Iallreduce(
+                buf.as_mut_ptr() as *mut std::ffi::c_void,
+                buf.as_mut_ptr() as *mut std::ffi::c_void,
+                count as i32,
+                mpi::ffi::RSMPI_DOUBLE,
+                mpi::ffi::RSMPI_SUM,
+                self.world.as_raw(),
+                &mut req,
+            )
+        };
+        if rc != 0 {
+            return Err(KError::SolveError(format!("MPI_Iallreduce failed: {}", rc)));
+        }
+        Ok((
+            AllreduceHandle::Mpi {
+                req,
+                buf,
+                convert: |slice| slice.to_vec(),
+            },
+            data,
+        ))
+    }
+
+    fn test_pair(h: &mut AllreduceHandle<(f64, f64)>) -> Option<(f64, f64)> {
+        match h {
+            AllreduceHandle::Ready(val) => Some(*val),
+            AllreduceHandle::Mpi { req, buf, convert } => {
+                if mpi_test_request(req) {
+                    let result = convert(buf);
+                    Some(finalize_handle_pair(h, result))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn test_vec(h: &mut AllreduceHandle<Vec<f64>>) -> Option<Vec<f64>> {
+        match h {
+            AllreduceHandle::Ready(val) => Some(val.clone()),
+            AllreduceHandle::Mpi { req, buf, convert } => {
+                if mpi_test_request(req) {
+                    let result = convert(buf);
+                    Some(finalize_handle_vec(h, result))
+                } else {
+                    None
+                }
+            }
+            _ => None,
+        }
+    }
+
+    fn wait_pair(h: AllreduceHandle<(f64, f64)>) -> (f64, f64) {
+        match h {
+            AllreduceHandle::Ready(val) => val,
+            AllreduceHandle::Mpi { req, buf, convert } => {
+                mpi_wait_request(req);
+                convert(&buf)
+            }
+            _ => unreachable!(),
+        }
+    }
+
+    fn wait_vec(h: AllreduceHandle<Vec<f64>>) -> Vec<f64> {
+        match h {
+            AllreduceHandle::Ready(val) => val,
+            AllreduceHandle::Mpi { req, buf, convert } => {
+                mpi_wait_request(req);
+                convert(&buf)
+            }
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl AllreduceOps for crate::parallel::UniverseComm {
+    fn allreduce2_async(
+        &self,
+        a: f64,
+        b: f64,
+        opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<(f64, f64)>, (f64, f64)), KError> {
+        match self {
+            crate::parallel::UniverseComm::NoComm(comm) => comm.allreduce2_async(a, b, opt),
+            #[cfg(feature = "mpi")]
+            crate::parallel::UniverseComm::Mpi(comm) => comm.allreduce2_async(a, b, opt),
+            #[cfg(feature = "rayon")]
+            crate::parallel::UniverseComm::Rayon(comm) => comm.allreduce2_async(a, b, opt),
+            #[cfg(not(any(feature = "mpi", feature = "rayon")))]
+            crate::parallel::UniverseComm::Serial => {
+                crate::parallel::NoComm.allreduce2_async(a, b, opt)
+            }
+        }
+    }
+
+    fn allreduce_n_async(
+        &self,
+        data: Vec<f64>,
+        opt: &ReductOptions,
+    ) -> Result<(AllreduceHandle<Vec<f64>>, Vec<f64>), KError> {
+        match self {
+            crate::parallel::UniverseComm::NoComm(comm) => comm.allreduce_n_async(data, opt),
+            #[cfg(feature = "mpi")]
+            crate::parallel::UniverseComm::Mpi(comm) => comm.allreduce_n_async(data, opt),
+            #[cfg(feature = "rayon")]
+            crate::parallel::UniverseComm::Rayon(comm) => comm.allreduce_n_async(data, opt),
+            #[cfg(not(any(feature = "mpi", feature = "rayon")))]
+            crate::parallel::UniverseComm::Serial => {
+                crate::parallel::NoComm.allreduce_n_async(data, opt)
+            }
+        }
+    }
+
+    fn test_pair(h: &mut AllreduceHandle<(f64, f64)>) -> Option<(f64, f64)> {
+        match h {
+            AllreduceHandle::Ready(val) => Some(*val),
+            #[cfg(feature = "mpi")]
+            AllreduceHandle::Mpi { .. } => {
+                <crate::parallel::mpi_comm::MpiComm as AllreduceOps>::test_pair(h)
+            }
+            #[cfg(feature = "rayon")]
+            AllreduceHandle::Rayon { .. } => {
+                <crate::parallel::rayon_comm::RayonComm as AllreduceOps>::test_pair(h)
+            }
+            #[cfg(not(feature = "rayon"))]
+            AllreduceHandle::Rayon { .. } => None,
+            AllreduceHandle::Deterministic { .. } => None,
+        }
+    }
+
+    fn test_vec(h: &mut AllreduceHandle<Vec<f64>>) -> Option<Vec<f64>> {
+        match h {
+            AllreduceHandle::Ready(val) => Some(val.clone()),
+            #[cfg(feature = "mpi")]
+            AllreduceHandle::Mpi { .. } => {
+                <crate::parallel::mpi_comm::MpiComm as AllreduceOps>::test_vec(h)
+            }
+            #[cfg(feature = "rayon")]
+            AllreduceHandle::Rayon { .. } => {
+                <crate::parallel::rayon_comm::RayonComm as AllreduceOps>::test_vec(h)
+            }
+            #[cfg(not(feature = "rayon"))]
+            AllreduceHandle::Rayon { .. } => None,
+            AllreduceHandle::Deterministic { .. } => None,
+        }
+    }
+
+    fn wait_pair(h: AllreduceHandle<(f64, f64)>) -> (f64, f64) {
+        match h {
+            AllreduceHandle::Ready(val) => val,
+            #[cfg(feature = "mpi")]
+            AllreduceHandle::Mpi { .. } => {
+                <crate::parallel::mpi_comm::MpiComm as AllreduceOps>::wait_pair(h)
+            }
+            #[cfg(feature = "rayon")]
+            AllreduceHandle::Rayon { .. } => {
+                <crate::parallel::rayon_comm::RayonComm as AllreduceOps>::wait_pair(h)
+            }
+            #[cfg(not(feature = "rayon"))]
+            AllreduceHandle::Rayon { .. } => unreachable!("rayon backend disabled"),
+            AllreduceHandle::Deterministic { .. } => {
+                panic!("deterministic reductions not implemented")
+            }
+        }
+    }
+
+    fn wait_vec(h: AllreduceHandle<Vec<f64>>) -> Vec<f64> {
+        match h {
+            AllreduceHandle::Ready(val) => val,
+            #[cfg(feature = "mpi")]
+            AllreduceHandle::Mpi { .. } => {
+                <crate::parallel::mpi_comm::MpiComm as AllreduceOps>::wait_vec(h)
+            }
+            #[cfg(feature = "rayon")]
+            AllreduceHandle::Rayon { .. } => {
+                <crate::parallel::rayon_comm::RayonComm as AllreduceOps>::wait_vec(h)
+            }
+            #[cfg(not(feature = "rayon"))]
+            AllreduceHandle::Rayon { .. } => unreachable!("rayon backend disabled"),
+            AllreduceHandle::Deterministic { .. } => {
+                panic!("deterministic reductions not implemented")
+            }
+        }
+    }
+}

--- a/tests/reduction_async.rs
+++ b/tests/reduction_async.rs
@@ -1,0 +1,68 @@
+use kryst::parallel::{Comm, NoComm};
+use kryst::utils::reduction::{AllreduceOps, ReductOptions};
+
+#[test]
+fn nocomm_allreduce_pair_ready_immediately() {
+    let comm = NoComm;
+    let opts = ReductOptions::default();
+    let (mut handle, local) = comm.allreduce2_async(3.0, 4.0, &opts).unwrap();
+    assert_eq!(local, (3.0, 4.0));
+    assert_eq!(NoComm::test_pair(&mut handle), Some((3.0, 4.0)));
+    assert_eq!(NoComm::wait_pair(handle), (3.0, 4.0));
+}
+
+#[test]
+fn nocomm_allreduce_vec_ready_immediately() {
+    let comm = NoComm;
+    let opts = ReductOptions::default();
+    let (mut handle, local) = comm.allreduce_n_async(vec![1.0, 2.0, 3.0], &opts).unwrap();
+    assert_eq!(local, vec![1.0, 2.0, 3.0]);
+    assert_eq!(NoComm::test_vec(&mut handle), Some(vec![1.0, 2.0, 3.0]));
+    assert_eq!(NoComm::wait_vec(handle), vec![1.0, 2.0, 3.0]);
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn rayon_allreduce_pair_async_completes() {
+    let comm = kryst::parallel::rayon_comm::RayonComm::new();
+    let opts = ReductOptions::default();
+    let (mut handle, local) = comm.allreduce2_async(5.0, 7.0, &opts).unwrap();
+    assert_eq!(local, (5.0, 7.0));
+    if let Some(res) = kryst::parallel::rayon_comm::RayonComm::test_pair(&mut handle) {
+        assert_eq!(res, (5.0, 7.0));
+    } else {
+        let waited = kryst::parallel::rayon_comm::RayonComm::wait_pair(handle);
+        assert_eq!(waited, (5.0, 7.0));
+    }
+}
+
+#[cfg(feature = "rayon")]
+#[test]
+fn rayon_allreduce_vec_async_completes() {
+    let comm = kryst::parallel::rayon_comm::RayonComm::new();
+    let opts = ReductOptions::default();
+    let (mut handle, local) = comm
+        .allreduce_n_async(vec![1.0, 2.0, 3.0, 4.0], &opts)
+        .unwrap();
+    assert_eq!(local, vec![1.0, 2.0, 3.0, 4.0]);
+    if let Some(res) = kryst::parallel::rayon_comm::RayonComm::test_vec(&mut handle) {
+        assert_eq!(res, vec![1.0, 2.0, 3.0, 4.0]);
+    } else {
+        let waited = kryst::parallel::rayon_comm::RayonComm::wait_vec(handle);
+        assert_eq!(waited, vec![1.0, 2.0, 3.0, 4.0]);
+    }
+}
+
+#[cfg(feature = "mpi")]
+#[test]
+fn mpi_allreduce_pair_matches_sum() {
+    use kryst::parallel::mpi_comm::MpiComm;
+    let comm = MpiComm::new();
+    let opts = ReductOptions::default();
+    let local = (comm.rank() as f64 + 1.0, comm.rank() as f64 + 2.0);
+    let (handle, _) = comm.allreduce2_async(local.0, local.1, &opts).unwrap();
+    let global = kryst::parallel::mpi_comm::MpiComm::wait_pair(handle);
+    let size = comm.size() as f64;
+    assert_eq!(global.0, (size * (size + 1.0)) / 2.0);
+    assert_eq!(global.1, (size * (size + 3.0)) / 2.0);
+}

--- a/tests/solver_async_dot.rs
+++ b/tests/solver_async_dot.rs
@@ -1,0 +1,60 @@
+use kryst::parallel::NoComm;
+use kryst::solver::common::{dot2_async, dotn_async, nrm2_async};
+use kryst::utils::reduction::{AllreduceOps, ReductOptions};
+
+#[test]
+fn async_dot2_matches_blocking() {
+    let comm = NoComm;
+    let x1 = [1.0, 2.0, 3.0];
+    let y1 = [4.0, 5.0, 6.0];
+    let x2 = [0.5, 1.5, -2.5];
+    let y2 = [2.0, -3.0, 4.0];
+    let opts = ReductOptions::default();
+    let mut async_pair = dot2_async(&comm, &x1, &y1, &x2, &y2, &opts);
+    assert_eq!(
+        async_pair.local.0,
+        x1.iter().zip(&y1).map(|(a, b)| a * b).sum::<f64>()
+    );
+    assert_eq!(
+        async_pair.local.1,
+        x2.iter().zip(&y2).map(|(a, b)| a * b).sum::<f64>()
+    );
+    assert_eq!(
+        NoComm::test_pair(&mut async_pair.handle),
+        Some(async_pair.local)
+    );
+    let global = <NoComm as AllreduceOps>::wait_pair(async_pair.handle);
+    assert_eq!(global, async_pair.local);
+}
+
+#[test]
+fn async_dotn_matches_blocking() {
+    let comm = NoComm;
+    let v1 = [1.0, -1.0, 2.0];
+    let w1 = [3.0, 0.5, -4.0];
+    let v2 = [0.0, 2.0, 1.0];
+    let w2 = [1.0, 1.0, 1.0];
+    let opts = ReductOptions::default();
+    let mut async_vec = dotn_async(&comm, &[(&v1[..], &w1[..]), (&v2[..], &w2[..])], &opts);
+    let expected0 = v1.iter().zip(&w1).map(|(a, b)| a * b).sum::<f64>();
+    let expected1 = v2.iter().zip(&w2).map(|(a, b)| a * b).sum::<f64>();
+    assert_eq!(async_vec.local, vec![expected0, expected1]);
+    assert_eq!(
+        NoComm::test_vec(&mut async_vec.handle),
+        Some(async_vec.local.clone())
+    );
+    let global = <NoComm as AllreduceOps>::wait_vec(async_vec.handle);
+    assert_eq!(global, vec![expected0, expected1]);
+}
+
+#[test]
+fn async_norm_matches_blocking() {
+    let comm = NoComm;
+    let x = [1.0, 2.0, 2.0];
+    let opts = ReductOptions::default();
+    let (handle, local) = nrm2_async(&comm, &x, &opts);
+    let expected = x.iter().map(|v| v * v).sum::<f64>();
+    assert_eq!(local, expected);
+    let sumsq = <NoComm as AllreduceOps>::wait_pair(handle);
+    assert_eq!(sumsq, (expected, 0.0));
+}

--- a/tests/workspace_tests.rs
+++ b/tests/workspace_tests.rs
@@ -60,3 +60,46 @@ fn gmres_workspace_allocation_stable_and_sized() {
     assert_eq!(ws.cs.len(), restart);
     assert_eq!(ws.sn.len(), restart);
 }
+
+#[test]
+fn ensure_block_reuses_buffer() {
+    let mut ws = Workspace::default();
+    ws.ensure_block(6, 4);
+    let buf = ws.block_buf.as_ref().expect("block vec allocated");
+    assert_eq!(buf.nrows(), 6);
+    assert!(buf.ncols() >= 4);
+    let base_ptr = buf.as_slice().as_ptr();
+
+    // Request fewer columns: should reuse existing allocation.
+    ws.ensure_block(6, 2);
+    let buf_small = ws.block_buf.as_ref().unwrap();
+    assert_eq!(buf_small.as_slice().as_ptr(), base_ptr);
+
+    // Request more columns: should grow allocation.
+    ws.ensure_block(6, 8);
+    let buf_large = ws.block_buf.as_ref().unwrap();
+    assert!(buf_large.ncols() >= 8);
+    assert!(buf_large.as_slice().as_ptr() != base_ptr);
+}
+
+#[test]
+fn ensure_tsqr_grows_monotonically() {
+    let mut ws = Workspace::default();
+    ws.ensure_tsqr(3);
+    let tsqr = ws.tsqr.as_ref().expect("tsqr allocated");
+    assert_eq!(tsqr.w_max, 3);
+    assert_eq!(tsqr.taus.len(), 3);
+    assert_eq!(tsqr.rmat.len(), 9);
+
+    // Smaller request should keep existing allocation.
+    ws.ensure_tsqr(2);
+    let tsqr_small = ws.tsqr.as_ref().unwrap();
+    assert_eq!(tsqr_small.w_max, 3);
+
+    // Larger request should grow buffers.
+    ws.ensure_tsqr(5);
+    let tsqr_large = ws.tsqr.as_ref().unwrap();
+    assert_eq!(tsqr_large.w_max, 5);
+    assert_eq!(tsqr_large.taus.len(), 5);
+    assert_eq!(tsqr_large.rmat.len(), 25);
+}


### PR DESCRIPTION
## Summary
- introduce utils::reduction module providing asynchronous reduction handles, options, and backend implementations
- expose solver-side async dot and norm helpers using the new reduction trait alias
- extend KSP workspace with reusable block vector and TSQR scratch plus tests for growth semantics
- add regression tests covering asynchronous reduction behaviour and solver wrappers

## Testing
- cargo test solver_async_dot --quiet
- cargo test reduction_async --quiet
- cargo test ensure_block_reuses_buffer --quiet
- cargo test ensure_tsqr_grows_monotonically --quiet

------
https://chatgpt.com/codex/tasks/task_e_68d0fe1363e08329a58b9607fe4ce8b5