### PR TITLE
Fix final residual check in pipelined PCG

### DIFF
--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -669,7 +669,41 @@ impl PcgSolver {
 
         if let Some(handle) = pending_rho.take() {
             counters.num_global_reductions += 1;
-            let _ = <C as AllreduceOps>::wait_pair(handle);
+            rho_curr = <C as AllreduceOps>::wait_pair(handle).0;
+            if !rho_curr.is_finite() || rho_curr < 0.0 {
+                return Err(KError::IndefinitePreconditioner);
+            }
+
+            reported_residual = match self.norm_type {
+                CgNormType::Preconditioned => rho_curr.sqrt(),
+                CgNormType::Unpreconditioned | CgNormType::None => {
+                    let (h_nr, _) = crate::solver::common::nrm2_async(comm, r, &opt);
+                    counters.num_global_reductions += 1;
+                    <C as AllreduceOps>::wait_pair(h_nr).0.sqrt()
+                }
+                CgNormType::Natural => {
+                    let (h_z, _) = crate::solver::common::nrm2_async(comm, z, &opt);
+                    counters.num_global_reductions += 1;
+                    <C as AllreduceOps>::wait_pair(h_z).0.sqrt()
+                }
+            };
+
+            if let Some(ms) = monitors {
+                for m in ms {
+                    m(iterations, reported_residual);
+                }
+            }
+            if let Some(m) = &self.true_residual_monitor {
+                m(iterations, self.nrm2(r, comm));
+            }
+
+            let (reason, mut stats) = self.conv.check(reported_residual, rnorm0, iterations);
+            if !matches!(reason, ConvergedReason::Continued) {
+                stats.final_residual = self.nrm2(r, comm);
+                counters.residual_replacements = residual_replacements;
+                stats.counters = counters;
+                return Ok(stats);
+            }
         }
 
         counters.residual_replacements = residual_replacements;


### PR DESCRIPTION
## Summary
- ensure the pipelined PCG solver waits on the final reduction result before finishing
- reuse the standard convergence/monitor path so the last iteration can report convergence and counters

## Testing
- cargo test *(fails: reduction_async MPI tests cannot run without MPI support)*

------
https://chatgpt.com/codex/tasks/task_e_68d1989025d883298d7188087c29dc77