### PR TITLE
Prepare s-step GMRES helpers

### DIFF
--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -41,8 +41,12 @@ pub struct KspOptions {
     pub gmres_reorth_tol: Option<f64>,
     /// If true, treat near-zero residual as a happy breakdown and stop
     pub gmres_happy_breakdown: Option<bool>,
-    /// GMRES algorithm variant: "classical" | "pipelined"
+    /// GMRES algorithm variant: "classical" | "pipelined" | "sstep"
     pub gmres_variant: Option<String>,
+    /// Block size for s-step GMRES panels
+    pub gmres_sstep: Option<usize>,
+    /// Conditioning guard for s-step QR (default 1e8)
+    pub gmres_sstep_max_cond: Option<f64>,
 
     /// Override restart for FGMRES; falls back to `restart` if unset
     pub fgmres_restart: Option<usize>,
@@ -296,6 +300,13 @@ impl Sink for KspOptions {
                 set_opt!(&mut self.gmres_reorth_tol, parse_as::<f64>(v, spec)?)
             }
             "ksp_gmres_variant" => set_opt!(&mut self.gmres_variant, v.to_string()),
+            "ksp_gmres_sstep" => set_opt!(
+                &mut self.gmres_sstep,
+                ensure_ge_1("ksp_gmres_sstep", parse_as::<usize>(v, spec)?)?
+            ),
+            "ksp_gmres_sstep_max_cond" => {
+                set_opt!(&mut self.gmres_sstep_max_cond, parse_as::<f64>(v, spec)?)
+            }
             "ksp_reduction" => set_opt!(&mut self.reduction, v.to_string()),
             "ksp_fgmres_restart" => set_opt!(
                 &mut self.fgmres_restart,

--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -52,7 +52,7 @@ use crate::utils::reduction::{ReductMode, ReductOptions};
 use std::str::FromStr;
 use std::sync::Arc;
 mod workspace;
-pub use workspace::{GmresSpec, ReorthPolicy, Workspace};
+pub use workspace::{BlockVec, GmresSStepWorkspace, GmresSpec, ReorthPolicy, Workspace};
 
 /// Supported solver types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -122,6 +122,13 @@ pub struct KspContext {
     pending_pcg: PendingPcg,
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum PendingGmresVariant {
+    Classical,
+    Pipelined,
+    SStep,
+}
+
 #[derive(Clone, Debug, Default)]
 struct PendingGmres {
     restart: Option<usize>,
@@ -129,7 +136,9 @@ struct PendingGmres {
     reorth: Option<ReorthPolicy>,
     reorth_tol: Option<f64>,
     happy_breakdown: Option<bool>,
-    variant: Option<crate::solver::gmres::GmresVariant>,
+    variant: Option<PendingGmresVariant>,
+    sstep: Option<usize>,
+    sstep_max_cond: Option<f64>,
 }
 
 #[derive(Clone, Debug, Default)]
@@ -439,17 +448,23 @@ impl KspContext {
                 self.pending_gmres.happy_breakdown = Some(flag);
             }
             if let Some(ref variant) = opts.gmres_variant {
-                let v = match variant.as_str() {
-                    "classical" => crate::solver::gmres::GmresVariant::Classical,
-                    "pipelined" => crate::solver::gmres::GmresVariant::Pipelined,
+                let pv = match variant.as_str() {
+                    "classical" => PendingGmresVariant::Classical,
+                    "pipelined" => PendingGmresVariant::Pipelined,
+                    "sstep" => PendingGmresVariant::SStep,
                     other => {
                         return Err(KError::SolveError(format!(
-                            "Unrecognized ksp_gmres_variant: {other} (expected 'classical'|'pipelined')"
+                            "Unrecognized ksp_gmres_variant: {other} (expected 'classical'|'pipelined'|'sstep')"
                         )));
                     }
                 };
-                s.set_variant(v);
-                self.pending_gmres.variant = Some(v);
+                self.pending_gmres.variant = Some(pv);
+            }
+            if let Some(sstep) = opts.gmres_sstep {
+                self.pending_gmres.sstep = Some(sstep);
+            }
+            if let Some(cond) = opts.gmres_sstep_max_cond {
+                self.pending_gmres.sstep_max_cond = Some(cond);
             }
         } else {
             if let Some(r) = opts.effective_restart_for(KspType::GMRES) {
@@ -484,15 +499,31 @@ impl KspContext {
             }
             if let Some(ref variant) = opts.gmres_variant {
                 self.pending_gmres.variant = Some(match variant.as_str() {
-                    "classical" => crate::solver::gmres::GmresVariant::Classical,
-                    "pipelined" => crate::solver::gmres::GmresVariant::Pipelined,
+                    "classical" => PendingGmresVariant::Classical,
+                    "pipelined" => PendingGmresVariant::Pipelined,
+                    "sstep" => PendingGmresVariant::SStep,
                     other => {
                         return Err(KError::SolveError(format!(
-                            "Unrecognized ksp_gmres_variant: {other} (expected 'classical'|'pipelined')"
+                            "Unrecognized ksp_gmres_variant: {other} (expected 'classical'|'pipelined'|'sstep')"
                         )));
                     }
                 });
             }
+            if let Some(sstep) = opts.gmres_sstep {
+                self.pending_gmres.sstep = Some(sstep);
+            }
+            if let Some(cond) = opts.gmres_sstep_max_cond {
+                self.pending_gmres.sstep_max_cond = Some(cond);
+            }
+        }
+
+        if let Some(s) = self
+            .solver
+            .as_mut()
+            .and_then(|b| b.as_any_mut().downcast_mut::<GmresSolver>())
+        {
+            let snapshot = self.pending_gmres.clone();
+            Self::apply_gmres_pending(&snapshot, s);
         }
 
         // --- FGMRES options ---
@@ -648,25 +679,71 @@ impl KspContext {
         Ok(self)
     }
 
-    fn apply_gmres_pending_to(&self, s: &mut GmresSolver) {
-        if let Some(r) = self.pending_gmres.restart {
+    fn apply_gmres_pending(pending: &PendingGmres, s: &mut GmresSolver) {
+        if let Some(r) = pending.restart {
             s.set_restart(r);
         }
-        if let Some(o) = self.pending_gmres.orthog {
+        if let Some(o) = pending.orthog {
             s.set_orthog(o);
         }
-        if let Some(p) = self.pending_gmres.reorth {
+        if let Some(p) = pending.reorth {
             s.set_reorth_policy(p);
         }
-        if let Some(tol) = self.pending_gmres.reorth_tol {
+        if let Some(tol) = pending.reorth_tol {
             s.set_reorth_tol(tol);
         }
-        if let Some(f) = self.pending_gmres.happy_breakdown {
+        if let Some(f) = pending.happy_breakdown {
             s.set_happy_breakdown(f);
         }
-        if let Some(v) = self.pending_gmres.variant {
-            s.set_variant(v);
+        let mut variant_kind = pending.variant;
+        if variant_kind.is_none()
+            && matches!(s.variant, crate::solver::gmres::GmresVariant::SStep { .. })
+            && (pending.sstep.is_some() || pending.sstep_max_cond.is_some())
+        {
+            variant_kind = Some(PendingGmresVariant::SStep);
         }
+
+        if let Some(kind) = variant_kind {
+            match kind {
+                PendingGmresVariant::Classical => {
+                    s.set_variant(crate::solver::gmres::GmresVariant::Classical);
+                }
+                PendingGmresVariant::Pipelined => {
+                    s.set_variant(crate::solver::gmres::GmresVariant::Pipelined);
+                }
+                PendingGmresVariant::SStep => {
+                    let current = match s.variant {
+                        crate::solver::gmres::GmresVariant::SStep {
+                            s,
+                            reorth,
+                            max_cond,
+                        } => Some((s, reorth, max_cond)),
+                        _ => None,
+                    };
+                    let block_s = pending
+                        .sstep
+                        .or_else(|| current.map(|(s, _, _)| s))
+                        .unwrap_or(2);
+                    let max_cond = pending
+                        .sstep_max_cond
+                        .or_else(|| current.map(|(_, _, cond)| cond))
+                        .unwrap_or(1e8);
+                    let reorth = pending
+                        .reorth
+                        .or_else(|| current.map(|(_, r, _)| r))
+                        .unwrap_or_else(|| s.reorth_policy());
+                    s.set_variant(crate::solver::gmres::GmresVariant::SStep {
+                        s: block_s,
+                        reorth,
+                        max_cond,
+                    });
+                }
+            }
+        }
+    }
+
+    fn apply_gmres_pending_to(&self, s: &mut GmresSolver) {
+        Self::apply_gmres_pending(&self.pending_gmres, s);
     }
 
     fn apply_fgmres_pending_to(&self, s: &mut FgmresSolver) {

--- a/src/context/ksp_context/workspace.rs
+++ b/src/context/ksp_context/workspace.rs
@@ -19,6 +19,7 @@ pub struct Workspace {
     pub pipelined_w: Vec<f64>,
     pub pipelined_wtmp: Vec<f64>,
     pub pipelined_payload: Vec<f64>,
+    pub gmres_sstep: Option<GmresSStepWorkspace>,
     pub reduction: crate::utils::reduction::ReductOptions,
     // Shared communication arenas
     pub send_arena: crate::utils::buffer_pool::BufferPool<u8>,
@@ -68,6 +69,19 @@ impl BlockVec {
         }
     }
 
+    pub fn resize(&mut self, n: usize, p: usize) {
+        if self.n != n || self.p != p {
+            self.data.resize(n.saturating_mul(p), 0.0);
+            self.n = n;
+            self.p = p;
+        } else {
+            let need = n.saturating_mul(p);
+            if self.data.len() != need {
+                self.data.resize(need, 0.0);
+            }
+        }
+    }
+
     #[inline]
     pub fn nrows(&self) -> usize {
         self.n
@@ -98,6 +112,44 @@ impl BlockVec {
     #[inline]
     pub fn as_mut_slice(&mut self) -> &mut [f64] {
         &mut self.data
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct GmresSStepWorkspace {
+    pub w: BlockVec,
+    pub q: BlockVec,
+    pub aq: BlockVec,
+    pub gram: Vec<f64>,
+    pub c_prev: Vec<f64>,
+    pub payload: Vec<f64>,
+    pub r: Vec<f64>,
+}
+
+impl GmresSStepWorkspace {
+    pub fn new(n: usize, s: usize, m: usize) -> Self {
+        let mut ws = Self {
+            w: BlockVec::new(n, s),
+            q: BlockVec::new(n, s),
+            aq: BlockVec::new(n, s),
+            gram: vec![0.0; s.saturating_mul(s)],
+            c_prev: vec![0.0; m.saturating_mul(s)],
+            payload: vec![0.0; s.saturating_mul(s + 1) / 2 + m.saturating_mul(s)],
+            r: vec![0.0; s.saturating_mul(s)],
+        };
+        ws.ensure(n, s, m);
+        ws
+    }
+
+    pub fn ensure(&mut self, n: usize, s: usize, m: usize) {
+        self.w.resize(n, s);
+        self.q.resize(n, s);
+        self.aq.resize(n, s);
+        ensure_len(&mut self.gram, s.saturating_mul(s));
+        ensure_len(&mut self.c_prev, m.saturating_mul(s));
+        let payload_len = s.saturating_mul(s + 1) / 2 + m.saturating_mul(s);
+        ensure_len(&mut self.payload, payload_len);
+        ensure_len(&mut self.r, s.saturating_mul(s));
     }
 }
 
@@ -164,6 +216,29 @@ impl Workspace {
         }
     }
 
+    pub fn ensure_sstep(&mut self, n: usize, s: usize, m: usize) {
+        if s == 0 {
+            self.gmres_sstep = None;
+            return;
+        }
+        let need_new = match self.gmres_sstep {
+            Some(ref buf) => {
+                buf.w.nrows() != n || buf.w.ncols() < s || buf.c_prev.len() < m.saturating_mul(s)
+            }
+            None => true,
+        };
+        if need_new {
+            self.gmres_sstep = Some(GmresSStepWorkspace::new(n, s, m));
+        } else if let Some(ref mut buf) = self.gmres_sstep {
+            buf.ensure(n, s, m);
+        }
+    }
+
+    #[inline]
+    pub fn sstep_mut(&mut self) -> Option<&mut GmresSStepWorkspace> {
+        self.gmres_sstep.as_mut()
+    }
+
     #[inline]
     pub fn n(&self) -> usize {
         self.n
@@ -223,6 +298,8 @@ impl Workspace {
         } else {
             self.blk_scratch.clear();
         }
+
+        self.ensure_sstep(n, spec.block_s, m);
     }
 
     pub fn set_reduction_options(&mut self, opt: crate::utils::reduction::ReductOptions) {

--- a/src/matrix/spmv/mod.rs
+++ b/src/matrix/spmv/mod.rs
@@ -8,6 +8,7 @@ pub mod simd_csr;
 pub use self::plan::{KernelKind, SpmvPlan, SpmvTuning, build as build_plan};
 pub use self::scalar::{spmv_scaled_csr, spmv_t_scaled_csr};
 
+use crate::context::ksp_context::BlockVec;
 use crate::error::KError;
 use crate::matrix::{csc::CscMatrix, sparse::CsrMatrix};
 use faer::{MatMut, MatRef};
@@ -93,6 +94,42 @@ pub fn spmv_csr_parallel(a: &CsrMatrix<f64>, x: &[f64], y: &mut [f64]) -> Result
         let sum = unsafe { lane_dot_gather_unchecked(&vv[rs..re], &cj[rs..re], x) };
         yi[0] = sum;
     });
+    Ok(())
+}
+
+pub fn spmm_csr_dense(a: &CsrMatrix<f64>, x: &BlockVec, y: &mut BlockVec) -> Result<(), KError> {
+    let (m, n) = (a.nrows(), a.ncols());
+    if x.nrows() != n || y.nrows() != m || x.ncols() != y.ncols() {
+        return Err(KError::InvalidInput(
+            "spmm_csr_dense: dimension mismatch".into(),
+        ));
+    }
+
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+    let p = x.ncols();
+    let xn = x.nrows();
+    let yn = y.nrows();
+    let x_data = x.as_slice();
+    let y_data = y.as_mut_slice();
+    y_data.fill(0.0);
+
+    for i in 0..m {
+        let row_start = rp[i];
+        let row_end = rp[i + 1];
+        for pos in row_start..row_end {
+            let j = cj[pos];
+            let aij = vv[pos];
+            let x_base = j;
+            for col in 0..p {
+                let y_idx = col * yn + i;
+                let x_idx = col * xn + x_base;
+                y_data[y_idx] += aij * x_data[x_idx];
+            }
+        }
+    }
+
     Ok(())
 }
 

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -31,10 +31,15 @@ pub enum GmresOrthog {
     Cgs,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GmresVariant {
     Classical,
     Pipelined,
+    SStep {
+        s: usize,
+        reorth: ReorthPolicy,
+        max_cond: f64,
+    },
 }
 
 pub struct GmresSolver {
@@ -82,13 +87,21 @@ impl GmresSolver {
     }
 
     fn ensure_workspace(&self, w: &mut Workspace, n: usize, side: PcSide) {
+        let block_s = match self.variant {
+            GmresVariant::SStep { s, .. } => s,
+            _ => 0,
+        };
         let spec = GmresSpec {
             n,
             m: self.restart,
             need_z: matches!(side, PcSide::Right),
-            block_s: 0,
+            block_s,
         };
         w.acquire_gmres(spec);
+    }
+
+    pub fn reorth_policy(&self) -> ReorthPolicy {
+        self.reorth
     }
 
     fn apply_precond(
@@ -137,6 +150,99 @@ impl GmresSolver {
             for (xi, &zj) in x.iter_mut().zip(z) {
                 *xi += yj * zj;
             }
+        }
+    }
+
+    #[allow(dead_code)]
+    #[inline]
+    fn mat_idx(ld: usize, row: usize, col: usize) -> usize {
+        col * ld + row
+    }
+
+    #[allow(dead_code)]
+    fn chol_upper(mat: &mut [f64], n: usize) -> Result<(), KError> {
+        for j in 0..n {
+            for i in 0..=j {
+                let mut sum = mat[Self::mat_idx(n, i, j)];
+                for k in 0..i {
+                    let left = mat[Self::mat_idx(n, k, i)];
+                    let right = mat[Self::mat_idx(n, k, j)];
+                    sum -= left * right;
+                }
+                if i == j {
+                    if sum <= 0.0 || !sum.is_finite() {
+                        return Err(KError::FactorError(
+                            "s-step GMRES: Cholesky factorization failed".into(),
+                        ));
+                    }
+                    mat[Self::mat_idx(n, i, j)] = sum.sqrt();
+                } else {
+                    let diag = mat[Self::mat_idx(n, i, i)];
+                    if diag == 0.0 {
+                        return Err(KError::FactorError(
+                            "s-step GMRES: zero diagonal during Cholesky".into(),
+                        ));
+                    }
+                    mat[Self::mat_idx(n, i, j)] = sum / diag;
+                }
+            }
+            for i in (j + 1)..n {
+                mat[Self::mat_idx(n, i, j)] = 0.0;
+            }
+        }
+        Ok(())
+    }
+
+    #[allow(dead_code)]
+    fn triangular_solve_right_upper(r: &[f64], block: usize, data: &mut [f64], nrows: usize) {
+        // Solve X R = data in-place for X, where data holds W' (nrows x block)
+        // stored column-major. After the solve, data contains Q.
+        for col in 0..block {
+            let mut col_slice = vec![0.0; nrows];
+            // copy target column (W' column)
+            for row in 0..nrows {
+                col_slice[row] = data[col * nrows + row];
+            }
+            for k in 0..col {
+                let r_kj = r[Self::mat_idx(block, k, col)];
+                if r_kj != 0.0 {
+                    for row in 0..nrows {
+                        col_slice[row] -= r_kj * data[k * nrows + row];
+                    }
+                }
+            }
+            let diag = r[Self::mat_idx(block, col, col)];
+            if diag != 0.0 {
+                for row in 0..nrows {
+                    data[col * nrows + row] = col_slice[row] / diag;
+                }
+            } else {
+                for row in 0..nrows {
+                    data[col * nrows + row] = 0.0;
+                }
+            }
+        }
+    }
+
+    #[allow(dead_code)]
+    fn estimate_triangular_condition(r: &[f64], block: usize) -> f64 {
+        let mut max_diag = 0.0;
+        let mut min_diag = f64::MAX;
+        for j in 0..block {
+            let diag = r[Self::mat_idx(block, j, j)].abs();
+            if diag > max_diag {
+                max_diag = diag;
+            }
+            if diag < min_diag {
+                min_diag = diag;
+            }
+        }
+        if min_diag <= 0.0 {
+            f64::INFINITY
+        } else if max_diag == 0.0 {
+            0.0
+        } else {
+            max_diag / min_diag
         }
     }
 }
@@ -256,6 +362,12 @@ impl LinearSolver for GmresSolver {
             return Ok(stats.with_counters(counters));
         }
 
+        if matches!(self.variant, GmresVariant::SStep { .. }) {
+            return Err(KError::NotImplemented(
+                "GMRES s-step variant is not yet implemented".into(),
+            ));
+        }
+
         'outer: loop {
             let mut k_steps = 0usize;
             for k in 0..self.restart {
@@ -355,6 +467,9 @@ impl LinearSolver for GmresSolver {
                         }
                         PcSide::Symmetric => unreachable!(),
                     },
+                    GmresVariant::SStep { .. } => {
+                        unreachable!("s-step path should exit before iteration loop")
+                    }
                 }
 
                 ws.apply_prev_givens_to_col(k, k);


### PR DESCRIPTION
## Summary
- add internal helper routines in the GMRES solver to support upcoming s-step block factorizations

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d8be6058548329a02b967cdc7bd8df