### PR TITLE
feat: add gmres augmentation scaffolding

### DIFF
--- a/docs/howto/phase-f-augmentation-plan.md
+++ b/docs/howto/phase-f-augmentation-plan.md
@@ -1,0 +1,131 @@
+# Phase F: GMRES/FGMRES Augmentation & Deflation Plan
+
+This plan extends the existing Phase C GMRES/FGMRES implementation with production-ready augmentation and deflation features. It preserves the current public API, works with the async reduction and block primitives already in place, and outlines tests required for validation.
+
+## 1. Public API & Wiring
+
+### 1.1 Solver options
+
+```rust
+#[derive(Clone, Debug)]
+pub enum AugmentationPolicy {
+    None,
+    /// GMRES-DR(m,k): carry k harmonic Ritz vectors across restarts
+    GmresDR { k: usize },
+    /// LGMRES(m,ℓ): carry ℓ recent solution-difference (or preconditioned) vectors
+    Lgmres { ell: usize },
+}
+
+pub struct GmresOptions {
+    pub restart: usize,
+    pub augment: AugmentationPolicy,
+    pub reorth: ReorthPolicy,
+    // existing fields remain unchanged
+}
+```
+
+* Add identical plumbing for FGMRES (right-preconditioned variant).
+* Introduce configuration flags:
+  * `-ksp_gmres_augment none|dr|lgmres`
+  * `-ksp_gmres_dr_k <int>`
+  * `-ksp_lgmres_ell <int>`
+
+## 2. RecyclingSpace in the workspace
+
+Embed a `RecyclingSpace` object inside the GMRES/FGMRES cycle workspace.
+
+```rust
+pub struct RecyclingSpace {
+    /// Orthonormal columns (size n × r), r ≤ rmax.
+    /// GMRES stores physical-space vectors; right-PC FGMRES stores Z-space vectors.
+    pub U: Vec<Vec<f64>>,
+    /// A*U in physical space (needed to seed Arnoldi and build the Hessenberg block).
+    pub AU: Vec<Vec<f64>>,
+    pub rmax: usize,
+    pub kind: AugmentationPolicy,
+}
+```
+
+* Provide `new`, `clear`, and `r()` helpers.
+* Thread `RecyclingSpace` into `GmresCycleWs` and `FgmresCycleWs`.
+
+## 3. Where augmentation enters the algorithm
+
+1. At restart (or the first cycle) refresh `recycle.U` and `recycle.AU` according to the active policy.
+2. Prepend the block `U` as the initial columns of the new Arnoldi basis and seed the block with `AU`.
+3. Continue the usual Arnoldi process from the deflated residual; the least-squares problem remains unchanged.
+
+## 4. GMRES-DR implementation
+
+1. Build harmonic Ritz vectors from the completed cycle:
+   * Form `C = [H_m; h_{m+1,m} e_m^T]`.
+   * Compute its small SVD via `faer` and select the `k` right singular vectors associated with the smallest singular values (`Y_k`).
+   * Compute `U = V_m Y_k` and orthonormalize with two-pass MGS.
+   * Compute `AU = V_{m+1} \bar H_m Y_k`; fall back to explicit matvecs if the cached data are unavailable.
+2. Install the block into `ws.recycle` and call `prepend_block` before starting the next Arnoldi cycle.
+3. Reduce `k` if the SVD is ill-conditioned or `k == 0`.
+
+## 5. LGMRES implementation
+
+1. During each cycle collect up to `ℓ` augmentation vectors:
+   * GMRES: solution differences `d_j = x_{j+1} - x_j`.
+   * FGMRES (right-PC): the preconditioned search directions `z_j`.
+2. At restart:
+   * Orthonormalize the collected vectors (two-pass MGS, drop tiny norms).
+   * Compute `AU = A U` with a batched SpMM/SpMV.
+   * Install the block into `ws.recycle` and call `prepend_block`.
+3. This approach matches classical LGMRES while reusing the standard Arnoldi and least-squares path.
+
+## 6. Mechanics to add
+
+### 6.1 Block prepend helper
+
+Implement `prepend_block` to consume `(U, AU)` and produce the first `r` basis vectors and the leading block of the Hessenberg matrix.
+
+* Reuse the existing block GMRES routines: compute Gram matrices with a batched reduction, perform Cholesky-QR, and fall back to Householder QR when conditioning is poor.
+* Populate `V[0..r-1]` with the orthonormalized columns and write the upper block of `H` using the resulting `R` factor.
+* Continue the Arnoldi loop starting at column `r`.
+
+### 6.2 Orthogonalization
+
+No special handling is required after the prepend; subsequent vectors already orthogonalize against the augmented basis via the standard code paths.
+
+## 7. Right-preconditioned FGMRES specifics
+
+* GMRES-DR: compute harmonic Ritz vectors in the unpreconditioned space but store augmentation vectors in `Z`-space (`U_Z = Z_m Y_k`) while `AU = A U_Z`.
+* LGMRES: capture and recycle the preconditioned search directions (`z_j`).
+* Ensure solution updates use the `Z` basis exactly as in Phase C.
+
+## 8. Multi-solve recycling (RecyclingKsp)
+
+Provide an optional wrapper that persists augmentation across solves.
+
+```rust
+pub struct RecyclingKsp<S: LinearSolver> {
+    inner: S,
+    space: RecyclingSpace,
+    policy: AugmentationPolicy,
+}
+```
+
+* Add `install_recycling` and `export_recycling` hooks on GMRES/FGMRES.
+* Merge exported vectors into the persistent space with eviction when exceeding `rmax`.
+
+## 9. Numerics & fallbacks
+
+* Two-pass MGS for all augmentation columns; drop vectors with norm `< 1e-12` of their initial norm.
+* Guard Cholesky-QR with a condition-number test (`cond(R) ≤ 1e8`); otherwise fall back to Householder QR.
+* Clamp `k` when the GMRES-DR SVD is rank deficient or singular values cluster.
+* Keep `U` in `Z`-space for right-preconditioned FGMRES while maintaining `AU = A U` in physical space.
+* Fix column ordering (ascending singular values, then `‖AU_i‖`) for deterministic behaviour.
+
+## 10. Tests & benchmarks
+
+1. **Augmentation efficacy**: classical GMRES(m) stagnation problems; compare iterations and residuals versus DR/LGMRES and ensure reduction counts only increase by the prepend reduction.
+2. **Right-PC parity**: validate DR/LGMRES with AMG (left PC) and ILU (right PC); confirm solution updates use the `Z` basis in small-dimension checks.
+3. **Recycling across solves**: multiple RHS or Newton steps; verify monotonic iteration reductions and enforcement of `rmax`.
+4. **Stability & guards**: trigger near-dependent augmentation columns to exercise QR fallbacks and SVD conditioning logic.
+
+---
+
+Delivering these steps yields a low-risk, production-ready augmentation phase with dramatic improvements on difficult restarted problems and optional multi-solve recycling without altering the existing external API.

--- a/src/context/ksp_context/workspace.rs
+++ b/src/context/ksp_context/workspace.rs
@@ -1,3 +1,5 @@
+use crate::solver::gmres::AugmentationPolicy;
+
 #[derive(Debug, Clone, Default)]
 pub struct Workspace {
     pub tmp1: Vec<f64>,
@@ -20,6 +22,7 @@ pub struct Workspace {
     pub pipelined_wtmp: Vec<f64>,
     pub pipelined_payload: Vec<f64>,
     pub gmres_sstep: Option<GmresSStepWorkspace>,
+    pub gmres_recycle: RecyclingSpace,
     pub reduction: crate::utils::reduction::ReductOptions,
     // Shared communication arenas
     pub send_arena: crate::utils::buffer_pool::BufferPool<u8>,
@@ -28,6 +31,93 @@ pub struct Workspace {
     n: usize,
     m: usize,
     need_z: bool,
+}
+
+#[derive(Debug, Clone)]
+pub struct RecyclingSpace {
+    u: Vec<f64>,
+    au: Vec<f64>,
+    n: usize,
+    rmax: usize,
+    cols: usize,
+    policy: AugmentationPolicy,
+}
+
+impl Default for RecyclingSpace {
+    fn default() -> Self {
+        Self {
+            u: Vec::new(),
+            au: Vec::new(),
+            n: 0,
+            rmax: 0,
+            cols: 0,
+            policy: AugmentationPolicy::None,
+        }
+    }
+}
+
+impl RecyclingSpace {
+    pub fn configure(&mut self, n: usize, rmax: usize, policy: AugmentationPolicy) {
+        if self.n != n || self.rmax != rmax {
+            self.u.resize(n.saturating_mul(rmax), 0.0);
+            self.au.resize(n.saturating_mul(rmax), 0.0);
+            self.n = n;
+            self.rmax = rmax;
+            self.cols = 0;
+        }
+        self.policy = policy;
+    }
+
+    #[inline]
+    pub fn policy(&self) -> AugmentationPolicy {
+        self.policy.clone()
+    }
+
+    #[inline]
+    pub fn capacity(&self) -> usize {
+        self.rmax
+    }
+
+    #[inline]
+    pub fn cols(&self) -> usize {
+        self.cols
+    }
+
+    pub fn clear(&mut self) {
+        self.cols = 0;
+    }
+
+    pub fn col(&self, j: usize) -> &[f64] {
+        let n = self.n;
+        &self.u[j * n..(j + 1) * n]
+    }
+
+    pub fn col_mut(&mut self, j: usize) -> &mut [f64] {
+        let n = self.n;
+        &mut self.u[j * n..(j + 1) * n]
+    }
+
+    pub fn a_col(&self, j: usize) -> &[f64] {
+        let n = self.n;
+        &self.au[j * n..(j + 1) * n]
+    }
+
+    pub fn a_col_mut(&mut self, j: usize) -> &mut [f64] {
+        let n = self.n;
+        &mut self.au[j * n..(j + 1) * n]
+    }
+
+    pub fn push_from(&mut self, u: &[f64], au: &[f64]) {
+        if self.cols >= self.rmax {
+            return;
+        }
+        let n = self.n;
+        let dst_u = &mut self.u[self.cols * n..(self.cols + 1) * n];
+        let dst_au = &mut self.au[self.cols * n..(self.cols + 1) * n];
+        dst_u.copy_from_slice(u);
+        dst_au.copy_from_slice(au);
+        self.cols += 1;
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -31,6 +31,13 @@ pub enum GmresOrthog {
     Cgs,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum AugmentationPolicy {
+    None,
+    GmresDR { k: usize },
+    Lgmres { ell: usize },
+}
+
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub enum GmresVariant {
     Classical,
@@ -56,6 +63,7 @@ pub struct GmresSolver {
     /// Whether to treat near-zero residual as a happy breakdown
     pub happy_breakdown: bool,
     pub variant: GmresVariant,
+    pub augmentation: AugmentationPolicy,
 }
 
 impl GmresSolver {
@@ -74,6 +82,7 @@ impl GmresSolver {
             reorth_tol: 0.7,
             happy_breakdown: true,
             variant: GmresVariant::Classical,
+            augmentation: AugmentationPolicy::None,
         }
     }
 
@@ -98,10 +107,25 @@ impl GmresSolver {
             block_s,
         };
         w.acquire_gmres(spec);
+        let rmax = self.augmentation_dim();
+        if rmax > 0 {
+            w.gmres_recycle
+                .configure(n, rmax, self.augmentation.clone());
+        } else {
+            w.gmres_recycle.configure(n, 0, AugmentationPolicy::None);
+        }
     }
 
     pub fn reorth_policy(&self) -> ReorthPolicy {
         self.reorth
+    }
+
+    fn augmentation_dim(&self) -> usize {
+        match self.augmentation {
+            AugmentationPolicy::None => 0,
+            AugmentationPolicy::GmresDR { k } => k.min(self.restart),
+            AugmentationPolicy::Lgmres { ell } => ell.min(self.restart),
+        }
     }
 
     fn apply_precond(


### PR DESCRIPTION
## Summary
- add an augmentation policy enum to the GMRES solver so callers can select future DR/LGMRES modes
- extend the shared GMRES workspace with a recycling space container that can hold augmentation vectors and their images

## Testing
- cargo fmt
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68d9eb52c0c88329a66a6e54c7b7d065