### PR TITLE
Introduce shared BlockVec and block matvec trait

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -52,7 +52,8 @@ use crate::utils::reduction::{ReductMode, ReductOptions};
 use std::str::FromStr;
 use std::sync::Arc;
 mod workspace;
-pub use workspace::{BlockVec, GmresSStepWorkspace, GmresSpec, ReorthPolicy, Workspace};
+pub use crate::core::block::BlockVec;
+pub use workspace::{GmresSStepWorkspace, GmresSpec, ReorthPolicy, Workspace};
 
 /// Supported solver types.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]

--- a/src/context/ksp_context/workspace.rs
+++ b/src/context/ksp_context/workspace.rs
@@ -1,3 +1,4 @@
+use crate::core::block::BlockVec;
 use crate::solver::gmres::AugmentationPolicy;
 
 #[derive(Debug, Clone, Default)]
@@ -140,69 +141,6 @@ pub struct GmresSpec {
     pub m: usize,
     pub need_z: bool,
     pub block_s: usize,
-}
-
-/// Column-major storage reused for block Krylov vectors.
-#[derive(Debug, Clone)]
-pub struct BlockVec {
-    data: Vec<f64>,
-    n: usize,
-    p: usize,
-}
-
-impl BlockVec {
-    pub fn new(n: usize, p: usize) -> Self {
-        Self {
-            data: vec![0.0; n.saturating_mul(p)],
-            n,
-            p,
-        }
-    }
-
-    pub fn resize(&mut self, n: usize, p: usize) {
-        if self.n != n || self.p != p {
-            self.data.resize(n.saturating_mul(p), 0.0);
-            self.n = n;
-            self.p = p;
-        } else {
-            let need = n.saturating_mul(p);
-            if self.data.len() != need {
-                self.data.resize(need, 0.0);
-            }
-        }
-    }
-
-    #[inline]
-    pub fn nrows(&self) -> usize {
-        self.n
-    }
-
-    #[inline]
-    pub fn ncols(&self) -> usize {
-        self.p
-    }
-
-    #[inline]
-    pub fn col(&self, j: usize) -> &[f64] {
-        let offset = j * self.n;
-        &self.data[offset..offset + self.n]
-    }
-
-    #[inline]
-    pub fn col_mut(&mut self, j: usize) -> &mut [f64] {
-        let offset = j * self.n;
-        &mut self.data[offset..offset + self.n]
-    }
-
-    #[inline]
-    pub fn as_slice(&self) -> &[f64] {
-        &self.data
-    }
-
-    #[inline]
-    pub fn as_mut_slice(&mut self) -> &mut [f64] {
-        &mut self.data
-    }
 }
 
 #[derive(Debug, Clone)]

--- a/src/core/block.rs
+++ b/src/core/block.rs
@@ -1,0 +1,104 @@
+use crate::error::KError;
+
+/// Column-major dense block vector storage used by block Krylov variants.
+#[derive(Debug, Clone)]
+pub struct BlockVec {
+    data: Vec<f64>,
+    n: usize,
+    p: usize,
+}
+
+impl BlockVec {
+    /// Create a new block vector with `n` rows and `p` columns.
+    pub fn new(n: usize, p: usize) -> Self {
+        Self {
+            data: vec![0.0; n.saturating_mul(p)],
+            n,
+            p,
+        }
+    }
+
+    /// Resize the block vector to `n` rows and `p` columns, zero-filling new entries.
+    pub fn resize(&mut self, n: usize, p: usize) {
+        if self.n != n || self.p != p {
+            self.data.resize(n.saturating_mul(p), 0.0);
+            self.n = n;
+            self.p = p;
+        } else {
+            let needed = n.saturating_mul(p);
+            if self.data.len() != needed {
+                self.data.resize(needed, 0.0);
+            }
+        }
+    }
+
+    /// Number of rows in the block vector.
+    #[inline]
+    pub fn nrows(&self) -> usize {
+        self.n
+    }
+
+    /// Number of columns in the block vector.
+    #[inline]
+    pub fn ncols(&self) -> usize {
+        self.p
+    }
+
+    /// Immutable view into the `j`-th column.
+    #[inline]
+    pub fn col(&self, j: usize) -> &[f64] {
+        let offset = j * self.n;
+        &self.data[offset..offset + self.n]
+    }
+
+    /// Mutable view into the `j`-th column.
+    #[inline]
+    pub fn col_mut(&mut self, j: usize) -> &mut [f64] {
+        let offset = j * self.n;
+        &mut self.data[offset..offset + self.n]
+    }
+
+    /// Immutable view into the raw column-major storage.
+    #[inline]
+    pub fn as_slice(&self) -> &[f64] {
+        &self.data
+    }
+
+    /// Mutable view into the raw column-major storage.
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [f64] {
+        &mut self.data
+    }
+}
+
+impl Default for BlockVec {
+    fn default() -> Self {
+        Self {
+            data: Vec::new(),
+            n: 0,
+            p: 0,
+        }
+    }
+}
+
+impl BlockVec {
+    /// Fill the block vector with zeros.
+    pub fn fill_zero(&mut self) {
+        for v in &mut self.data {
+            *v = 0.0;
+        }
+    }
+}
+
+/// Convenience helper for verifying block dimensions.
+#[allow(dead_code)]
+pub(crate) fn assert_block_dims(expected_rows: usize, vec: &BlockVec) -> Result<(), KError> {
+    if vec.nrows() != expected_rows {
+        return Err(KError::InvalidInput(format!(
+            "BlockVec has {} rows but expected {}",
+            vec.nrows(),
+            expected_rows
+        )));
+    }
+    Ok(())
+}

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -1,3 +1,4 @@
+pub mod block;
 pub mod mat;
 pub mod traits;
 pub mod wrappers;

--- a/src/core/traits.rs
+++ b/src/core/traits.rs
@@ -13,6 +13,8 @@ pub trait MatTransVec<V> {
 }
 
 // Blanket implementations of MatVec/MatTransVec for LinOp types using Vec storage.
+use crate::core::block::BlockVec;
+use crate::error::KError;
 use crate::matrix::op::LinOp;
 use faer::traits::ComplexField;
 
@@ -36,6 +38,52 @@ where
             panic!("t_matvec not supported");
         }
         LinOp::t_matvec(self, &x[..], &mut y[..]);
+    }
+}
+
+/// Optional extension trait for block matvec operations while remaining matrix-free.
+pub trait BlockOp {
+    /// Apply the operator to multiple columns at once. Default implementation calls
+    /// [`apply`](Self::apply) per column to remain format agnostic.
+    fn apply_many(&self, x: &BlockVec, y: &mut BlockVec) -> Result<(), KError> {
+        if x.ncols() != y.ncols() {
+            return Err(KError::InvalidInput(format!(
+                "apply_many column mismatch: {} vs {}",
+                x.ncols(),
+                y.ncols()
+            )));
+        }
+        for c in 0..x.ncols() {
+            self.apply(x.col(c), y.col_mut(c))?;
+        }
+        Ok(())
+    }
+
+    /// Apply the operator to a single column.
+    fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), KError>;
+
+    /// Apply the transpose of the operator if available.
+    fn apply_t(&self, _x: &[f64], _y: &mut [f64]) -> Result<(), KError> {
+        Err(KError::Unsupported("transpose not available".into()))
+    }
+}
+
+impl<T> BlockOp for T
+where
+    T: LinOp<S = f64> + ?Sized,
+{
+    fn apply(&self, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        LinOp::try_matvec(self, x, y)
+    }
+
+    fn apply_t(&self, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        if !LinOp::supports_transpose(self) {
+            return Err(KError::Unsupported(
+                "LinOp::t_matvec called but transpose not supported".into(),
+            ));
+        }
+        LinOp::t_matvec(self, x, y);
+        Ok(())
     }
 }
 


### PR DESCRIPTION
## Summary
- move the block Krylov vector storage into a shared `core::block` module
- add a `BlockOp` trait with a default matrix-free `apply_many` helper for `LinOp`
- adjust the KSP workspace re-exports to use the shared block vector type

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68da057621608329990d300cf96f198b