### PR TITLE
Add solver regression tests and reduction instrumentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -185,3 +185,17 @@ jobs:
           echo "[CI] Running MPI-enabled tests with 4 processes..."
           mpirun --oversubscribe -np 4 \
             cargo test --locked --verbose --features mpi -- --nocapture --ignored
+
+  bench-smoke:
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main' || startsWith(github.ref_name, 'release/')
+    needs: build-and-unit-tests
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Rust (stable)
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Criterion smoke test
+        run: cargo bench -- spmv_vs_spmm -- --sample-size 10

--- a/README.md
+++ b/README.md
@@ -47,9 +47,27 @@ High-performance Krylov subspace and preconditioned iterative solvers for dense 
 ### Monitoring & Automation
 
 - **Iteration Monitoring**: Real-time convergence tracking with `IterationMonitor`
-- **Parameter Tuning**: Automated optimization with `ParameterTuner` and grid search  
+- **Parameter Tuning**: Automated optimization with `ParameterTuner` and grid search
 - **Data Export**: CSV output for convergence analysis with `enable_csv_logging()`
 - **Performance Metrics**: Comprehensive timing and convergence rate analysis
+
+### Latency-aware solver knobs
+
+The Krylov drivers expose command-line options to balance global reductions
+against additional local work. The most common flags mirror PETSc's `-ksp_*`
+options and can be combined with the deterministic reduction feature for
+reproducible CI runs.
+
+| Flag | Default | Effect |
+| --- | --- | --- |
+| `-ksp_cg_pipelined <bool>` | `false` | Enable the pipelined PCG algorithm (≈1 allreduce / iteration). |
+| `-ksp_gmres_variant classical|pipelined|sstep[:s]` | `classical` | Select the GMRES variant. `sstep` accepts an optional block size `s` (currently parsed but reported as not yet implemented). |
+| `-ksp_residual_replacement <iters>` | `50` | Force periodic residual recomputation in pipelined CG to control drift (`0` disables). |
+| `-ksp_reorthog never|ifneeded|always` | `ifneeded` | Control Gram-Schmidt reorthogonalisation in GMRES and FGMRES. |
+
+Each solver also records the number of global reductions performed in
+`SolveStats::counters.num_global_reductions`, making it easy to assert expected
+latency costs in automated tests.
 
 ### Architecture
 - **PETSc-style API**: Unified KSP context for runtime solver selection

--- a/benches/spmv_vs_spmm.rs
+++ b/benches/spmv_vs_spmm.rs
@@ -1,0 +1,47 @@
+use criterion::{BatchSize, Criterion, criterion_group, criterion_main};
+use kryst::matrix::sparse::CsrMatrix;
+use kryst::solver::block::block_vec::BlockVec;
+use kryst::solver::block::kernels::spmm_csr_dense;
+
+fn poisson3d(n: usize) -> CsrMatrix<f64> {
+    kryst::matrix::utils::poisson::poisson_7pt_3d(n)
+}
+
+fn bench_spmv_vs_spmm(c: &mut Criterion) {
+    let a = poisson3d(20); // ~8k unknowns, quick but illustrative
+    let n = a.nrows();
+
+    c.bench_function("spmv_x4", |b| {
+        b.iter_batched(
+            || (vec![1.0f64; n], vec![0.0f64; n]),
+            |(x, mut y)| {
+                for _ in 0..4 {
+                    a.spmv_scaled(1.0, &x, 0.0, &mut y).unwrap();
+                }
+            },
+            BatchSize::SmallInput,
+        )
+    });
+
+    c.bench_function("spmm_block4", |b| {
+        b.iter_batched(
+            || {
+                let mut x = BlockVec::new(n, 4);
+                for col in 0..4 {
+                    for row in 0..n {
+                        x[(row, col)] = 1.0;
+                    }
+                }
+                let y = BlockVec::new(n, 4);
+                (x, y)
+            },
+            |(x, mut y)| {
+                spmm_csr_dense(&a, &x, &mut y).unwrap();
+            },
+            BatchSize::SmallInput,
+        )
+    });
+}
+
+criterion_group!(benches, bench_spmv_vs_spmm);
+criterion_main!(benches);

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -89,7 +89,7 @@ pub static SPECS: &[Spec] = &[
         key: "ksp_gmres_variant",
         arity: Arity::One,
         kind: ValueKind::Str,
-        doc: "GMRES variant: classical|pipelined",
+        doc: "GMRES variant: classical|pipelined|sstep[:s]",
     },
     Spec {
         flag: "-ksp_gmres_reorthog",

--- a/src/matrix/utils.rs
+++ b/src/matrix/utils.rs
@@ -200,6 +200,160 @@ pub fn spgemm(a: &CsrMatrix<f64>, b: &CsrMatrix<f64>) -> Result<CsrMatrix<f64>, 
     spgemm_with_drop_tol(a, b, 1e-12)
 }
 
+/// Canonical Poisson stencil helpers used by solver tests and benchmarks.
+pub mod poisson {
+    use super::*;
+
+    /// Return the 5-point finite-difference discretisation of the 2-D Poisson
+    /// operator on an `n × n` grid.
+    pub fn poisson_5pt_2d(n: usize) -> CsrMatrix<f64> {
+        super::poisson_2d(n, n)
+    }
+
+    /// Return the 7-point finite-difference discretisation of the 3-D Poisson
+    /// operator on an `n × n × n` grid.
+    pub fn poisson_7pt_3d(n: usize) -> CsrMatrix<f64> {
+        super::poisson_3d(n, n, n)
+    }
+}
+
+/// Build an SPD anisotropic diffusion operator with a rotated principal axis.
+///
+/// The diffusion tensor is `R diag(1, eps) Rᵀ` with rotation angle `theta`.
+/// The discretisation uses a nine-point stencil so that cross-derivative terms
+/// are represented explicitly; the diagonal entry is chosen to preserve row
+/// sum symmetry so the matrix remains SPD.
+pub fn anisotropic_poisson_2d(n: usize, theta: f64, eps: f64) -> CsrMatrix<f64> {
+    assert!(n > 1, "grid must be at least 2 × 2");
+    let nx = n;
+    let ny = n;
+    let mut row_ptr = Vec::with_capacity(nx * ny + 1);
+    let mut col_idx = Vec::new();
+    let mut vals = Vec::new();
+    row_ptr.push(0);
+
+    let c = theta.cos();
+    let s = theta.sin();
+    let d11 = c * c + eps * s * s;
+    let d22 = s * s + eps * c * c;
+    let d12 = (1.0 - eps) * s * c;
+
+    let mut push_entry = |i: usize, j: usize, v: f64| {
+        col_idx.push(j);
+        vals.push(v);
+    };
+
+    for y in 0..ny {
+        for x in 0..nx {
+            let idx = y * nx + x;
+            let mut diag = 0.0;
+
+            // West/East diffusion
+            if x > 0 {
+                push_entry(idx, idx - 1, -d11);
+                diag += d11;
+            }
+            if x + 1 < nx {
+                push_entry(idx, idx + 1, -d11);
+                diag += d11;
+            }
+
+            // South/North diffusion
+            if y > 0 {
+                push_entry(idx, idx - nx, -d22);
+                diag += d22;
+            }
+            if y + 1 < ny {
+                push_entry(idx, idx + nx, -d22);
+                diag += d22;
+            }
+
+            // Cross derivatives (nine-point stencil). The discretisation uses
+            // the symmetric form so that opposite corners receive opposite
+            // signs which keeps the assembled matrix SPD for eps > 0.
+            if x > 0 && y > 0 {
+                push_entry(idx, idx - nx - 1, -d12);
+                diag += d12.abs();
+            }
+            if x > 0 && y + 1 < ny {
+                push_entry(idx, idx + nx - 1, d12);
+                diag += d12.abs();
+            }
+            if x + 1 < nx && y > 0 {
+                push_entry(idx, idx - nx + 1, d12);
+                diag += d12.abs();
+            }
+            if x + 1 < nx && y + 1 < ny {
+                push_entry(idx, idx + nx + 1, -d12);
+                diag += d12.abs();
+            }
+
+            push_entry(idx, idx, diag);
+            row_ptr.push(col_idx.len());
+        }
+    }
+
+    CsrMatrix::from_csr(nx * ny, nx * ny, row_ptr, col_idx, vals)
+}
+
+/// Build a non-symmetric convection–diffusion operator on an `n × n` grid.
+///
+/// The diffusion part is the standard 5-point Laplacian, while the
+/// convection term uses a simple upwind bias controlled by the Peclet number.
+pub fn convection_diffusion_2d(n: usize, peclet: f64) -> CsrMatrix<f64> {
+    assert!(n > 1, "grid must be at least 2 × 2");
+    let nx = n;
+    let ny = n;
+    let mut row_ptr = Vec::with_capacity(nx * ny + 1);
+    let mut col_idx = Vec::new();
+    let mut vals = Vec::new();
+    row_ptr.push(0);
+
+    let upwind = 0.5 * peclet;
+
+    let mut push_entry = |i: usize, j: usize, v: f64| {
+        col_idx.push(j);
+        vals.push(v);
+    };
+
+    for y in 0..ny {
+        for x in 0..nx {
+            let idx = y * nx + x;
+            let mut diag = 4.0;
+
+            if x > 0 {
+                push_entry(idx, idx - 1, -1.0 - upwind);
+                diag += 1.0 + upwind;
+            }
+            if x + 1 < nx {
+                push_entry(idx, idx + 1, -1.0 + upwind);
+                diag += 1.0 - upwind;
+            }
+            if y > 0 {
+                push_entry(idx, idx - nx, -1.0 - upwind);
+                diag += 1.0 + upwind;
+            }
+            if y + 1 < ny {
+                push_entry(idx, idx + nx, -1.0 + upwind);
+                diag += 1.0 - upwind;
+            }
+
+            push_entry(idx, idx, diag);
+            row_ptr.push(col_idx.len());
+        }
+    }
+
+    CsrMatrix::from_csr(nx * ny, nx * ny, row_ptr, col_idx, vals)
+}
+
+/// Generate a reproducible random right-hand side vector of length `n` using a
+/// deterministic seed. Values lie in `[-0.5, 0.5)`.
+pub fn random_rhs(n: usize, seed: u64) -> Vec<f64> {
+    use rand::{Rng, SeedableRng};
+    let mut rng = rand::rngs::StdRng::seed_from_u64(seed);
+    (0..n).map(|_| rng.r#gen::<f64>() - 0.5).collect()
+}
+
 #[cfg(feature = "simd")]
 /// Returns the crate-wide default tuning for the SIMD SpMV plan builder.
 pub fn default_spmv_tuning() -> SpmvTuning {

--- a/src/solver/tests/aug_recycling.rs
+++ b/src/solver/tests/aug_recycling.rs
@@ -1,0 +1,38 @@
+use crate::context::ksp_context::Workspace;
+use crate::error::KError;
+use crate::parallel::{NoComm, UniverseComm};
+use crate::preconditioner::PcSide;
+use crate::solver::LinearSolver;
+use crate::solver::gmres::{AugmentationPolicy, GmresSolver};
+
+use super::util;
+
+#[test]
+fn gmres_configures_recycling_workspace() -> Result<(), KError> {
+    let mut solver = GmresSolver::new(12, 1e-8, 200);
+    solver.augmentation = AugmentationPolicy::GmresDR { k: 6 };
+    let a = util::spd_poisson2d(8);
+    let b = util::rhs_random(a.nrows(), 11);
+    let mut x = vec![0.0; a.nrows()];
+    let mut ws = Workspace::default();
+    let comm = UniverseComm::NoComm(NoComm);
+    let op: &dyn crate::matrix::op::LinOp<S = f64> = &a;
+
+    solver.solve(
+        op,
+        None,
+        &b,
+        &mut x,
+        PcSide::Left,
+        &comm,
+        None,
+        Some(&mut ws),
+    )?;
+
+    assert_eq!(ws.gmres_recycle.capacity(), 6);
+    assert!(matches!(
+        ws.gmres_recycle.policy(),
+        AugmentationPolicy::GmresDR { k } if k == 6
+    ));
+    Ok(())
+}

--- a/src/solver/tests/block_solvers.rs
+++ b/src/solver/tests/block_solvers.rs
@@ -1,0 +1,33 @@
+use crate::context::ksp_context::Workspace;
+use crate::error::KError;
+use crate::parallel::{NoComm, UniverseComm};
+use crate::preconditioner::PcSide;
+use crate::solver::LinearSolver;
+use crate::solver::block::{BlockKrylovOptions, gmres::BlockGmresSolver};
+
+#[test]
+fn block_gmres_reports_not_implemented() {
+    let mut opts = BlockKrylovOptions::default();
+    opts.block_size = 4;
+    opts.restart_blocks = 2;
+    let mut solver = BlockGmresSolver::new(opts);
+    let a = super::util::spd_poisson2d(4);
+    let b = vec![0.0; a.nrows()];
+    let mut x = vec![0.0; a.nrows()];
+    let mut ws = Workspace::default();
+    let comm = UniverseComm::NoComm(NoComm);
+    let op: &dyn crate::matrix::op::LinOp<S = f64> = &a;
+    let err = solver
+        .solve(
+            op,
+            None,
+            &b,
+            &mut x,
+            PcSide::Left,
+            &comm,
+            None,
+            Some(&mut ws),
+        )
+        .unwrap_err();
+    assert!(matches!(err, KError::NotImplemented(_)));
+}

--- a/src/solver/tests/cg_pipelined.rs
+++ b/src/solver/tests/cg_pipelined.rs
@@ -1,0 +1,65 @@
+use crate::context::ksp_context::Workspace;
+use crate::error::KError;
+use crate::parallel::{NoComm, UniverseComm};
+use crate::preconditioner::PcSide;
+use crate::preconditioner::jacobi::Jacobi;
+use crate::solver::LinearSolver;
+use crate::solver::pcg::{PcgSolver, PcgVariant};
+
+use super::util;
+
+fn solve_with_variant(
+    a: &crate::matrix::sparse::CsrMatrix<f64>,
+    b: &[f64],
+    variant: PcgVariant,
+) -> Result<(Vec<f64>, usize, f64), KError> {
+    let mut solver = PcgSolver::new(1e-10, 5_000);
+    solver.set_variant(variant);
+    let mut x = vec![0.0f64; b.len()];
+    let mut ws = Workspace::default();
+    let mut pc = Jacobi::new();
+    let op: &dyn crate::matrix::op::LinOp<S = f64> = a;
+    pc.setup(op)?;
+    let comm = UniverseComm::NoComm(NoComm);
+    let stats = solver.solve(
+        op,
+        Some(&mut pc),
+        b,
+        &mut x,
+        PcSide::Left,
+        &comm,
+        None,
+        Some(&mut ws),
+    )?;
+    let rtrue = util::true_residual_norm(op, &x, b);
+    Ok((x, stats.iterations, rtrue))
+}
+
+#[test]
+fn pcg_pipelined_matches_classic_on_spd_gallery() -> Result<(), KError> {
+    let sizes = [12usize, 16usize];
+    for &n in &sizes {
+        let a = util::spd_poisson2d(n);
+        let b = util::rhs_random(a.nrows(), 42);
+        let bnorm = util::vec_norm(&b).max(1e-32);
+
+        let (x_classic, it_classic, res_classic) = solve_with_variant(&a, &b, PcgVariant::Classic)?;
+        let (_x_pipe, it_pipe, res_pipe) = solve_with_variant(
+            &a,
+            &b,
+            PcgVariant::Pipelined {
+                replace_every: crate::solver::PCG_PIPELINED_DEFAULT_REPLACE_EVERY,
+            },
+        )?;
+
+        assert!(res_classic <= 1e-10 * bnorm + 1e-12);
+        assert!(res_pipe <= 1e-10 * bnorm + 1e-12);
+        assert!((it_classic as isize - it_pipe as isize).abs() <= 1);
+
+        // Ensure the solutions are close in norm.
+        let op: &dyn crate::matrix::op::LinOp<S = f64> = &a;
+        let r_classic = util::true_residual_norm(op, &x_classic, &b);
+        assert!(r_classic <= 1e-10 * bnorm + 1e-12);
+    }
+    Ok(())
+}

--- a/src/solver/tests/gmres_variants.rs
+++ b/src/solver/tests/gmres_variants.rs
@@ -1,0 +1,81 @@
+use crate::context::ksp_context::Workspace;
+use crate::error::KError;
+use crate::parallel::{NoComm, UniverseComm};
+use crate::preconditioner::PcSide;
+use crate::solver::LinearSolver;
+use crate::solver::gmres::{GmresSolver, GmresVariant};
+
+use super::util;
+
+fn solve_with_variant(
+    a: &crate::matrix::sparse::CsrMatrix<f64>,
+    b: &[f64],
+    variant: GmresVariant,
+    restart: usize,
+) -> Result<(Vec<f64>, usize, f64), KError> {
+    let mut solver = GmresSolver::new(restart, 1e-8, 2_000);
+    solver.set_variant(variant);
+    let mut x = vec![0.0; b.len()];
+    let mut ws = Workspace::default();
+    let op: &dyn crate::matrix::op::LinOp<S = f64> = a;
+    let comm = UniverseComm::NoComm(NoComm);
+    let stats = solver.solve(
+        op,
+        None,
+        b,
+        &mut x,
+        PcSide::Left,
+        &comm,
+        None,
+        Some(&mut ws),
+    )?;
+    let rtrue = util::true_residual_norm(op, &x, b);
+    Ok((x, stats.iterations, rtrue))
+}
+
+#[test]
+fn gmres_pipelined_tracks_classical_convergence() -> Result<(), KError> {
+    let a = util::nonsym_convdiff_2d(10, 5.0);
+    let b = util::rhs_random(a.nrows(), 7);
+    let restart = 20;
+    let bnorm = util::vec_norm(&b).max(1e-32);
+
+    let (_x_classic, it_classic, res_classic) =
+        solve_with_variant(&a, &b, GmresVariant::Classical, restart)?;
+    let (_x_pipe, it_pipe, res_pipe) =
+        solve_with_variant(&a, &b, GmresVariant::Pipelined, restart)?;
+
+    assert!(res_classic <= 1e-8 * bnorm + 1e-10);
+    assert!(res_pipe <= 1e-8 * bnorm + 1e-10);
+    assert!((it_classic as isize - it_pipe as isize).abs() as usize <= restart);
+    Ok(())
+}
+
+#[test]
+fn gmres_sstep_reports_not_implemented() {
+    let mut solver = GmresSolver::new(10, 1e-8, 100);
+    solver.set_variant(GmresVariant::SStep {
+        s: 3,
+        reorth: crate::context::ksp_context::ReorthPolicy::IfNeeded,
+        max_cond: 1e8,
+    });
+    let a = util::spd_poisson2d(6);
+    let b = vec![0.0; a.nrows()];
+    let mut x = vec![0.0; a.nrows()];
+    let mut ws = Workspace::default();
+    let comm = UniverseComm::NoComm(NoComm);
+    let op: &dyn crate::matrix::op::LinOp<S = f64> = &a;
+    let err = solver
+        .solve(
+            op,
+            None,
+            &b,
+            &mut x,
+            PcSide::Left,
+            &comm,
+            None,
+            Some(&mut ws),
+        )
+        .unwrap_err();
+    assert!(matches!(err, KError::NotImplemented(_)));
+}

--- a/src/solver/tests/mod.rs
+++ b/src/solver/tests/mod.rs
@@ -1,5 +1,50 @@
+mod aug_recycling;
 mod block_arnoldi;
+mod block_solvers;
+mod cg_pipelined;
 mod cg_side;
 mod gmres_left_right;
 mod gmres_right_z_basis;
+mod gmres_variants;
 mod gmres_workspace_reuse;
+mod stability;
+mod sync_counts;
+
+pub mod util {
+    use crate::matrix::op::LinOp;
+    use crate::matrix::sparse::CsrMatrix;
+    use crate::matrix::utils::{self, poisson};
+
+    pub fn spd_poisson2d(n: usize) -> CsrMatrix<f64> {
+        poisson::poisson_5pt_2d(n)
+    }
+
+    pub fn spd_poisson3d(n: usize) -> CsrMatrix<f64> {
+        poisson::poisson_7pt_3d(n)
+    }
+
+    pub fn rotated_anisotropy_2d(n: usize, theta: f64, eps: f64) -> CsrMatrix<f64> {
+        utils::anisotropic_poisson_2d(n, theta, eps)
+    }
+
+    pub fn nonsym_convdiff_2d(n: usize, peclet: f64) -> CsrMatrix<f64> {
+        utils::convection_diffusion_2d(n, peclet)
+    }
+
+    pub fn rhs_random(n: usize, seed: u64) -> Vec<f64> {
+        utils::random_rhs(n, seed)
+    }
+
+    pub fn vec_norm(v: &[f64]) -> f64 {
+        v.iter().map(|x| x * x).sum::<f64>().sqrt()
+    }
+
+    pub fn true_residual_norm(op: &dyn LinOp<S = f64>, x: &[f64], b: &[f64]) -> f64 {
+        let mut ax = vec![0.0; b.len()];
+        op.matvec(x, &mut ax);
+        for (ax_i, &b_i) in ax.iter_mut().zip(b) {
+            *ax_i -= b_i;
+        }
+        vec_norm(&ax)
+    }
+}

--- a/src/solver/tests/stability.rs
+++ b/src/solver/tests/stability.rs
@@ -1,0 +1,51 @@
+use crate::context::ksp_context::Workspace;
+use crate::error::KError;
+use crate::parallel::{NoComm, UniverseComm};
+use crate::preconditioner::PcSide;
+use crate::preconditioner::jacobi::Jacobi;
+use crate::solver::LinearSolver;
+use crate::solver::gmres::GmresSolver;
+use crate::solver::pcg::{PcgSolver, PcgVariant};
+
+use super::util;
+
+#[test]
+fn pipelined_cg_reports_residual_replacements() -> Result<(), KError> {
+    let a = util::rotated_anisotropy_2d(12, 0.3, 1e-2);
+    let b = util::rhs_random(a.nrows(), 21);
+    let op: &dyn crate::matrix::op::LinOp<S = f64> = &a;
+    let mut solver = PcgSolver::new(1e-8, 5_000);
+    solver.set_variant(PcgVariant::Pipelined { replace_every: 5 });
+    let mut ws = Workspace::default();
+    let mut pc = Jacobi::new();
+    pc.setup(op)?;
+    let mut x = vec![0.0; a.nrows()];
+    let comm = UniverseComm::NoComm(NoComm);
+    let stats = solver.solve(
+        op,
+        Some(&mut pc),
+        &b,
+        &mut x,
+        PcSide::Left,
+        &comm,
+        None,
+        Some(&mut ws),
+    )?;
+    assert!(stats.counters.residual_replacements > 0);
+    Ok(())
+}
+
+#[test]
+fn gmres_reorth_policy_toggle() {
+    let mut solver = GmresSolver::new(10, 1e-8, 200);
+    solver.set_reorth_policy(crate::context::ksp_context::ReorthPolicy::Always);
+    assert!(matches!(
+        solver.reorth_policy(),
+        crate::context::ksp_context::ReorthPolicy::Always
+    ));
+    solver.set_reorth_policy(crate::context::ksp_context::ReorthPolicy::Never);
+    assert!(matches!(
+        solver.reorth_policy(),
+        crate::context::ksp_context::ReorthPolicy::Never
+    ));
+}

--- a/src/solver/tests/sync_counts.rs
+++ b/src/solver/tests/sync_counts.rs
@@ -1,0 +1,70 @@
+use crate::context::ksp_context::Workspace;
+use crate::error::KError;
+use crate::parallel::{NoComm, UniverseComm};
+use crate::preconditioner::PcSide;
+use crate::preconditioner::jacobi::Jacobi;
+use crate::solver::LinearSolver;
+use crate::solver::gmres::{GmresSolver, GmresVariant};
+use crate::solver::pcg::{PcgSolver, PcgVariant};
+
+use super::util;
+
+#[test]
+fn pipelined_cg_uses_single_reduction_per_iteration() -> Result<(), KError> {
+    crate::utils::reduction::install_test_counter(true);
+    let a = util::spd_poisson2d(10);
+    let b = util::rhs_random(a.nrows(), 5);
+    let mut solver = PcgSolver::new(1e-8, 5_000);
+    solver.set_variant(PcgVariant::Pipelined { replace_every: 0 });
+    let mut ws = Workspace::default();
+    let mut pc = Jacobi::new();
+    let op: &dyn crate::matrix::op::LinOp<S = f64> = &a;
+    pc.setup(op)?;
+    let comm = UniverseComm::NoComm(NoComm);
+    let mut x = vec![0.0; a.nrows()];
+    let stats = solver.solve(
+        op,
+        Some(&mut pc),
+        &b,
+        &mut x,
+        PcSide::Left,
+        &comm,
+        None,
+        Some(&mut ws),
+    )?;
+    let counters = crate::utils::reduction::take_test_counter();
+    crate::utils::reduction::install_test_counter(false);
+    assert!((counters.allreduces as isize - stats.iterations as isize).abs() <= 2);
+    assert!(counters.allreduces >= stats.iterations.saturating_sub(1));
+    assert!(stats.counters.num_global_reductions >= stats.iterations.saturating_sub(1));
+    Ok(())
+}
+
+#[test]
+fn gmres_classic_reduction_count_within_expected_bounds() -> Result<(), KError> {
+    crate::utils::reduction::install_test_counter(true);
+    let a = util::nonsym_convdiff_2d(8, 4.0);
+    let b = util::rhs_random(a.nrows(), 17);
+    let mut solver = GmresSolver::new(12, 1e-8, 500);
+    solver.set_variant(GmresVariant::Classical);
+    let mut ws = Workspace::default();
+    let op: &dyn crate::matrix::op::LinOp<S = f64> = &a;
+    let comm = UniverseComm::NoComm(NoComm);
+    let mut x = vec![0.0; a.nrows()];
+    let stats = solver.solve(
+        op,
+        None,
+        &b,
+        &mut x,
+        PcSide::Left,
+        &comm,
+        None,
+        Some(&mut ws),
+    )?;
+    let counters = crate::utils::reduction::take_test_counter();
+    crate::utils::reduction::install_test_counter(false);
+    assert!(counters.allreduces >= stats.iterations);
+    assert!(counters.allreduces <= stats.iterations + solver.restart + 4);
+    assert!(stats.counters.num_global_reductions <= counters.allreduces + 2);
+    Ok(())
+}

--- a/src/utils/reduction.rs
+++ b/src/utils/reduction.rs
@@ -1,13 +1,51 @@
+use std::sync::Mutex;
 use std::sync::mpsc::Receiver;
 
 use crate::error::KError;
 use crate::parallel::Comm;
 #[cfg(feature = "mpi")]
 use mpi::raw::AsRaw;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use once_cell::sync::Lazy;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
 
 static WAIT_PAIR_COUNT: AtomicUsize = AtomicUsize::new(0);
 static WAIT_VEC_COUNT: AtomicUsize = AtomicUsize::new(0);
+
+/// Test-only counters that track how many global reductions were launched.
+#[derive(Clone, Debug, Default)]
+pub struct ReductionCounters {
+    /// Number of distinct allreduce operations.
+    pub allreduces: usize,
+    /// Total number of scalar entries reduced across all operations.
+    pub reduced_scalars: usize,
+}
+
+static TEST_COUNTER_ENABLED: AtomicBool = AtomicBool::new(false);
+static TEST_COUNTERS: Lazy<Mutex<ReductionCounters>> =
+    Lazy::new(|| Mutex::new(ReductionCounters::default()));
+
+fn record_reduction(len: usize) {
+    if TEST_COUNTER_ENABLED.load(Ordering::Relaxed) {
+        let mut guard = TEST_COUNTERS.lock().unwrap();
+        guard.allreduces += 1;
+        guard.reduced_scalars += len;
+    }
+}
+
+/// Enable or disable the global reduction counter used in tests.
+pub fn install_test_counter(enable: bool) {
+    TEST_COUNTER_ENABLED.store(enable, Ordering::SeqCst);
+    if !enable {
+        let mut guard = TEST_COUNTERS.lock().unwrap();
+        *guard = ReductionCounters::default();
+    }
+}
+
+/// Take the current reduction counters, resetting the stored values to zero.
+pub fn take_test_counter() -> ReductionCounters {
+    let mut guard = TEST_COUNTERS.lock().unwrap();
+    std::mem::take(&mut *guard)
+}
 
 #[inline]
 fn record_wait_pair() {
@@ -195,6 +233,7 @@ impl AllreduceOps for crate::parallel::NoComm {
         b: f64,
         _opt: &ReductOptions,
     ) -> Result<(AllreduceHandle<(f64, f64)>, (f64, f64)), KError> {
+        record_reduction(2);
         let sum = (a, b);
         Ok((AllreduceHandle::new_ready(sum), sum))
     }
@@ -204,6 +243,7 @@ impl AllreduceOps for crate::parallel::NoComm {
         data: Vec<f64>,
         _opt: &ReductOptions,
     ) -> Result<(AllreduceHandle<Vec<f64>>, Vec<f64>), KError> {
+        record_reduction(data.len());
         Ok((AllreduceHandle::new_ready(data.clone()), data))
     }
 
@@ -246,6 +286,7 @@ impl AllreduceOps for crate::parallel::rayon_comm::RayonComm {
         b: f64,
         _opt: &ReductOptions,
     ) -> Result<(AllreduceHandle<(f64, f64)>, (f64, f64)), KError> {
+        record_reduction(2);
         let (tx, rx) = std::sync::mpsc::channel();
         let local = (a, b);
         rayon::spawn_fifo(move || {
@@ -259,6 +300,7 @@ impl AllreduceOps for crate::parallel::rayon_comm::RayonComm {
         data: Vec<f64>,
         _opt: &ReductOptions,
     ) -> Result<(AllreduceHandle<Vec<f64>>, Vec<f64>), KError> {
+        record_reduction(data.len());
         let (tx, rx) = std::sync::mpsc::channel();
         let local = data.clone();
         rayon::spawn_fifo(move || {
@@ -313,6 +355,7 @@ impl AllreduceOps for crate::parallel::mpi_comm::MpiComm {
         if matches!(opt.mode, ReductMode::Deterministic) {
             return Err(KError::Unsupported("deterministic reductions"));
         }
+        record_reduction(2);
         let mut buf = vec![a, b];
         let mut req: mpi::ffi::MPI_Request = unsafe { std::mem::zeroed() };
         let rc = unsafe {
@@ -347,6 +390,7 @@ impl AllreduceOps for crate::parallel::mpi_comm::MpiComm {
         if matches!(opt.mode, ReductMode::Deterministic) {
             return Err(KError::Unsupported("deterministic reductions"));
         }
+        record_reduction(data.len());
         let mut buf = data.clone();
         let count = buf.len();
         let mut req: mpi::ffi::MPI_Request = unsafe { std::mem::zeroed() };


### PR DESCRIPTION
## Summary
- add focused solver regression tests covering pipelined PCG/GMRES, recycling hooks, and reduction counters
- expose reduction-count instrumentation utilities and lightweight matrix gallery builders to support the tests
- document latency-aware options, add a block-vs-panel benchmark, and extend CI with a bench smoke job

## Testing
- ⚠️ `cargo test --lib` *(aborted: build time exceeded sandbox limits)*

------
https://chatgpt.com/codex/tasks/task_e_68da10d72fd88329a24d94ad760d3871