### PR TITLE
feat: add scalar abstraction and update spmv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -973,6 +973,7 @@ dependencies = [
  "iai-callgrind",
  "log",
  "mpi",
+ "num-complex",
  "num-traits",
  "num_cpus",
  "once_cell",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,7 @@ parking_lot = { version = "0.12", optional = true }
 oorandom = "11"
 wide = { version = "0.7", optional = true }
 rand_distr = "0.4"
-rand = "0.8"
+num-complex = { version = "0.4", optional = true }
 
 [dev-dependencies]
 approx = "0.5"
@@ -79,6 +79,7 @@ mat-values-fingerprint = []
 
 # Optional, OFF by default, so new PCs must target the modern trait.
 legacy-pc-bridge = []
+complex = ["dep:num-complex"]
 
 [[example]]
 name = "mpi_amg_gmres_demo"

--- a/src/algebra/blas.rs
+++ b/src/algebra/blas.rs
@@ -1,23 +1,16 @@
-use super::scalar::{RealScalar, Scalar};
+use crate::algebra::scalar::{KrystScalar, R, S};
 
-/// Compute the dot product \(x^\mathrm{H} y\).
 #[inline]
-pub fn dot<S>(x: &[S], y: &[S]) -> S
-where
-    S: Scalar,
-{
+pub fn dot_conj(x: &[S], y: &[S]) -> S {
+    debug_assert_eq!(x.len(), y.len());
     let mut acc = S::zero();
     for i in 0..x.len() {
-        acc = acc + x[i].conj() * y[i];
+        acc = x[i].conj().mul_add(y[i], acc);
     }
     acc
 }
 
-/// Compute the Euclidean norm of a vector.
 #[inline]
-pub fn nrm2<S>(x: &[S]) -> <S as Scalar>::Real
-where
-    S: Scalar,
-{
-    dot(x, x).real().sqrt()
+pub fn nrm2(x: &[S]) -> R {
+    dot_conj(x, x).abs().sqrt()
 }

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -3,4 +3,4 @@
 pub mod blas;
 pub mod scalar;
 
-pub use scalar::{RealScalar, Scalar};
+pub use scalar::{KrystScalar, R, S};

--- a/src/algebra/scalar.rs
+++ b/src/algebra/scalar.rs
@@ -1,12 +1,116 @@
 use core::fmt::Debug;
 use core::ops::{Add, Div, Mul, Sub};
+#[cfg(feature = "complex")]
+use num_complex::Complex64;
 
-/// Trait for real scalar types used for magnitudes and comparisons.
+/// Scalar abstraction used throughout the crate.
 ///
-/// This trait intentionally mirrors only the operations required by the
-/// algorithms in this crate and is kept separate from `num_traits::Float`
-/// so that complex support can be added without relying on external trait
-/// hierarchies.
+/// Implementations should remain lightweight so the compiler can inline
+/// aggressively in hot loops. The associated `Real` type corresponds to the
+/// magnitude field for the scalar (always `f64` for the supported types).
+pub trait KrystScalar: Copy + Send + Sync + 'static {
+    type Real: Copy + Send + Sync + 'static;
+
+    fn zero() -> Self;
+    fn one() -> Self;
+
+    fn abs(self) -> Self::Real;
+    fn conj(self) -> Self;
+    fn inv(self) -> Self;
+    fn is_finite(self) -> bool;
+
+    fn mul_add(self, a: Self, b: Self) -> Self;
+}
+
+impl KrystScalar for f64 {
+    type Real = f64;
+
+    #[inline]
+    fn zero() -> Self {
+        0.0
+    }
+
+    #[inline]
+    fn one() -> Self {
+        1.0
+    }
+
+    #[inline]
+    fn abs(self) -> Self::Real {
+        self.abs()
+    }
+
+    #[inline]
+    fn conj(self) -> Self {
+        self
+    }
+
+    #[inline]
+    fn inv(self) -> Self {
+        1.0 / self
+    }
+
+    #[inline]
+    fn is_finite(self) -> bool {
+        self.is_finite()
+    }
+
+    #[inline]
+    fn mul_add(self, a: Self, b: Self) -> Self {
+        self * a + b
+    }
+}
+
+#[cfg(feature = "complex")]
+impl KrystScalar for Complex64 {
+    type Real = f64;
+
+    #[inline]
+    fn zero() -> Self {
+        Complex64::new(0.0, 0.0)
+    }
+
+    #[inline]
+    fn one() -> Self {
+        Complex64::new(1.0, 0.0)
+    }
+
+    #[inline]
+    fn abs(self) -> Self::Real {
+        self.norm()
+    }
+
+    #[inline]
+    fn conj(self) -> Self {
+        let Complex64 { re, im } = self;
+        Complex64::new(re, -im)
+    }
+
+    #[inline]
+    fn inv(self) -> Self {
+        let Complex64 { re, im } = self;
+        let denom = re * re + im * im;
+        Complex64::new(re / denom, -im / denom)
+    }
+
+    #[inline]
+    fn is_finite(self) -> bool {
+        self.re.is_finite() && self.im.is_finite()
+    }
+
+    #[inline]
+    fn mul_add(self, a: Self, b: Self) -> Self {
+        self * a + b
+    }
+}
+
+#[cfg(feature = "complex")]
+pub type S = Complex64;
+#[cfg(not(feature = "complex"))]
+pub type S = f64;
+
+pub type R = <S as KrystScalar>::Real;
+
 pub trait RealScalar:
     Copy
     + Send
@@ -25,16 +129,12 @@ pub trait RealScalar:
     fn is_finite(self) -> bool;
     fn from_f64(x: f64) -> Self;
     fn sqrt(self) -> Self;
-    /// Absolute value. For non-negative types, this is the identity.
     fn abs(self) -> Self;
 }
 
-/// Trait for scalar types, potentially complex, that algorithms operate on.
-///
-/// Every scalar has an associated real type used for magnitudes and
-/// comparisons.
 pub trait Scalar:
-    Copy
+    KrystScalar<Real = f64>
+    + Copy
     + Send
     + Sync
     + 'static
@@ -43,15 +143,8 @@ pub trait Scalar:
     + Mul<Output = Self>
     + Div<Output = Self>
 {
-    type Real: RealScalar;
-
-    fn zero() -> Self;
-    fn one() -> Self;
-    fn conj(self) -> Self;
-    fn abs(self) -> Self::Real;
-    fn is_finite(self) -> bool;
-    fn from_real(x: Self::Real) -> Self;
-    fn real(self) -> Self::Real;
+    fn from_real(x: <Self as KrystScalar>::Real) -> Self;
+    fn real(self) -> <Self as KrystScalar>::Real;
 }
 
 impl RealScalar for f64 {
@@ -59,68 +152,59 @@ impl RealScalar for f64 {
     fn zero() -> Self {
         0.0
     }
+
     #[inline]
     fn one() -> Self {
         1.0
     }
+
     #[inline]
     fn epsilon() -> Self {
         f64::EPSILON
     }
+
     #[inline]
     fn is_finite(self) -> bool {
-        f64::is_finite(self)
+        self.is_finite()
     }
+
     #[inline]
     fn from_f64(x: f64) -> Self {
         x
     }
+
     #[inline]
     fn sqrt(self) -> Self {
-        f64::sqrt(self)
+        self.sqrt()
     }
+
     #[inline]
     fn abs(self) -> Self {
-        f64::abs(self)
+        self.abs()
     }
 }
 
 impl Scalar for f64 {
-    type Real = f64;
     #[inline]
-    fn zero() -> Self {
-        0.0
-    }
-    #[inline]
-    fn one() -> Self {
-        1.0
-    }
-    #[inline]
-    fn conj(self) -> Self {
-        self
-    }
-    #[inline]
-    fn abs(self) -> Self::Real {
-        f64::abs(self)
-    }
-    #[inline]
-    fn is_finite(self) -> bool {
-        f64::is_finite(self)
-    }
-    #[inline]
-    fn from_real(x: Self::Real) -> Self {
+    fn from_real(x: <Self as KrystScalar>::Real) -> Self {
         x
     }
+
     #[inline]
-    fn real(self) -> Self::Real {
+    fn real(self) -> <Self as KrystScalar>::Real {
         self
     }
 }
 
-pub trait RealField: private::Sealed + Copy + 'static {}
-impl RealField for f64 {}
+#[cfg(feature = "complex")]
+impl Scalar for Complex64 {
+    #[inline]
+    fn from_real(x: <Self as KrystScalar>::Real) -> Self {
+        Complex64::new(x, 0.0)
+    }
 
-mod private {
-    pub trait Sealed {}
-    impl Sealed for f64 {}
+    #[inline]
+    fn real(self) -> <Self as KrystScalar>::Real {
+        self.re
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,6 +19,11 @@
 //! (default [`crate::parallel::threads::DEFAULT_PAR_CUTOFF`]). Control the pool
 //! size with `KRYST_THREADS` or `RAYON_NUM_THREADS`. See
 //! [`crate::parallel::threads`] for details.
+//!
+//! ### Scalars
+//! Internal linear algebra now operates on a crate-wide scalar alias `S`.
+//! The default build keeps `S = f64`, while enabling the `complex` feature
+//! switches to `Complex64` without changing public solver interfaces.
 
 pub mod parallel;
 

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -22,6 +22,11 @@ pub use convert::{
 pub use csc::CscMatrix;
 pub use sparse::CsrMatrix;
 
+use crate::algebra::scalar::S;
+
+pub type Csr = crate::matrix::sparse::CsrMatrix<S>;
+pub type Csc = crate::matrix::csc::CscMatrix<S>;
+
 pub use dist_csr::DistCsrOp;
 pub use op::{ChangeIds, CsrOp, DenseOp, LinOp, StructureId, ValuesId};
 pub use op_shell::MatShell;

--- a/src/matrix/spmv/scalar.rs
+++ b/src/matrix/spmv/scalar.rs
@@ -1,5 +1,7 @@
 //! Scalar sparse matrix-vector multiplication kernels.
 
+use crate::algebra::scalar::{KrystScalar, S};
+
 /// Computes `y = alpha * A * x + beta * y` for a matrix stored in CSR format.
 ///
 /// This is the baseline SpMV kernel and remains the reference implementation
@@ -11,11 +13,11 @@ pub fn spmv_scaled_csr(
     m: usize,
     row_ptr: &[usize],
     col_idx: &[usize],
-    vals: &[f64],
-    alpha: f64,
-    x: &[f64],
-    beta: f64,
-    y: &mut [f64],
+    vals: &[S],
+    alpha: S,
+    x: &[S],
+    beta: S,
+    y: &mut [S],
 ) {
     assert_eq!(row_ptr.len(), m + 1);
     assert_eq!(col_idx.len(), vals.len());
@@ -24,29 +26,29 @@ pub fn spmv_scaled_csr(
     }
     assert!(y.len() >= m);
 
-    if beta == 0.0 {
-        y[..m].fill(0.0);
-    } else if beta != 1.0 {
+    if beta == S::zero() {
+        y[..m].fill(S::zero());
+    } else if beta != S::one() {
         for yi in &mut y[..m] {
             *yi *= beta;
         }
     }
 
     for i in 0..m {
-        let mut acc = 0.0f64;
+        let mut acc = S::zero();
         let mut p = row_ptr[i];
         let end = row_ptr[i + 1];
 
         while p + 3 < end {
-            acc += vals[p] * x[col_idx[p]]
-                + vals[p + 1] * x[col_idx[p + 1]]
-                + vals[p + 2] * x[col_idx[p + 2]]
-                + vals[p + 3] * x[col_idx[p + 3]];
+            acc = vals[p].mul_add(x[col_idx[p]], acc);
+            acc = vals[p + 1].mul_add(x[col_idx[p + 1]], acc);
+            acc = vals[p + 2].mul_add(x[col_idx[p + 2]], acc);
+            acc = vals[p + 3].mul_add(x[col_idx[p + 3]], acc);
             p += 4;
         }
 
         while p < end {
-            acc += vals[p] * x[col_idx[p]];
+            acc = vals[p].mul_add(x[col_idx[p]], acc);
             p += 1;
         }
 
@@ -59,18 +61,18 @@ pub fn spmv_t_scaled_csr(
     m: usize,
     row_ptr: &[usize],
     col_idx: &[usize],
-    vals: &[f64],
-    alpha: f64,
-    x: &[f64],
-    beta: f64,
-    y: &mut [f64],
+    vals: &[S],
+    alpha: S,
+    x: &[S],
+    beta: S,
+    y: &mut [S],
 ) {
     assert_eq!(row_ptr.len(), m + 1);
     assert!(col_idx.len() == vals.len());
 
-    if beta == 0.0 {
-        y.fill(0.0);
-    } else if beta != 1.0 {
+    if beta == S::zero() {
+        y.fill(S::zero());
+    } else if beta != S::one() {
         for yi in y.iter_mut() {
             *yi *= beta;
         }
@@ -78,7 +80,7 @@ pub fn spmv_t_scaled_csr(
 
     for i in 0..m {
         let xi = x[i];
-        if xi == 0.0 {
+        if xi == S::zero() {
             continue;
         }
         let rs = row_ptr[i];


### PR DESCRIPTION
## Summary
- add a lightweight `KrystScalar` facade with a crate-wide scalar alias and optional complex feature wiring
- update BLAS helpers and CSR SpMV kernels to operate on the shared scalar alias
- document the new scalar abstraction in the crate docs

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68ddd75ee2648329bf0dbd76c3b8b08d