### PR TITLE
Add scalar bridge adapters for matvec and preconditioner

### DIFF
--- a/src/algebra/blas.rs
+++ b/src/algebra/blas.rs
@@ -1,4 +1,5 @@
-use crate::algebra::scalar::{KrystScalar, R, S};
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 
 #[inline]
 pub fn dot_conj(x: &[S], y: &[S]) -> S {

--- a/src/algebra/bridge.rs
+++ b/src/algebra/bridge.rs
@@ -1,0 +1,65 @@
+use crate::algebra::prelude::*;
+use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
+
+/// Temporary buffers reused by solver bridges when converting between `S` and `f64`.
+#[derive(Default, Clone, Debug)]
+pub struct BridgeScratch {
+    xr: Vec<f64>,
+    yr: Vec<f64>,
+    xs: Vec<S>,
+    ys: Vec<S>,
+}
+
+impl BridgeScratch {
+    fn ensure(&mut self, n: usize) {
+        if self.xr.len() < n {
+            self.xr.resize(n, 0.0);
+        }
+        if self.yr.len() < n {
+            self.yr.resize(n, 0.0);
+        }
+        if self.xs.len() < n {
+            self.xs.resize(n, S::zero());
+        }
+        if self.ys.len() < n {
+            self.ys.resize(n, S::zero());
+        }
+    }
+
+    #[inline]
+    pub fn xr(&mut self, n: usize) -> &mut [f64] {
+        self.ensure(n);
+        &mut self.xr[..n]
+    }
+
+    #[inline]
+    pub fn yr(&mut self, n: usize) -> &mut [f64] {
+        self.ensure(n);
+        &mut self.yr[..n]
+    }
+
+    #[inline]
+    pub fn xs(&mut self, n: usize) -> &mut [S] {
+        self.ensure(n);
+        &mut self.xs[..n]
+    }
+
+    #[inline]
+    pub fn ys(&mut self, n: usize) -> &mut [S] {
+        self.ensure(n);
+        &mut self.ys[..n]
+    }
+
+    #[inline]
+    pub fn copy_scalar_into_real(&mut self, src: &[S]) -> &mut [f64] {
+        let n = src.len();
+        let dst = self.xr(n);
+        copy_scalar_to_real_in(src, dst);
+        dst
+    }
+
+    #[inline]
+    pub fn copy_real_into_scalar(&mut self, src: &[f64], dst: &mut [S]) {
+        copy_real_to_scalar_in(src, dst);
+    }
+}

--- a/src/algebra/mod.rs
+++ b/src/algebra/mod.rs
@@ -1,6 +1,8 @@
 //! Basic numeric traits and operations used throughout the crate.
 
 pub mod blas;
+pub mod bridge;
+pub mod prelude;
 pub mod scalar;
 
 pub use scalar::{KrystScalar, R, S};

--- a/src/algebra/prelude.rs
+++ b/src/algebra/prelude.rs
@@ -1,0 +1,4 @@
+//! Bring scalar aliases and `KrystScalar` into scope in one shot.
+//! Usage in modules: `use crate::algebra::prelude::*;`
+
+pub use super::scalar::{KrystScalar, R, S};

--- a/src/algebra/scalar.rs
+++ b/src/algebra/scalar.rs
@@ -1,26 +1,61 @@
-use core::fmt::Debug;
-use core::ops::{Add, Div, Mul, Sub};
+#![allow(clippy::excessive_precision)]
+
+use core::ops::{Add, Div, Mul, Neg, Sub};
+
 #[cfg(feature = "complex")]
 use num_complex::Complex64;
 
-/// Scalar abstraction used throughout the crate.
-///
-/// Implementations should remain lightweight so the compiler can inline
-/// aggressively in hot loops. The associated `Real` type corresponds to the
-/// magnitude field for the scalar (always `f64` for the supported types).
-pub trait KrystScalar: Copy + Send + Sync + 'static {
-    type Real: Copy + Send + Sync + 'static;
+/// Scalar abstraction used internally by kryst.  The goal is to
+/// keep the public API monomorphic (f64), while the internals use `S`.
+pub trait KrystScalar:
+    Copy
+    + Clone
+    + Send
+    + Sync
+    + 'static
+    + Default
+    + PartialEq
+    + Add<Output = Self>
+    + Sub<Output = Self>
+    + Mul<Output = Self>
+    + Div<Output = Self>
+    + Neg<Output = Self>
+{
+    /// The corresponding real type (always `f64` for now).
+    type Real: Copy
+        + Clone
+        + Send
+        + Sync
+        + 'static
+        + Default
+        + PartialEq
+        + PartialOrd
+        + Add<Output = Self::Real>
+        + Sub<Output = Self::Real>
+        + Mul<Output = Self::Real>
+        + Div<Output = Self::Real>;
 
+    // Constructors / constants
     fn zero() -> Self;
     fn one() -> Self;
 
-    fn abs(self) -> Self::Real;
-    fn conj(self) -> Self;
-    fn inv(self) -> Self;
+    /// Convert from a real (`f64`) to this scalar type.
+    fn from_real(x: Self::Real) -> Self;
+
+    /// Extract the real part (identity for real, `.re` for complex).
+    fn real(self) -> Self::Real;
+
+    // Basic ops we need everywhere
+    fn abs(self) -> Self::Real; // |z| for complex, |x| for real
+    fn conj(self) -> Self; // identity for real
+    fn inv(self) -> Self; // 1/self (caller ensures nonzero)
     fn is_finite(self) -> bool;
 
+    /// Fused multiply-add.  For `f64` we use HW FMA; for complex we fall back.
     fn mul_add(self, a: Self, b: Self) -> Self;
 }
+
+// ==================== Implementations ====================
 
 impl KrystScalar for f64 {
     type Real = f64;
@@ -36,8 +71,18 @@ impl KrystScalar for f64 {
     }
 
     #[inline]
+    fn from_real(x: Self::Real) -> Self {
+        x
+    }
+
+    #[inline]
+    fn real(self) -> Self::Real {
+        self
+    }
+
+    #[inline]
     fn abs(self) -> Self::Real {
-        self.abs()
+        f64::abs(self)
     }
 
     #[inline]
@@ -52,12 +97,12 @@ impl KrystScalar for f64 {
 
     #[inline]
     fn is_finite(self) -> bool {
-        self.is_finite()
+        f64::is_finite(self)
     }
 
     #[inline]
     fn mul_add(self, a: Self, b: Self) -> Self {
-        self * a + b
+        f64::mul_add(self, a, b)
     }
 }
 
@@ -76,21 +121,29 @@ impl KrystScalar for Complex64 {
     }
 
     #[inline]
+    fn from_real(x: Self::Real) -> Self {
+        Complex64::new(x, 0.0)
+    }
+
+    #[inline]
+    fn real(self) -> Self::Real {
+        self.re
+    }
+
+    #[inline]
     fn abs(self) -> Self::Real {
         self.norm()
     }
 
     #[inline]
     fn conj(self) -> Self {
-        let Complex64 { re, im } = self;
-        Complex64::new(re, -im)
+        Complex64::new(self.re, -self.im)
     }
 
     #[inline]
     fn inv(self) -> Self {
-        let Complex64 { re, im } = self;
-        let denom = re * re + im * im;
-        Complex64::new(re / denom, -im / denom)
+        let n2 = self.re * self.re + self.im * self.im;
+        Complex64::new(self.re / n2, -self.im / n2)
     }
 
     #[inline]
@@ -104,107 +157,54 @@ impl KrystScalar for Complex64 {
     }
 }
 
+// ==================== Feature-gated scalar choice ====================
+
 #[cfg(feature = "complex")]
 pub type S = Complex64;
 #[cfg(not(feature = "complex"))]
 pub type S = f64;
 
+/// Real partner of `S` (currently always `f64`)
 pub type R = <S as KrystScalar>::Real;
 
-pub trait RealScalar:
-    Copy
-    + Send
-    + Sync
-    + 'static
-    + PartialOrd
-    + Debug
-    + Add<Output = Self>
-    + Sub<Output = Self>
-    + Mul<Output = Self>
-    + Div<Output = Self>
-{
-    fn zero() -> Self;
-    fn one() -> Self;
-    fn epsilon() -> Self;
-    fn is_finite(self) -> bool;
-    fn from_f64(x: f64) -> Self;
-    fn sqrt(self) -> Self;
-    fn abs(self) -> Self;
-}
-
-pub trait Scalar:
-    KrystScalar<Real = f64>
-    + Copy
-    + Send
-    + Sync
-    + 'static
-    + Add<Output = Self>
-    + Sub<Output = Self>
-    + Mul<Output = Self>
-    + Div<Output = Self>
-{
-    fn from_real(x: <Self as KrystScalar>::Real) -> Self;
-    fn real(self) -> <Self as KrystScalar>::Real;
-}
-
-impl RealScalar for f64 {
-    #[inline]
-    fn zero() -> Self {
-        0.0
-    }
-
-    #[inline]
-    fn one() -> Self {
-        1.0
-    }
-
-    #[inline]
-    fn epsilon() -> Self {
-        f64::EPSILON
-    }
-
-    #[inline]
-    fn is_finite(self) -> bool {
-        self.is_finite()
-    }
-
-    #[inline]
-    fn from_f64(x: f64) -> Self {
-        x
-    }
-
-    #[inline]
-    fn sqrt(self) -> Self {
-        self.sqrt()
-    }
-
-    #[inline]
-    fn abs(self) -> Self {
-        self.abs()
-    }
-}
-
-impl Scalar for f64 {
-    #[inline]
-    fn from_real(x: <Self as KrystScalar>::Real) -> Self {
-        x
-    }
-
-    #[inline]
-    fn real(self) -> <Self as KrystScalar>::Real {
-        self
+#[cfg(feature = "complex")]
+#[inline]
+pub fn copy_scalar_to_real_in(z: &[S], out: &mut [f64]) {
+    debug_assert_eq!(z.len(), out.len());
+    for (dst, &src) in out.iter_mut().zip(z.iter()) {
+        *dst = src.real();
     }
 }
 
 #[cfg(feature = "complex")]
-impl Scalar for Complex64 {
-    #[inline]
-    fn from_real(x: <Self as KrystScalar>::Real) -> Self {
-        Complex64::new(x, 0.0)
+#[inline]
+pub fn copy_real_to_scalar_in(x: &[f64], out: &mut [S]) {
+    debug_assert_eq!(x.len(), out.len());
+    for (dst, &src) in out.iter_mut().zip(x.iter()) {
+        *dst = S::from_real(src);
     }
+}
 
-    #[inline]
-    fn real(self) -> <Self as KrystScalar>::Real {
-        self.re
+#[cfg(not(feature = "complex"))]
+#[inline]
+pub fn copy_scalar_to_real_in(z: &[S], out: &mut [f64]) {
+    debug_assert_eq!(z.len(), out.len());
+    if core::ptr::eq(z.as_ptr() as *const f64, out.as_ptr()) {
+        return;
     }
+    // SAFETY: when the complex feature is disabled we have S == f64.
+    let z_as_f64: &[f64] = unsafe { &*(z as *const [S] as *const [f64]) };
+    out.copy_from_slice(z_as_f64);
+}
+
+#[cfg(not(feature = "complex"))]
+#[inline]
+pub fn copy_real_to_scalar_in(x: &[f64], out: &mut [S]) {
+    debug_assert_eq!(x.len(), out.len());
+    if core::ptr::eq(x.as_ptr(), out.as_ptr() as *const f64) {
+        return;
+    }
+    // SAFETY: when the complex feature is disabled we have S == f64.
+    let out_as_f64: &mut [f64] = unsafe { &mut *(out as *mut [S] as *mut [f64]) };
+    out_as_f64.copy_from_slice(x);
 }

--- a/src/context/ksp_context/workspace.rs
+++ b/src/context/ksp_context/workspace.rs
@@ -1,4 +1,6 @@
-use crate::algebra::scalar::{KrystScalar, S};
+use crate::algebra::bridge::BridgeScratch;
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::core::block::BlockVec;
 use crate::solver::gmres::AugmentationPolicy;
 
@@ -7,6 +9,9 @@ pub struct Workspace {
     pub tmp1: Vec<S>,
     pub tmp2: Vec<S>,
     // Legacy buffers for solvers not yet migrated
+    pub q_s: Vec<Vec<S>>,
+    pub z_s: Vec<Vec<S>>,
+    pub h_s: Vec<Vec<S>>,
     pub q: Vec<Vec<f64>>,
     pub z: Vec<Vec<f64>>,
     pub h: Vec<Vec<f64>>,
@@ -18,6 +23,8 @@ pub struct Workspace {
     pub sn: Vec<f64>,
     pub g: Vec<S>,
     pub blk_scratch: Vec<S>,
+    pub bridge: BridgeScratch,
+    pub bridge_tmp: Vec<S>,
     pub block_buf: Option<BlockVec>,
     pub tsqr: Option<TsqrWorkspace>,
     pub pipelined_w: Vec<S>,

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -8,6 +8,7 @@ pub mod dist_csr;
 pub mod format;
 mod format_impls;
 pub mod op;
+pub mod op_bridge;
 pub mod op_shell;
 pub mod parcsr;
 pub mod sparse;
@@ -22,7 +23,8 @@ pub use convert::{
 pub use csc::CscMatrix;
 pub use sparse::CsrMatrix;
 
-use crate::algebra::scalar::S;
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 
 pub type Csr = crate::matrix::sparse::CsrMatrix<S>;
 pub type Csc = crate::matrix::csc::CscMatrix<S>;

--- a/src/matrix/op_bridge.rs
+++ b/src/matrix/op_bridge.rs
@@ -1,0 +1,30 @@
+use crate::algebra::bridge::BridgeScratch;
+use crate::algebra::prelude::*;
+#[cfg(feature = "complex")]
+use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
+use crate::matrix::op::LinOp;
+
+#[inline]
+pub fn matvec_s(a: &dyn LinOp<S = f64>, x: &[S], y: &mut [S], scratch: &mut BridgeScratch) {
+    debug_assert_eq!(x.len(), y.len());
+
+    #[cfg(not(feature = "complex"))]
+    {
+        let _ = scratch;
+        // SAFETY: when the complex feature is disabled we have S == f64.
+        let x_r: &[f64] = unsafe { &*(x as *const [S] as *const [f64]) };
+        let y_r: &mut [f64] = unsafe { &mut *(y as *mut [S] as *mut [f64]) };
+        a.matvec(x_r, y_r);
+        return;
+    }
+
+    #[cfg(feature = "complex")]
+    {
+        let n = x.len();
+        let xr = scratch.xr(n);
+        let yr = scratch.yr(n);
+        copy_scalar_to_real_in(x, xr);
+        a.matvec(xr, yr);
+        copy_real_to_scalar_in(yr, y);
+    }
+}

--- a/src/matrix/spmv/scalar.rs
+++ b/src/matrix/spmv/scalar.rs
@@ -1,6 +1,7 @@
 //! Scalar sparse matrix-vector multiplication kernels.
 
-use crate::algebra::scalar::{KrystScalar, S};
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 
 /// Computes `y = alpha * A * x + beta * y` for a matrix stored in CSR format.
 ///

--- a/src/preconditioner/bridge.rs
+++ b/src/preconditioner/bridge.rs
@@ -1,0 +1,37 @@
+use crate::algebra::bridge::BridgeScratch;
+use crate::algebra::prelude::*;
+#[cfg(feature = "complex")]
+use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
+use crate::error::KError;
+use crate::preconditioner::{PcSide, Preconditioner};
+
+#[inline]
+pub fn apply_pc_s(
+    pc: &dyn Preconditioner,
+    side: PcSide,
+    x: &[S],
+    y: &mut [S],
+    scratch: &mut BridgeScratch,
+) -> Result<(), KError> {
+    debug_assert_eq!(x.len(), y.len());
+
+    #[cfg(not(feature = "complex"))]
+    {
+        let _ = scratch;
+        // SAFETY: when the complex feature is disabled we have S == f64.
+        let x_r: &[f64] = unsafe { &*(x as *const [S] as *const [f64]) };
+        let y_r: &mut [f64] = unsafe { &mut *(y as *mut [S] as *mut [f64]) };
+        return pc.apply(side, x_r, y_r);
+    }
+
+    #[cfg(feature = "complex")]
+    {
+        let n = x.len();
+        let xr = scratch.xr(n);
+        let yr = scratch.yr(n);
+        copy_scalar_to_real_in(x, xr);
+        pc.apply(side, xr, yr)?;
+        copy_real_to_scalar_in(yr, y);
+        Ok(())
+    }
+}

--- a/src/preconditioner/ilu_csr/csr_builder.rs
+++ b/src/preconditioner/ilu_csr/csr_builder.rs
@@ -1,4 +1,5 @@
-use crate::algebra::scalar::Scalar;
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use num_traits::Zero;
 use std::cmp::Reverse;
 use std::collections::BinaryHeap;
@@ -96,7 +97,7 @@ pub enum Meta<R> {
 }
 
 /// Trait for building a single sparse row under a given ILU policy.
-pub trait RowBuilder<S: Scalar> {
+pub trait RowBuilder<S: KrystScalar> {
     /// Reset the builder for a new row without allocating.
     fn clear(&mut self);
     /// Update an existing column value. The column is guaranteed to be present
@@ -116,13 +117,13 @@ pub struct Ilu0Row<'a, S> {
     vals: &'a mut [S],
 }
 
-impl<'a, S: Scalar> Ilu0Row<'a, S> {
+impl<'a, S: KrystScalar> Ilu0Row<'a, S> {
     pub fn new(cols: &'a [usize], vals: &'a mut [S]) -> Self {
         Self { cols, vals }
     }
 }
 
-impl<'a, S: Scalar> RowBuilder<S> for Ilu0Row<'a, S> {
+impl<'a, S: KrystScalar> RowBuilder<S> for Ilu0Row<'a, S> {
     fn clear(&mut self) {}
 
     fn push_existing(&mut self, col: usize, val: S) {
@@ -137,7 +138,7 @@ impl<'a, S: Scalar> RowBuilder<S> for Ilu0Row<'a, S> {
 }
 
 /// ILU(k) row builder using fixed-size arrays for candidate fills.
-pub struct IlukRow<S: Scalar, const CAP: usize> {
+pub struct IlukRow<S: KrystScalar, const CAP: usize> {
     pub used: usize,
     pub max_level: u32,
     pub cand_col: [usize; CAP],
@@ -145,7 +146,7 @@ pub struct IlukRow<S: Scalar, const CAP: usize> {
     pub cand_val: [S; CAP],
 }
 
-impl<S: Scalar, const CAP: usize> IlukRow<S, CAP> {
+impl<S: KrystScalar, const CAP: usize> IlukRow<S, CAP> {
     pub fn new(max_level: u32) -> Self {
         Self {
             used: 0,
@@ -197,7 +198,7 @@ impl<S: Scalar, const CAP: usize> IlukRow<S, CAP> {
     }
 }
 
-impl<S: Scalar, const CAP: usize> RowBuilder<S> for IlukRow<S, CAP> {
+impl<S: KrystScalar, const CAP: usize> RowBuilder<S> for IlukRow<S, CAP> {
     fn clear(&mut self) {
         self.used = 0;
     }
@@ -232,40 +233,40 @@ impl<S: Scalar, const CAP: usize> RowBuilder<S> for IlukRow<S, CAP> {
 }
 
 #[derive(Clone)]
-struct HeapElem<S: Scalar> {
+struct HeapElem<S: KrystScalar> {
     mag: S::Real,
     col: usize,
     val: S,
 }
 
-impl<S: Scalar> PartialEq for HeapElem<S> {
+impl<S: KrystScalar> PartialEq for HeapElem<S> {
     fn eq(&self, other: &Self) -> bool {
         self.mag == other.mag
     }
 }
 
-impl<S: Scalar> Eq for HeapElem<S> {}
+impl<S: KrystScalar> Eq for HeapElem<S> {}
 
-impl<S: Scalar> PartialOrd for HeapElem<S> {
+impl<S: KrystScalar> PartialOrd for HeapElem<S> {
     fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
         self.mag.partial_cmp(&other.mag)
     }
 }
 
-impl<S: Scalar> Ord for HeapElem<S> {
+impl<S: KrystScalar> Ord for HeapElem<S> {
     fn cmp(&self, other: &Self) -> std::cmp::Ordering {
         self.partial_cmp(other).unwrap()
     }
 }
 
 /// ILUT row builder using a magnitude-based capped heap.
-pub struct IlutRow<S: Scalar> {
+pub struct IlutRow<S: KrystScalar> {
     p: usize,
     drop_tol: S::Real,
     heap: BinaryHeap<Reverse<HeapElem<S>>>,
 }
 
-impl<S: Scalar> IlutRow<S> {
+impl<S: KrystScalar> IlutRow<S> {
     pub fn new(p: usize, drop_tol: S::Real) -> Self {
         Self {
             p,
@@ -275,7 +276,7 @@ impl<S: Scalar> IlutRow<S> {
     }
 }
 
-impl<S: Scalar> RowBuilder<S> for IlutRow<S> {
+impl<S: KrystScalar> RowBuilder<S> for IlutRow<S> {
     fn clear(&mut self) {
         self.heap.clear();
     }

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -41,6 +41,8 @@
 use crate::error::KError;
 use crate::matrix::format::FormatHint;
 use crate::matrix::op::LinOp;
+
+pub mod bridge;
 #[cfg(feature = "legacy-pc-bridge")]
 use faer::Mat;
 use std::str::FromStr;

--- a/src/solver/cg.rs
+++ b/src/solver/cg.rs
@@ -4,6 +4,8 @@
 //! If [`PcSide`] is not `Left`, the solver returns `InvalidInput`.
 //! Residual norm is the preconditioned norm `||M^{-1} r||`; final stats include true `||r||`.
 
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -32,7 +34,7 @@ pub enum CgNormType {
 }
 
 pub struct CgSolver {
-    pub(crate) conv: Convergence<f64>,
+    pub(crate) conv: Convergence,
     norm_type: CgNormType,
     trust_region: Option<f64>,
     true_residual_monitor: Option<Box<dyn Fn(usize, f64) + Send + Sync>>,

--- a/src/solver/cgnr.rs
+++ b/src/solver/cgnr.rs
@@ -1,3 +1,5 @@
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -11,7 +13,7 @@ use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 use crate::utils::profiling::StageGuard;
 
 pub struct CgnrSolver {
-    pub(crate) conv: Convergence<f64>,
+    pub(crate) conv: Convergence,
 }
 
 impl CgnrSolver {

--- a/src/solver/cgs.rs
+++ b/src/solver/cgs.rs
@@ -8,6 +8,8 @@
 //! - Monitors report the true residual `||r||_2`.
 //! - Parallel safety: all inner products/norms use `UniverseComm`.
 
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -20,7 +22,7 @@ use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 #[cfg(feature = "logging")]
 use crate::utils::profiling::StageGuard;
 pub struct CgsSolver {
-    pub(crate) conv: Convergence<f64>,
+    pub(crate) conv: Convergence,
 }
 
 /// Relative threshold for CGS breakdown detection.

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -15,6 +15,8 @@
 //! in column-major form. The legacy `Workspace.z` (Vec<Vec<_>>) is not used by
 //! GMRES/FGMRES.
 
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::context::ksp_context::{GmresSpec, ReorthPolicy, Workspace};
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -51,7 +53,7 @@ pub enum GmresVariant {
 
 pub struct GmresSolver {
     pub restart: usize,
-    pub conv: Convergence<f64>,
+    pub conv: Convergence,
     /// Happy breakdown tolerance
     pub haptol: f64,
     /// Orthogonalization flavor (currently not altering algorithmic path)

--- a/src/solver/minres.rs
+++ b/src/solver/minres.rs
@@ -2,6 +2,8 @@
 //
 // … (header doc unchanged) …
 
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -12,7 +14,7 @@ use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 use std::any::Any;
 
 pub struct MinresSolver {
-    pub conv: Convergence<f64>, // { rtol, atol, dtol, max_iters }
+    pub conv: Convergence, // { rtol, atol, dtol, max_iters }
 }
 
 impl MinresSolver {

--- a/src/solver/pca_gmres.rs
+++ b/src/solver/pca_gmres.rs
@@ -1,10 +1,16 @@
 //! PCA-GMRES (baseline) over &dyn LinOp<f64> with left/right/no preconditioning,
 //! using disjoint slabs for V and Z, with semantics enforced by `pc_mode`.
 
+use crate::algebra::blas::{dot_conj, nrm2};
+use crate::algebra::bridge::BridgeScratch;
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
+use crate::matrix::op_bridge::matvec_s;
 use crate::parallel::UniverseComm;
+use crate::preconditioner::bridge::apply_pc_s;
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
@@ -20,7 +26,7 @@ pub struct PcaGmresSolver {
     pub restart: usize,
     pub pipeline_depth: usize, // reserved hook; baseline uses 1
     pub block_size: usize,     // reserved hook; baseline uses 1
-    pub conv: Convergence<f64>,
+    pub conv: Convergence,
     pub pc_mode: PcaPcMode,
     /// Choose MGS for better robustness; switch to CGS when s>1 (future)
     pub modified_gs: bool,
@@ -52,38 +58,29 @@ impl PcaGmresSolver {
         }
     }
 
-    #[inline]
-    fn dot(x: &[f64], y: &[f64]) -> f64 {
-        x.iter().zip(y).map(|(a, b)| a * b).sum()
-    }
-    #[inline]
-    fn nrm2(x: &[f64]) -> f64 {
-        x.iter().map(|v| v * v).sum::<f64>().sqrt()
-    }
-
     /// Workspace policy:
-    ///   - V basis in `w.q[0..=m]`
-    ///   - Z basis in `w.z[0..m-1]` (only used for Right PC)
+    ///   - V basis in `w.q_s[0..=m]`
+    ///   - Z basis in `w.z_s[0..m-1]` (only used for Right PC)
     fn ensure_workspace(&self, w: &mut Workspace, n: usize) {
         let m = self.restart;
 
         // V basis
-        if w.q.len() < m + 1 {
-            w.q.resize(m + 1, Vec::new());
+        if w.q_s.len() < m + 1 {
+            w.q_s.resize(m + 1, Vec::new());
         }
-        for v in &mut w.q[..m + 1] {
+        for v in &mut w.q_s[..m + 1] {
             if v.len() != n {
-                v.resize(n, 0.0);
+                v.resize(n, S::zero());
             }
         }
 
         // Z basis (right preconditioning only, but always size for simplicity)
-        if w.z.len() < m {
-            w.z.resize(m, Vec::new());
+        if w.z_s.len() < m {
+            w.z_s.resize(m, Vec::new());
         }
-        for z in &mut w.z[..m] {
+        for z in &mut w.z_s[..m] {
             if z.len() != n {
-                z.resize(n, 0.0);
+                z.resize(n, S::zero());
             }
         }
 
@@ -99,10 +96,10 @@ impl PcaGmresSolver {
 
         // Scalars and temporaries
         if w.tmp1.len() != n {
-            w.tmp1.resize(n, 0.0);
+            w.tmp1.resize(n, S::zero());
         }
         if w.tmp2.len() != n {
-            w.tmp2.resize(n, 0.0);
+            w.tmp2.resize(n, S::zero());
         }
         if w.cs.len() < m {
             w.cs.resize(m, 0.0);
@@ -111,7 +108,7 @@ impl PcaGmresSolver {
             w.sn.resize(m, 0.0);
         }
         if w.g.len() < m + 1 {
-            w.g.resize(m + 1, 0.0);
+            w.g.resize(m + 1, S::zero());
         }
     }
 
@@ -130,11 +127,12 @@ impl PcaGmresSolver {
     fn apply_pc(
         pc: Option<&dyn Preconditioner>,
         side: PcSide,
-        x: &[f64],
-        y: &mut [f64],
+        x: &[S],
+        y: &mut [S],
+        scratch: &mut BridgeScratch,
     ) -> Result<(), KError> {
         if let Some(p) = pc {
-            p.apply(side, x, y)
+            apply_pc_s(p, side, x, y, scratch)
         } else {
             y.copy_from_slice(x);
             Ok(())
@@ -146,15 +144,15 @@ impl PcaGmresSolver {
     /// This is the hook to fuse reductions and, later, hoist k steps for CA/pipelining.
     fn project_and_normalize(
         &self,
-        v_basis: &[Vec<f64>],
+        v_basis: &[Vec<S>],
         k: usize,
-        w: &mut [f64],
+        w: &mut [S],
         h: &mut [Vec<f64>],
-    ) -> f64 {
+    ) -> R {
         // First pass
         for i in 0..=k {
-            let hij = Self::dot(w, &v_basis[i]);
-            h[i][k] = hij;
+            let hij: S = dot_conj(&v_basis[i], w);
+            h[i][k] = hij.real();
             for (wi, &vi) in w.iter_mut().zip(&v_basis[i]) {
                 *wi -= hij * vi;
             }
@@ -162,16 +160,16 @@ impl PcaGmresSolver {
         if self.modified_gs {
             // Re-orthogonalize for robustness
             for i in 0..=k {
-                let corr = Self::dot(w, &v_basis[i]);
+                let corr: S = dot_conj(&v_basis[i], w);
                 if corr.abs() > 1e-12 {
-                    h[i][k] += corr;
+                    h[i][k] += corr.real();
                     for (wi, &vi) in w.iter_mut().zip(&v_basis[i]) {
                         *wi -= corr * vi;
                     }
                 }
             }
         }
-        Self::nrm2(w)
+        nrm2(w)
     }
 
     #[inline]
@@ -201,11 +199,11 @@ impl LinearSolver for PcaGmresSolver {
     fn setup_workspace(&mut self, w: &mut Workspace) {
         // Outline only; concrete sizes are set in solve()
         let m = self.restart;
-        if w.q.len() < m + 1 {
-            w.q.resize(m + 1, Vec::new());
+        if w.q_s.len() < m + 1 {
+            w.q_s.resize(m + 1, Vec::new());
         }
-        if w.z.len() < m {
-            w.z.resize(m, Vec::new());
+        if w.z_s.len() < m {
+            w.z_s.resize(m, Vec::new());
         }
         if w.h.len() < m + 1 {
             w.h.resize(m + 1, Vec::new());
@@ -217,7 +215,7 @@ impl LinearSolver for PcaGmresSolver {
             w.sn.resize(m, 0.0);
         }
         if w.g.len() < m + 1 {
-            w.g.resize(m + 1, 0.0);
+            w.g.resize(m + 1, S::zero());
         }
     }
 
@@ -271,49 +269,52 @@ impl LinearSolver for PcaGmresSolver {
         self.ensure_workspace(ws, n);
 
         // r = b - A x
-        a.matvec(x, &mut ws.tmp1);
+        matvec_s(a, x, &mut ws.tmp1, &mut ws.bridge);
         for i in 0..n {
-            ws.tmp1[i] = b[i] - ws.tmp1[i];
+            ws.tmp1[i] = S::from_real(b[i]) - ws.tmp1[i];
         }
 
         // Initialize v0 and g[0] according to mode
-        let beta0 = match mode {
+        let beta0: R = match mode {
             PcaPcMode::None => {
-                let beta = Self::nrm2(&ws.tmp1);
+                let beta = nrm2(&ws.tmp1);
+                let v0 = &mut ws.q_s[0][..];
                 if beta > 0.0 {
-                    let v0 = &mut ws.q[0][..];
+                    let denom = S::from_real(beta);
                     for i in 0..n {
-                        v0[i] = ws.tmp1[i] / beta;
+                        v0[i] = ws.tmp1[i] / denom;
                     }
                 } else {
-                    ws.q[0].fill(0.0);
+                    v0.fill(S::zero());
                 }
                 beta
             }
             PcaPcMode::Left => {
                 // v0 = M^{-1} r / ||M^{-1}r||
-                Self::apply_pc(pc_in, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                let beta = Self::nrm2(&ws.tmp2);
+                Self::apply_pc(pc_in, PcSide::Left, &ws.tmp1, &mut ws.tmp2, &mut ws.bridge)?;
+                let beta = nrm2(&ws.tmp2);
+                let v0 = &mut ws.q_s[0][..];
                 if beta > 0.0 {
-                    let v0 = &mut ws.q[0][..];
+                    let denom = S::from_real(beta);
                     for i in 0..n {
-                        v0[i] = ws.tmp2[i] / beta;
+                        v0[i] = ws.tmp2[i] / denom;
                     }
                 } else {
-                    ws.q[0].fill(0.0);
+                    v0.fill(S::zero());
                 }
                 beta
             }
             PcaPcMode::Right => {
                 // v0 = r / ||r||  (Arnoldi on A M^{-1})
-                let beta = Self::nrm2(&ws.tmp1);
+                let beta = nrm2(&ws.tmp1);
+                let v0 = &mut ws.q_s[0][..];
                 if beta > 0.0 {
-                    let v0 = &mut ws.q[0][..];
+                    let denom = S::from_real(beta);
                     for i in 0..n {
-                        v0[i] = ws.tmp1[i] / beta;
+                        v0[i] = ws.tmp1[i] / denom;
                     }
                 } else {
-                    ws.q[0].fill(0.0);
+                    v0.fill(S::zero());
                 }
                 beta
             }
@@ -322,10 +323,10 @@ impl LinearSolver for PcaGmresSolver {
         ws.h.iter_mut().for_each(|row| row.fill(0.0));
         ws.cs.fill(0.0);
         ws.sn.fill(0.0);
-        ws.g.fill(0.0);
-        ws.g[0] = beta0;
+        ws.g.fill(S::zero());
+        ws.g[0] = S::from_real(beta0);
 
-        let bnorm = Self::nrm2(b).max(1e-32);
+        let bnorm = b.iter().map(|&bi| bi * bi).sum::<R>().sqrt().max(1e-32);
         let thr = self.conv.atol.max(self.conv.rtol * bnorm);
 
         let mut total_iters = 0usize;
@@ -356,34 +357,41 @@ impl LinearSolver for PcaGmresSolver {
                 match mode {
                     PcaPcMode::None => {
                         // w = A v_k
-                        a.matvec(&ws.q[k], &mut ws.tmp1);
+                        matvec_s(a, &ws.q_s[k], &mut ws.tmp1, &mut ws.bridge);
                     }
                     PcaPcMode::Left => {
                         // w = M^{-1} A v_k
-                        a.matvec(&ws.q[k], &mut ws.tmp1);
-                        Self::apply_pc(pc_in, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
+                        matvec_s(a, &ws.q_s[k], &mut ws.tmp1, &mut ws.bridge);
+                        Self::apply_pc(
+                            pc_in,
+                            PcSide::Left,
+                            &ws.tmp1,
+                            &mut ws.tmp2,
+                            &mut ws.bridge,
+                        )?;
                         ws.tmp1.copy_from_slice(&ws.tmp2);
                     }
                     PcaPcMode::Right => {
                         // z_k = M^{-1} v_k; w = A z_k
-                        let zk = &mut ws.z[k][..];
-                        Self::apply_pc(pc_in, PcSide::Right, &ws.q[k], zk)?;
-                        a.matvec(zk, &mut ws.tmp1);
+                        let zk = &mut ws.z_s[k][..];
+                        Self::apply_pc(pc_in, PcSide::Right, &ws.q_s[k], zk, &mut ws.bridge)?;
+                        matvec_s(a, zk, &mut ws.tmp1, &mut ws.bridge);
                     }
                 }
 
                 // Orthonormalize against V
-                let hnorm = self.project_and_normalize(&ws.q, k, &mut ws.tmp1, &mut ws.h);
+                let hnorm = self.project_and_normalize(&ws.q_s, k, &mut ws.tmp1, &mut ws.h);
                 ws.h[k + 1][k] = hnorm;
 
                 // v_{k+1}
-                let vnext = &mut ws.q[k + 1][..];
+                let vnext = &mut ws.q_s[k + 1][..];
                 if hnorm > 0.0 {
+                    let denom = S::from_real(hnorm);
                     for i in 0..n {
-                        vnext[i] = ws.tmp1[i] / hnorm;
+                        vnext[i] = ws.tmp1[i] / denom;
                     }
                 } else {
-                    vnext.fill(0.0);
+                    vnext.fill(S::zero());
                 }
 
                 // Apply stored Givens
@@ -403,9 +411,12 @@ impl LinearSolver for PcaGmresSolver {
                 Self::apply_givens(hjk, hj1k, c, s);
 
                 // Update RHS g
-                let t = c * ws.g[k] + s * ws.g[k + 1];
-                ws.g[k + 1] = -s * ws.g[k] + c * ws.g[k + 1];
-                ws.g[k] = t;
+                let gk = ws.g[k];
+                let gk1 = ws.g[k + 1];
+                let c_s = S::from_real(c);
+                let s_s = S::from_real(s);
+                ws.g[k] = c_s * gk + s_s * gk1;
+                ws.g[k + 1] = -s_s * gk + c_s * gk1;
 
                 res = ws.g[k + 1].abs(); // estimate; equals true ||r|| for Right/None, precond ||M^{-1}r|| for Left
                 total_iters += 1;
@@ -431,20 +442,20 @@ impl LinearSolver for PcaGmresSolver {
 
             // Back-substitute
             let k = arnoldi_steps;
-            let mut y = vec![0.0; k];
+            let mut y = vec![S::zero(); k];
             for i in (0..k).rev() {
                 let mut sum = ws.g[i];
                 for l in (i + 1)..k {
-                    sum -= ws.h[i][l] * y[l];
+                    sum -= S::from_real(ws.h[i][l]) * y[l];
                 }
-                y[i] = sum / ws.h[i][i];
+                y[i] = sum / S::from_real(ws.h[i][i]);
             }
 
             // Update x with V or Z depending on mode
             match mode {
                 PcaPcMode::Right => {
                     for i in 0..k {
-                        let zi = &ws.z[i][..];
+                        let zi = &ws.z_s[i][..];
                         for (xj, &zij) in x.iter_mut().zip(zi) {
                             *xj += y[i] * zij;
                         }
@@ -452,7 +463,7 @@ impl LinearSolver for PcaGmresSolver {
                 }
                 PcaPcMode::None | PcaPcMode::Left => {
                     for i in 0..k {
-                        let vi = &ws.q[i][..];
+                        let vi = &ws.q_s[i][..];
                         for (xj, &vij) in x.iter_mut().zip(vi) {
                             *xj += y[i] * vij;
                         }
@@ -461,45 +472,48 @@ impl LinearSolver for PcaGmresSolver {
             }
 
             // Restart: r = b - A x, rebuild v0 based on mode
-            a.matvec(x, &mut ws.tmp1);
+            matvec_s(a, x, &mut ws.tmp1, &mut ws.bridge);
             for i in 0..n {
-                ws.tmp1[i] = b[i] - ws.tmp1[i];
+                ws.tmp1[i] = S::from_real(b[i]) - ws.tmp1[i];
             }
-            let beta0_new = match mode {
+            let beta0_new: R = match mode {
                 PcaPcMode::None => {
-                    let beta = Self::nrm2(&ws.tmp1);
-                    let v0 = &mut ws.q[0][..];
+                    let beta = nrm2(&ws.tmp1);
+                    let v0 = &mut ws.q_s[0][..];
                     if beta > 0.0 {
+                        let denom = S::from_real(beta);
                         for i in 0..n {
-                            v0[i] = ws.tmp1[i] / beta;
+                            v0[i] = ws.tmp1[i] / denom;
                         }
                     } else {
-                        v0.fill(0.0);
+                        v0.fill(S::zero());
                     }
                     beta
                 }
                 PcaPcMode::Left => {
-                    Self::apply_pc(pc_in, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                    let beta = Self::nrm2(&ws.tmp2);
-                    let v0 = &mut ws.q[0][..];
+                    Self::apply_pc(pc_in, PcSide::Left, &ws.tmp1, &mut ws.tmp2, &mut ws.bridge)?;
+                    let beta = nrm2(&ws.tmp2);
+                    let v0 = &mut ws.q_s[0][..];
                     if beta > 0.0 {
+                        let denom = S::from_real(beta);
                         for i in 0..n {
-                            v0[i] = ws.tmp2[i] / beta;
+                            v0[i] = ws.tmp2[i] / denom;
                         }
                     } else {
-                        v0.fill(0.0);
+                        v0.fill(S::zero());
                     }
                     beta
                 }
                 PcaPcMode::Right => {
-                    let beta = Self::nrm2(&ws.tmp1);
-                    let v0 = &mut ws.q[0][..];
+                    let beta = nrm2(&ws.tmp1);
+                    let v0 = &mut ws.q_s[0][..];
                     if beta > 0.0 {
+                        let denom = S::from_real(beta);
                         for i in 0..n {
-                            v0[i] = ws.tmp1[i] / beta;
+                            v0[i] = ws.tmp1[i] / denom;
                         }
                     } else {
-                        v0.fill(0.0);
+                        v0.fill(S::zero());
                     }
                     beta
                 }
@@ -509,8 +523,8 @@ impl LinearSolver for PcaGmresSolver {
             ws.h.iter_mut().for_each(|row| row.fill(0.0));
             ws.cs.fill(0.0);
             ws.sn.fill(0.0);
-            ws.g.fill(0.0);
-            ws.g[0] = beta0_new;
+            ws.g.fill(S::zero());
+            ws.g[0] = S::from_real(beta0_new);
 
             if total_iters >= self.conv.max_iters {
                 break 'outer;
@@ -527,11 +541,11 @@ impl LinearSolver for PcaGmresSolver {
         }
 
         // Report *true* residual at the end for consistency
-        a.matvec(x, &mut ws.tmp1);
+        matvec_s(a, x, &mut ws.tmp1, &mut ws.bridge);
         for i in 0..n {
             ws.tmp1[i] = b[i] - ws.tmp1[i];
         }
-        let true_res = Self::nrm2(&ws.tmp1);
+        let true_res: R = nrm2(&ws.tmp1);
         let (_r, mut s) = self.conv.check(true_res, bnorm, total_iters);
         s.iterations = total_iters;
         s.final_residual = true_res;

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -1,3 +1,5 @@
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -40,7 +42,7 @@ pub enum PcgVariant {
 pub const PCG_PIPELINED_DEFAULT_REPLACE_EVERY: usize = 50;
 
 pub struct PcgSolver {
-    pub(crate) conv: Convergence<f64>,
+    pub(crate) conv: Convergence,
     norm_type: CgNormType,
     reduction: ReductionOptions,
     true_residual_monitor: Option<Box<dyn Fn(usize, f64) + Send + Sync>>,

--- a/src/solver/qmr.rs
+++ b/src/solver/qmr.rs
@@ -2,6 +2,8 @@
 //!
 //! Accepts [`PcSide::Left`] or [`PcSide::Right`]; monitors report the true `||r||`.
 
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -11,7 +13,7 @@ use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 
 pub struct QmrSolver {
-    pub conv: Convergence<f64>,
+    pub conv: Convergence,
 }
 
 impl QmrSolver {

--- a/src/solver/tfqmr.rs
+++ b/src/solver/tfqmr.rs
@@ -2,17 +2,22 @@
 //!
 //! Accepts [`PcSide::Left`] or [`PcSide::Right`]; residuals are reported as the true `||r||`.
 
+use crate::algebra::blas::{dot_conj, nrm2};
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
+use crate::matrix::op_bridge::matvec_s;
 use crate::parallel::UniverseComm;
+use crate::preconditioner::bridge::apply_pc_s;
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 use std::any::Any;
 
 pub struct TfqmrSolver {
-    pub conv: Convergence<f64>,
+    pub conv: Convergence,
     pub resid_recalc_every: usize,
     pub breakdown_eps: f64,
 }
@@ -33,18 +38,16 @@ impl TfqmrSolver {
 
     fn setup_tfqmr_workspace(work: &mut Workspace, n: usize) {
         if work.tmp1.len() != n {
-            work.tmp1.resize(n, 0.0);
+            work.tmp1.resize(n, S::zero());
         }
         if work.tmp2.len() != n {
-            work.tmp2.resize(n, 0.0);
+            work.tmp2.resize(n, S::zero());
         }
-        while work.q.len() < 6 {
-            work.q.push(vec![0.0; n]);
-        }
-        for v in &mut work.q[..6] {
-            if v.len() != n {
-                v.resize(n, 0.0);
-            }
+        let need = 6usize
+            .checked_mul(n)
+            .expect("tfqmr scratch length overflow");
+        if work.blk_scratch.len() != need {
+            work.blk_scratch.resize(need, S::zero());
         }
     }
 }
@@ -93,33 +96,30 @@ impl LinearSolver for TfqmrSolver {
         TfqmrSolver::setup_tfqmr_workspace(w, n);
 
         let (r, au) = (&mut w.tmp1, &mut w.tmp2);
-        let (u_slice, rest) = w.q.split_at_mut(1);
-        let (v_slice, rest) = rest.split_at_mut(1);
-        let (wv_slice, rest) = rest.split_at_mut(1);
-        let (yv_slice, rest) = rest.split_at_mut(1);
-        let (d_slice, rest) = rest.split_at_mut(1);
-        let (qv_slice, _) = rest.split_at_mut(1);
-        let (u, v, wv, yv, d, qv) = (
-            &mut u_slice[0][..],
-            &mut v_slice[0][..],
-            &mut wv_slice[0][..],
-            &mut yv_slice[0][..],
-            &mut d_slice[0][..],
-            &mut qv_slice[0][..],
-        );
+        let scratch = &mut w.blk_scratch;
+        debug_assert_eq!(scratch.len(), 6 * n);
+        let (u, rest) = scratch.split_at_mut(n);
+        let (v, rest) = rest.split_at_mut(n);
+        let (wv, rest) = rest.split_at_mut(n);
+        let (yv, rest) = rest.split_at_mut(n);
+        let (d, qv) = rest.split_at_mut(n);
+        if w.bridge_tmp.len() != n {
+            w.bridge_tmp.resize(n, S::zero());
+        }
 
-        a.matvec(x, r);
+        matvec_s(a, x, r, &mut w.bridge);
         for i in 0..n {
-            r[i] = b[i] - r[i];
+            r[i] = S::from_real(b[i]) - r[i];
         }
         if let Some(pc) = pc {
-            let rin = r.clone();
-            pc.apply(pc_side, &rin, r)?;
+            let tmp = &mut w.bridge_tmp[..n];
+            tmp.copy_from_slice(r);
+            apply_pc_s(pc, pc_side, tmp, r, &mut w.bridge)?;
         }
 
         let r_tld = r.clone();
-        let mut rho = dot(&r_tld, r);
-        let res0 = norm2(r);
+        let mut rho: S = dot_conj(&r_tld, r);
+        let res0: R = nrm2(r);
         let mut stats = SolveStats::new(0, res0, ConvergedReason::Continued);
         for m in mons {
             m(0, res0);
@@ -136,21 +136,22 @@ impl LinearSolver for TfqmrSolver {
 
         yv.clone_from_slice(r);
         wv.clone_from_slice(r);
-        d.fill(0.0);
-        let mut theta_prev = 0.0;
-        let mut eta_prev = 0.0;
-        let mut dpold = res0;
-        let mut true_res = res0;
+        d.fill(S::zero());
+        let mut theta_prev: R = 0.0;
+        let mut eta_prev: S = S::zero();
+        let mut dpold: R = res0;
+        let mut true_res: R = res0;
 
         for k in 1..=self.conv.max_iters {
-            v.fill(0.0);
-            a.matvec(yv, v);
+            v.fill(S::zero());
+            matvec_s(a, yv, v, &mut w.bridge);
             if let Some(pc) = pc {
-                let vin = v.to_vec();
-                pc.apply(pc_side, &vin, v)?;
+                let tmp = &mut w.bridge_tmp[..n];
+                tmp.copy_from_slice(v);
+                apply_pc_s(pc, pc_side, tmp, v, &mut w.bridge)?;
             }
 
-            let sigma = dot(&r_tld, v);
+            let sigma: S = dot_conj(&r_tld, v);
             if !sigma.is_finite() || sigma.abs() < self.breakdown_eps {
                 stats.iterations = k;
                 stats.final_residual = true_res;
@@ -158,7 +159,7 @@ impl LinearSolver for TfqmrSolver {
                 return Ok(stats);
             }
             let alpha = rho / sigma;
-            if !alpha.is_finite() || alpha == 0.0 {
+            if !alpha.is_finite() || alpha == S::zero() {
                 stats.iterations = k;
                 stats.final_residual = true_res;
                 stats.reason = ConvergedReason::DivergedDtol;
@@ -168,7 +169,7 @@ impl LinearSolver for TfqmrSolver {
             for i in 0..n {
                 u[i] = r[i] - alpha * v[i];
             }
-            let mut tau_local = (norm2(u) * dpold).sqrt();
+            let mut tau_local: R = (nrm2(u) * dpold).sqrt();
 
             for mstep in 0..2 {
                 if mstep == 0 {
@@ -179,25 +180,26 @@ impl LinearSolver for TfqmrSolver {
                 for i in 0..n {
                     au[i] = u[i] + qv[i];
                 }
-                let tmp_in = au.to_vec();
-                a.matvec(&tmp_in, au);
+                let tmp = &mut w.bridge_tmp[..n];
+                tmp.copy_from_slice(au);
+                matvec_s(a, tmp, au, &mut w.bridge);
                 if let Some(pc) = pc {
-                    let tmp2 = au.to_vec();
-                    pc.apply(pc_side, &tmp2, au)?;
+                    tmp.copy_from_slice(au);
+                    apply_pc_s(pc, pc_side, tmp, au, &mut w.bridge)?;
                 }
                 for i in 0..n {
                     r[i] -= alpha * au[i];
                 }
 
                 {
-                    let src: &[f64] = if mstep == 0 { &u[..] } else { &qv[..] };
-                    let psi = norm2(src) / tau_local.max(1e-300);
-                    let c = 1.0 / (1.0 + psi * psi).sqrt();
-                    let eta = c * c * alpha;
-                    let cf = if k == 1 && mstep == 0 {
-                        0.0
+                    let src: &[S] = if mstep == 0 { &u[..] } else { &qv[..] };
+                    let psi: R = nrm2(src) / tau_local.max(1e-300);
+                    let c: R = 1.0 / (1.0 + psi * psi).sqrt();
+                    let eta: S = S::from_real(c * c) * alpha;
+                    let cf: S = if k == 1 && mstep == 0 {
+                        S::zero()
                     } else {
-                        theta_prev * theta_prev * (eta_prev / alpha)
+                        S::from_real(theta_prev * theta_prev) * (eta_prev / alpha)
                     };
                     for i in 0..n {
                         d[i] = src[i] + cf * d[i];
@@ -205,7 +207,7 @@ impl LinearSolver for TfqmrSolver {
                     }
 
                     let iter_count = 2 * (k - 1) + mstep + 1;
-                    let dpest = ((2 * k + mstep + 1) as f64).sqrt() * tau_local;
+                    let dpest: R = ((2 * k + mstep + 1) as f64).sqrt() * tau_local;
                     for mfn in mons {
                         mfn(iter_count, dpest);
                     }
@@ -222,15 +224,16 @@ impl LinearSolver for TfqmrSolver {
                                 ConvergedReason::ConvergedRtol | ConvergedReason::ConvergedAtol
                             ))
                     {
-                        a.matvec(x, au);
+                        matvec_s(a, x, au, &mut w.bridge);
                         for i in 0..n {
-                            au[i] = b[i] - au[i];
+                            au[i] = S::from_real(b[i]) - au[i];
                         }
                         if let Some(pc) = pc {
-                            let tmp = au.to_vec();
-                            pc.apply(pc_side, &tmp, au)?;
+                            let tmp = &mut w.bridge_tmp[..n];
+                            tmp.copy_from_slice(au);
+                            apply_pc_s(pc, pc_side, tmp, au, &mut w.bridge)?;
                         }
-                        true_res = norm2(au);
+                        true_res = nrm2(au);
                         stats.final_residual = true_res;
                     } else {
                         stats.final_residual = dpest;
@@ -252,7 +255,7 @@ impl LinearSolver for TfqmrSolver {
                 }
             }
 
-            let rho_new = dot(&r_tld, r);
+            let rho_new: S = dot_conj(&r_tld, r);
             if !rho_new.is_finite() || rho_new.abs() < self.breakdown_eps {
                 stats.iterations = k;
                 stats.reason = ConvergedReason::DivergedDtol;
@@ -266,18 +269,19 @@ impl LinearSolver for TfqmrSolver {
                 yv[i] = r[i] + beta * (qv[i] + beta * yv[i]);
             }
 
-            dpold = norm2(r);
+            dpold = nrm2(r);
 
             if self.resid_recalc_every == 1 {
-                a.matvec(x, au);
+                matvec_s(a, x, au, &mut w.bridge);
                 for i in 0..n {
-                    au[i] = b[i] - au[i];
+                    au[i] = S::from_real(b[i]) - au[i];
                 }
                 if let Some(pc) = pc {
-                    let tmp = au.clone();
-                    pc.apply(pc_side, &tmp, au)?;
+                    let tmp = &mut w.bridge_tmp[..n];
+                    tmp.copy_from_slice(au);
+                    apply_pc_s(pc, pc_side, tmp, au, &mut w.bridge)?;
                 }
-                true_res = norm2(au);
+                true_res = nrm2(au);
                 stats.final_residual = true_res;
                 let (reason, s2) = self.conv.check(true_res, res0, 2 * k);
                 stats = s2;
@@ -299,16 +303,6 @@ impl LinearSolver for TfqmrSolver {
         }
         Ok(stats)
     }
-}
-
-#[inline]
-fn dot(x: &[f64], y: &[f64]) -> f64 {
-    x.iter().zip(y).map(|(a, b)| a * b).sum()
-}
-
-#[inline]
-fn norm2(x: &[f64]) -> f64 {
-    dot(x, x).sqrt()
 }
 
 #[cfg(test)]

--- a/src/utils/convergence.rs
+++ b/src/utils/convergence.rs
@@ -1,6 +1,7 @@
 //! Convergence tracking & tolerance checks for iterative solvers.
 
-use crate::algebra::scalar::RealScalar;
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 
 /// Convergence criteria for iterative solvers.
 ///
@@ -9,7 +10,7 @@ use crate::algebra::scalar::RealScalar;
 /// - **Absolute tolerance**: `‖r‖ ≤ atol`
 /// - **Divergence threshold**: `‖r‖ ≥ dtol * ‖b‖`
 /// - **Maximum iterations**: `iterations ≥ max_iters`
-pub struct Convergence<R: RealScalar> {
+pub struct Convergence {
     /// Relative tolerance: ‖r‖/‖b‖ ≤ rtol ⇒ converge
     pub rtol: R,
     /// Absolute tolerance: ‖r‖ ≤ atol ⇒ converge
@@ -79,10 +80,7 @@ impl<R> SolveStats<R> {
     }
 }
 
-impl<R> Convergence<R>
-where
-    R: RealScalar + core::ops::Mul<Output = R>,
-{
+impl Convergence {
     /// Create new convergence criteria.
     pub fn new(rtol: R, atol: R, dtol: R, max_iters: usize) -> Self {
         Self {
@@ -136,10 +134,7 @@ where
 }
 
 // Legacy convenience method for backward compatibility
-impl<R> Convergence<R>
-where
-    R: RealScalar + core::ops::Mul<Output = R>,
-{
+impl Convergence {
     /// Legacy method for backward compatibility.
     /// Returns (should_stop, stats) given current `res_norm` and iteration `i`.
     ///

--- a/src/utils/merge.rs
+++ b/src/utils/merge.rs
@@ -1,4 +1,5 @@
-use crate::algebra::scalar::Scalar;
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 
 /// Map a slice of value slots into an iterator over references into the
 /// underlying value array.
@@ -10,7 +11,7 @@ pub fn map_vals<'a, S>(vals: &'a [S], slots: &'a [usize]) -> impl Iterator<Item 
 /// Lookup a value within a sorted sparse row returning `None` if the column is
 /// absent.
 #[inline]
-pub fn lookup_in_row<S: Scalar>(cols: &[usize], vals: &[S], col: usize) -> Option<S> {
+pub fn lookup_in_row<S: KrystScalar>(cols: &[usize], vals: &[S], col: usize) -> Option<S> {
     match cols.binary_search(&col) {
         Ok(pos) => Some(vals[pos]),
         Err(_) => None,
@@ -20,7 +21,7 @@ pub fn lookup_in_row<S: Scalar>(cols: &[usize], vals: &[S], col: usize) -> Optio
 /// Compute the dot product of two sparse rows up to a column limit by
 /// simultaneously walking both index arrays.
 #[inline]
-pub fn merged_dot_prefix<S: Scalar>(
+pub fn merged_dot_prefix<S: KrystScalar>(
     a_cols: &[usize],
     a_vals: &[S],
     b_cols: &[usize],
@@ -57,7 +58,7 @@ pub fn merged_dot_prefix<S: Scalar>(
 /// first row and only accumulates products where columns match and are greater
 /// than `start_col`.
 #[inline]
-pub fn merged_dot_strict_upper<S: Scalar>(
+pub fn merged_dot_strict_upper<S: KrystScalar>(
     a_cols: &[usize],
     a_vals: &[S],
     start_col: usize,
@@ -89,7 +90,7 @@ pub fn merged_dot_strict_upper<S: Scalar>(
 /// Kahan compensated variant of [`merged_dot_prefix`] for improved numerical
 /// reproducibility.
 #[inline]
-pub fn merged_dot_prefix_kahan<S: Scalar>(
+pub fn merged_dot_prefix_kahan<S: KrystScalar>(
     a_cols: &[usize],
     a_vals: &[S],
     b_cols: &[usize],

--- a/src/utils/permutation.rs
+++ b/src/utils/permutation.rs
@@ -1,4 +1,5 @@
-use crate::algebra::scalar::Scalar;
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
 use crate::matrix::sparse::CsrMatrix;
 
 /// Permutation with cached inverse mapping.
@@ -25,14 +26,14 @@ impl Permutation {
     }
 
     /// Apply permutation to a vector: y(new) = x(old)[p[new]]
-    pub fn apply_vec<S: Scalar>(&self, x_old: &[S], y_new: &mut [S]) {
+    pub fn apply_vec<S: KrystScalar>(&self, x_old: &[S], y_new: &mut [S]) {
         for (i, y) in y_new.iter_mut().enumerate() {
             *y = x_old[self.p[i]];
         }
     }
 
     /// Apply transpose permutation to a vector: y(old) = x(new)[pinv[old]]
-    pub fn apply_vec_t<S: Scalar>(&self, x_new: &[S], y_old: &mut [S]) {
+    pub fn apply_vec_t<S: KrystScalar>(&self, x_new: &[S], y_old: &mut [S]) {
         for (i, y) in y_old.iter_mut().enumerate() {
             *y = x_new[self.pinv[i]];
         }

--- a/tests/bridge_adapters.rs
+++ b/tests/bridge_adapters.rs
@@ -1,0 +1,66 @@
+use kryst::algebra::bridge::BridgeScratch;
+use kryst::algebra::prelude::*;
+use kryst::error::KError;
+use kryst::matrix::op::LinOp;
+use kryst::matrix::op_bridge::matvec_s;
+use kryst::preconditioner::bridge::apply_pc_s;
+use kryst::preconditioner::{PcSide, Preconditioner};
+use std::any::Any;
+
+struct Scale2Op;
+
+impl LinOp for Scale2Op {
+    type S = f64;
+
+    fn dims(&self) -> (usize, usize) {
+        (0, 0)
+    }
+
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        for (yi, &xi) in y.iter_mut().zip(x.iter()) {
+            *yi = 2.0 * xi;
+        }
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+}
+
+struct IdentityPc;
+
+impl Preconditioner for IdentityPc {
+    fn setup(&mut self, _a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        Ok(())
+    }
+
+    fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        y.copy_from_slice(x);
+        Ok(())
+    }
+}
+
+#[test]
+fn bridge_roundtrip() {
+    let n = 4;
+    let a = Scale2Op;
+    let pc = IdentityPc;
+    let mut scratch = BridgeScratch::default();
+
+    let x: Vec<S> = (0..n).map(|i| S::from_real(i as f64)).collect();
+    let mut y = vec![S::zero(); n];
+
+    matvec_s(&a, &x, &mut y, &mut scratch);
+    for (i, yi) in y.iter().enumerate() {
+        assert!((yi.real() - 2.0 * i as f64).abs() < 1e-12);
+        #[cfg(feature = "complex")]
+        {
+            assert_eq!(yi.conj(), *yi);
+        }
+    }
+
+    apply_pc_s(&pc, PcSide::Left, &x, &mut y, &mut scratch).unwrap();
+    for (i, yi) in y.iter().enumerate() {
+        assert!((yi.real() - i as f64).abs() < 1e-12);
+    }
+}

--- a/tests/scalar_prelude.rs
+++ b/tests/scalar_prelude.rs
@@ -1,0 +1,14 @@
+use kryst::algebra::prelude::*;
+
+#[test]
+fn prelude_basic_ops_compile() {
+    let a: S = S::from_real(3.0);
+    let b: S = S::from_real(4.0);
+    let _sum: S = a + b;
+    let _prod: S = a * b;
+    let _neg: S = -a;
+    let _conj: S = a.conj();
+    let _abs: R = a.abs();
+    let _inv: S = a.inv();
+    assert!(a.is_finite());
+}


### PR DESCRIPTION
## Summary
- add scalar-to-real copy helpers and a reusable BridgeScratch buffer for solver shims
- implement matvec_s and apply_pc_s bridges and teach TFQMR/PCA-GMRES workspaces to route through them
- cover the adapters with a unit smoke test to ensure conversions work in both scalar modes

## Testing
- cargo check
- cargo test --no-run
- cargo check --features complex *(fails: remaining modules still assume f64 pipelines and givens updates)*

------
https://chatgpt.com/codex/tasks/task_e_68df03d18a148329b3ebf89f93c3ee1b