### PR TITLE
Finish complex scalar support for GMRES family

### DIFF
--- a/src/context/ksp_context/workspace.rs
+++ b/src/context/ksp_context/workspace.rs
@@ -2,6 +2,7 @@ use crate::algebra::bridge::BridgeScratch;
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
 use crate::core::block::BlockVec;
+use crate::solver::common::givens::{apply_complex_givens, build_complex_givens};
 use crate::solver::gmres::AugmentationPolicy;
 
 #[derive(Debug, Clone, Default)]
@@ -19,8 +20,8 @@ pub struct Workspace {
     pub z_mem: Vec<S>,
     // Column-major Hessenberg storage for GMRES/FGMRES
     pub h_mem: Vec<S>,
-    pub cs: Vec<f64>,
-    pub sn: Vec<f64>,
+    pub cs: Vec<R>,
+    pub sn: Vec<S>,
     pub g: Vec<S>,
     pub blk_scratch: Vec<S>,
     pub bridge: BridgeScratch,
@@ -499,9 +500,7 @@ impl Workspace {
             let c = self.cs[i];
             let s = self.sn[i];
             let (hij, hij1) = self.h2_mut(i, j);
-            let t = c * *hij + s * *hij1;
-            *hij1 = -s * *hij + c * *hij1;
-            *hij = t;
+            apply_complex_givens(hij, hij1, c, s);
         }
     }
 
@@ -510,23 +509,19 @@ impl Workspace {
         let ld = self.ld_h();
         let hkk = self.h_mem[j * ld + j];
         let hk1k = self.h_mem[j * ld + j + 1];
-        let (c, s) = if hk1k == 0.0 {
-            (1.0, 0.0)
-        } else {
-            let r = (hkk * hkk + hk1k * hk1k).sqrt();
-            (hkk / r, hk1k / r)
-        };
+        let (c, s) = build_complex_givens(hkk, hk1k);
         self.cs[j] = c;
         self.sn[j] = s;
         let (hjj, hj1j) = self.h2_mut(j, j);
-        let t = c * *hjj + s * *hj1j;
-        *hj1j = -s * *hjj + c * *hj1j;
-        *hjj = t;
-        let t = c * self.g[j] + s * self.g[j + 1];
-        self.g[j + 1] = -s * self.g[j] + c * self.g[j + 1];
-        self.g[j] = t;
+        apply_complex_givens(hjj, hj1j, c, s);
+        let gk = self.g[j];
+        let gk1 = self.g[j + 1];
+        let c_s = S::from_real(c);
+        self.g[j] = c_s * gk + s * gk1;
+        self.g[j + 1] = -s.conj() * gk + c_s * gk1;
     }
 
+    #[cfg(not(feature = "complex"))]
     pub fn pipelined_arnoldi_step(
         &mut self,
         k: usize,
@@ -650,6 +645,21 @@ impl Workspace {
         }
 
         Ok(reductions)
+    }
+
+    #[cfg(feature = "complex")]
+    pub fn pipelined_arnoldi_step(
+        &mut self,
+        k: usize,
+        n: usize,
+        _comm: &crate::parallel::UniverseComm,
+        _policy: ReorthPolicy,
+        _tol: f64,
+    ) -> Result<usize, crate::error::KError> {
+        let _ = (k, n);
+        Err(crate::error::KError::NotImplemented(
+            "pipelined GMRES is not yet implemented for complex scalars".into(),
+        ))
     }
 }
 

--- a/src/solver/common/givens.rs
+++ b/src/solver/common/givens.rs
@@ -1,0 +1,89 @@
+use crate::algebra::prelude::*;
+
+/// Build a complex Givens rotation that zeroes the second entry of the vector [a; b].
+/// Returns (c, s) where `c` is real and non-negative, and `s` is the complex sine.
+#[inline]
+pub fn build_complex_givens(a: S, b: S) -> (R, S) {
+    let absa = a.abs();
+    let absb = b.abs();
+    if absb == 0.0 {
+        return (1.0, S::zero());
+    }
+    let r = absa.hypot(absb);
+    let c = if r == 0.0 { 0.0 } else { absa / r };
+    let s = if absa != 0.0 {
+        let scale = S::from_real(c / (absa * absa));
+        (a.conj() * b) * scale
+    } else {
+        b / S::from_real(absb)
+    };
+    (c, s)
+}
+
+/// Apply a complex Givens rotation to the in-place vector [h_ik; h_ip1k].
+#[inline]
+pub fn apply_complex_givens(h_ik: &mut S, h_ip1k: &mut S, c: R, s: S) {
+    let c_s = S::from_real(c);
+    let t = c_s * *h_ik + s * *h_ip1k;
+    let t2 = -s.conj() * *h_ik + c_s * *h_ip1k;
+    *h_ik = t;
+    *h_ip1k = t2;
+}
+
+/// Apply the previously accumulated Givens rotations to a Hessenberg column.
+#[inline]
+pub fn apply_prev_givens_to_col(hcol: &mut [S], k: usize, cs: &[R], sn: &[S]) {
+    for i in 0..k {
+        let (head, tail) = hcol.split_at_mut(i + 1);
+        let hij = &mut head[i];
+        let hij1 = &mut tail[0];
+        apply_complex_givens(hij, hij1, cs[i], sn[i]);
+    }
+}
+
+/// Apply a freshly built Givens rotation to the Hessenberg column and update g.
+#[inline]
+pub fn apply_new_givens_and_update_g(
+    hcol: &mut [S],
+    k: usize,
+    cs: &mut [R],
+    sn: &mut [S],
+    g: &mut [S],
+) {
+    let (c, s) = build_complex_givens(hcol[k], hcol[k + 1]);
+    cs[k] = c;
+    sn[k] = s;
+    let (head, tail) = hcol.split_at_mut(k + 1);
+    let hik = &mut head[k];
+    let hip1k = &mut tail[0];
+    apply_complex_givens(hik, hip1k, c, s);
+
+    let c_s = S::from_real(c);
+    let gk = g[k];
+    let gk1 = g[k + 1];
+    g[k] = c_s * gk + s * gk1;
+    g[k + 1] = -s.conj() * gk + c_s * gk1;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn complex_givens_zeroes_second_entry() {
+        let a: S = S::from_real(1.2);
+        #[cfg(feature = "complex")]
+        let b: S = num_complex::Complex64::new(-0.7, 0.5);
+        #[cfg(not(feature = "complex"))]
+        let b: S = S::from_real(-0.7);
+
+        let (c, s) = build_complex_givens(a, b);
+        let mut h0 = a;
+        let mut h1 = b;
+        apply_complex_givens(&mut h0, &mut h1, c, s);
+
+        let scale = (a.abs() + b.abs()).max(1.0);
+        assert!(h1.abs() <= 1e-12 * scale);
+        assert!(c >= 0.0);
+    }
+}

--- a/src/solver/common/mod.rs
+++ b/src/solver/common/mod.rs
@@ -1,3 +1,5 @@
+pub mod givens;
+
 use crate::matrix::op::LinOp;
 use crate::parallel::{Comm, UniverseComm};
 use crate::utils::reduction::{AllreduceHandle, AsyncComm, ReductOptions};

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -1,8 +1,13 @@
 //! Flexible GMRES (FGMRES) over &dyn LinOp<f64>, right-preconditioned, object-safe.
 
+use crate::algebra::blas::{dot_conj, nrm2};
+#[allow(unused_imports)]
+use crate::algebra::prelude::*;
+use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
 use crate::context::ksp_context::{GmresSpec, ReorthPolicy, Workspace};
 use crate::error::KError;
 use crate::matrix::op::LinOp;
+use crate::matrix::op_bridge::matvec_s;
 use crate::parallel::UniverseComm;
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
@@ -64,12 +69,12 @@ impl FgmresSolver {
     }
 
     #[inline]
-    fn dot(x: &[f64], y: &[f64], _comm: &UniverseComm) -> f64 {
-        x.iter().zip(y).map(|(a, b)| a * b).sum()
+    fn dot(x: &[S], y: &[S]) -> S {
+        dot_conj(x, y)
     }
     #[inline]
-    fn nrm2(x: &[f64], comm: &UniverseComm) -> f64 {
-        Self::dot(x, x, comm).sqrt()
+    fn nrm2(x: &[S]) -> R {
+        nrm2(x)
     }
 
     fn ensure_workspace(&self, w: &mut Workspace, n: usize, m: usize) {
@@ -121,38 +126,44 @@ impl FgmresSolver {
         })?;
         self.ensure_workspace(ws, n, block_m);
 
-        a.matvec(x, &mut ws.tmp1);
+        let mons = monitors.unwrap_or(&[]);
+
+        let mut x_s = vec![S::zero(); n];
+        copy_real_to_scalar_in(x, &mut x_s);
+        let mut b_s = vec![S::zero(); n];
+        copy_real_to_scalar_in(b, &mut b_s);
+
+        matvec_s(a, &x_s, &mut ws.tmp1, &mut ws.bridge);
         for i in 0..n {
-            ws.tmp1[i] = b[i] - ws.tmp1[i];
+            ws.tmp1[i] = b_s[i] - ws.tmp1[i];
         }
-        let mut beta0 = Self::nrm2(&ws.tmp1, comm);
-        let bnorm = Self::nrm2(b, comm).max(1e-32);
+        let mut beta0 = Self::nrm2(&ws.tmp1[..n]);
+        let bnorm = nrm2(&b_s).max(1e-32);
         let thr = self.atol.max(self.rtol * bnorm);
 
         if beta0 > 0.0 {
-            for i in 0..n {
-                ws.tmp2[i] = ws.tmp1[i] / beta0;
+            let inv = S::from_real(1.0 / beta0);
+            for (dst, &src) in ws.tmp2[..n].iter_mut().zip(&ws.tmp1[..n]) {
+                *dst = src * inv;
             }
             ws.copy_tmp2_into_vcol(0);
         } else {
-            ws.v_col(0).fill(0.0);
+            ws.v_col(0).fill(S::zero());
         }
 
-        ws.h_mem.fill(0.0);
+        ws.h_mem.fill(S::zero());
         ws.cs.fill(0.0);
-        ws.sn.fill(0.0);
-        ws.g.fill(0.0);
-        ws.g[0] = beta0;
+        ws.sn.fill(S::zero());
+        ws.g.fill(S::zero());
+        ws.g[0] = S::from_real(beta0);
 
         let mut total_iters = 0usize;
         let mut res = beta0;
         let mut stats = SolveStats::new(0, res, ConvergedReason::Continued);
         let start_reduct = crate::utils::reduction::test_hooks::wait_counters();
 
-        if let Some(mons) = monitors {
-            for m in mons {
-                m(0, res);
-            }
+        for m in mons {
+            m(0, res);
         }
         if res <= thr {
             stats.final_residual = res;
@@ -161,6 +172,10 @@ impl FgmresSolver {
             } else {
                 ConvergedReason::ConvergedRtol
             };
+            copy_scalar_to_real_in(&x_s, x);
+            let tmp = ws.bridge.xr(n);
+            let true_res = recompute_true_residual_norm(a, b, x, comm, tmp);
+            stats.final_residual = true_res;
             let end_reduct = crate::utils::reduction::test_hooks::wait_counters();
             let reductions = end_reduct.0 + end_reduct.1 - start_reduct.0 - start_reduct.1;
             let counters = crate::utils::convergence::SolverCounters {
@@ -185,75 +200,109 @@ impl FgmresSolver {
                     FgmresVariant::Classical => {
                         {
                             let (vj, zj) = ws.v_and_z_mut(j);
-                            if let Some(pc_) = pc.as_deref_mut() {
-                                pc_.apply_mut(pc_side, vj, zj)?;
+                            if let Some(pc_) = pc.as_mut() {
+                                #[cfg(not(feature = "complex"))]
+                                {
+                                    let vj_r: &[f64] =
+                                        unsafe { &*(vj as *const [S] as *const [f64]) };
+                                    let zj_r: &mut [f64] =
+                                        unsafe { &mut *(zj as *mut [S] as *mut [f64]) };
+                                    (*pc_).apply_mut(pc_side, vj_r, zj_r)?;
+                                }
+                                #[cfg(feature = "complex")]
+                                {
+                                    let xr = ws.bridge.xr(n);
+                                    let yr = ws.bridge.yr(n);
+                                    copy_scalar_to_real_in(vj, xr);
+                                    (*pc_).apply_mut(pc_side, xr, yr)?;
+                                    copy_real_to_scalar_in(yr, zj);
+                                }
                             } else {
                                 zj.copy_from_slice(vj);
                             }
                         }
                         {
-                            let (zj, tmp2) = ws.z_and_tmp2_mut(j);
-                            a.matvec(zj, tmp2);
+                            let base = j * n;
+                            ws.tmp1[..n].copy_from_slice(&ws.z_mem[base..base + n]);
+                            matvec_s(a, &ws.tmp1[..n], &mut ws.tmp2[..n], &mut ws.bridge);
                         }
 
-                        for i in 0..=j {
-                            let hij = {
+                        let mut hvals = vec![S::zero(); j + 1];
+                        {
+                            let tmp2 = &mut ws.tmp2[..n];
+                            for i in 0..=j {
                                 let vi = &ws.v_mem[i * n..(i + 1) * n];
-                                let hij = Self::dot(&ws.tmp2, vi, comm);
-                                for (w_i, &vi_val) in ws.tmp2.iter_mut().zip(vi) {
+                                let hij = Self::dot(vi, tmp2);
+                                hvals[i] = hij;
+                                for (w_i, &vi_val) in tmp2.iter_mut().zip(vi) {
                                     *w_i -= hij * vi_val;
                                 }
-                                hij
-                            };
-                            *ws.h_at_mut(i, j) = hij;
-                        }
-
-                        if matches!(self.orthog, Orthog::Modified) {
-                            for i in 0..=j {
-                                let corr = {
+                            }
+                            if matches!(self.orthog, Orthog::Modified) {
+                                for i in 0..=j {
                                     let vi = &ws.v_mem[i * n..(i + 1) * n];
-                                    let corr = Self::dot(&ws.tmp2, vi, comm);
+                                    let corr = Self::dot(vi, tmp2);
                                     if corr.abs() > 1e-12 {
-                                        for (w_i, &vi_val) in ws.tmp2.iter_mut().zip(vi) {
+                                        for (w_i, &vi_val) in tmp2.iter_mut().zip(vi) {
                                             *w_i -= corr * vi_val;
                                         }
+                                        hvals[i] += corr;
                                     }
-                                    corr
-                                };
-                                if corr.abs() > 1e-12 {
-                                    *ws.h_at_mut(i, j) += corr;
                                 }
                             }
                         }
+                        for i in 0..=j {
+                            *ws.h_at_mut(i, j) = hvals[i];
+                        }
 
-                        let hij1 = Self::nrm2(&ws.tmp2, comm);
-                        *ws.h_at_mut(j + 1, j) = hij1;
+                        let hij1 = nrm2(&ws.tmp2[..n]);
+                        *ws.h_at_mut(j + 1, j) = S::from_real(hij1);
 
                         if hij1 > 0.0 {
-                            for i in 0..n {
-                                ws.tmp2[i] /= hij1;
+                            let inv = S::from_real(1.0 / hij1);
+                            for val in &mut ws.tmp2[..n] {
+                                *val *= inv;
                             }
                             ws.copy_tmp2_into_vcol(j + 1);
                         } else {
-                            ws.v_col(j + 1).fill(0.0);
+                            ws.v_col(j + 1).fill(S::zero());
                         }
                     }
                     FgmresVariant::Pipelined => {
+                        #[cfg(feature = "complex")]
                         {
-                            let (vj, zj) = ws.v_and_z_mut(j);
-                            if let Some(pc_) = pc.as_deref_mut() {
-                                pc_.apply_mut(pc_side, vj, zj)?;
-                            } else {
-                                zj.copy_from_slice(vj);
+                            return Err(KError::NotImplemented(
+                                "Pipelined FGMRES is not yet implemented for complex scalars",
+                            ));
+                        }
+                        #[cfg(not(feature = "complex"))]
+                        {
+                            {
+                                let (vj, zj) = ws.v_and_z_mut(j);
+                                if let Some(pc_) = pc.as_mut() {
+                                    let vj_r: &[f64] =
+                                        unsafe { &*(vj as *const [S] as *const [f64]) };
+                                    let zj_r: &mut [f64] =
+                                        unsafe { &mut *(zj as *mut [S] as *mut [f64]) };
+                                    (*pc_).apply_mut(pc_side, vj_r, zj_r)?;
+                                } else {
+                                    zj.copy_from_slice(vj);
+                                }
                             }
+                            {
+                                let base = j * n;
+                                ws.tmp1[..n].copy_from_slice(&ws.z_mem[base..base + n]);
+                                matvec_s(a, &ws.tmp1[..n], &mut ws.tmp2[..n], &mut ws.bridge);
+                            }
+                            ws.pipelined_w[..n].copy_from_slice(&ws.tmp2[..n]);
+                            let _ = ws.pipelined_arnoldi_step(
+                                j,
+                                n,
+                                comm,
+                                self.reorth,
+                                self.reorth_tol,
+                            )?;
                         }
-                        {
-                            let (zj, tmp2) = ws.z_and_tmp2_mut(j);
-                            a.matvec(zj, tmp2);
-                        }
-                        ws.pipelined_w[..n].copy_from_slice(&ws.tmp2[..n]);
-                        let _ =
-                            ws.pipelined_arnoldi_step(j, n, comm, self.reorth, self.reorth_tol)?;
                     }
                 }
 
@@ -264,10 +313,8 @@ impl FgmresSolver {
                 total_iters += 1;
                 arnoldi_steps = j + 1;
 
-                if let Some(mons) = monitors {
-                    for m in mons {
-                        m(total_iters, res);
-                    }
+                for m in mons {
+                    m(total_iters, res);
                 }
 
                 let res0 = beta0;
@@ -291,7 +338,7 @@ impl FgmresSolver {
             }
 
             let k = arnoldi_steps;
-            let mut y = vec![0.0; k];
+            let mut y = vec![S::zero(); k];
             for i in (0..k).rev() {
                 let mut sum = ws.g[i];
                 for l in (i + 1)..k {
@@ -302,7 +349,7 @@ impl FgmresSolver {
 
             for i in 0..k {
                 let zi = &ws.z_mem[i * n..(i + 1) * n];
-                for (xj, &zij) in x.iter_mut().zip(zi) {
+                for (xj, &zij) in x_s.iter_mut().zip(zi) {
                     *xj += y[i] * zij;
                 }
             }
@@ -321,38 +368,40 @@ impl FgmresSolver {
                 break;
             }
 
-            a.matvec(x, &mut ws.tmp1);
+            matvec_s(a, &x_s, &mut ws.tmp1, &mut ws.bridge);
             for i in 0..n {
-                ws.tmp1[i] = b[i] - ws.tmp1[i];
+                ws.tmp1[i] = b_s[i] - ws.tmp1[i];
             }
-            beta0 = Self::nrm2(&ws.tmp1, comm);
-            ws.h_mem.fill(0.0);
+            beta0 = Self::nrm2(&ws.tmp1[..n]);
+
+            ws.h_mem.fill(S::zero());
             ws.cs.fill(0.0);
-            ws.sn.fill(0.0);
-            ws.g.fill(0.0);
-            ws.g[0] = beta0;
+            ws.sn.fill(S::zero());
+            ws.g.fill(S::zero());
+            ws.g[0] = S::from_real(beta0);
             if beta0 > 0.0 {
-                for i in 0..n {
-                    ws.tmp2[i] = ws.tmp1[i] / beta0;
+                let inv = S::from_real(1.0 / beta0);
+                for (dst, &src) in ws.tmp2[..n].iter_mut().zip(&ws.tmp1[..n]) {
+                    *dst = src * inv;
                 }
                 ws.copy_tmp2_into_vcol(0);
             } else {
-                ws.v_col(0).fill(0.0);
+                ws.v_col(0).fill(S::zero());
             }
 
-            // Allow both legacy hook and the new Preconditioner::on_restart to adjust PC
             if let Some(hook) = self.on_restart.as_mut() {
                 hook(total_iters, beta0)?;
             }
-            if let Some(pc_) = pc.as_deref_mut() {
-                pc_.on_restart(total_iters, beta0)?;
+            if let Some(pc_) = pc.as_mut() {
+                (*pc_).on_restart(total_iters, beta0)?;
             }
         }
 
         stats.iterations = total_iters;
 
-        // Compute true residual at exit for reporting
-        let true_res = recompute_true_residual_norm(a, b, x, comm, &mut ws.tmp1);
+        copy_scalar_to_real_in(&x_s, x);
+        let tmp = ws.bridge.xr(n);
+        let true_res = recompute_true_residual_norm(a, b, x, comm, tmp);
         stats.final_residual = true_res;
 
         if matches!(stats.reason, ConvergedReason::Continued) {

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -15,12 +15,16 @@
 //! in column-major form. The legacy `Workspace.z` (Vec<Vec<_>>) is not used by
 //! GMRES/FGMRES.
 
+use crate::algebra::blas::{dot_conj, nrm2};
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
+use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
 use crate::context::ksp_context::{GmresSpec, ReorthPolicy, Workspace};
 use crate::error::KError;
 use crate::matrix::op::LinOp;
+use crate::matrix::op_bridge::matvec_s;
 use crate::parallel::UniverseComm;
+use crate::preconditioner::bridge::apply_pc_s;
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::solver::common::recompute_true_residual_norm;
@@ -88,15 +92,6 @@ impl GmresSolver {
         }
     }
 
-    #[inline]
-    fn dot(x: &[f64], y: &[f64]) -> f64 {
-        x.iter().zip(y).map(|(a, b)| a * b).sum()
-    }
-    #[inline]
-    fn nrm2(x: &[f64]) -> f64 {
-        Self::dot(x, x).sqrt()
-    }
-
     fn ensure_workspace(&self, w: &mut Workspace, n: usize, side: PcSide) {
         let block_s = match self.variant {
             GmresVariant::SStep { s, .. } => s,
@@ -130,24 +125,8 @@ impl GmresSolver {
         }
     }
 
-    fn apply_precond(
-        &self,
-        pc: Option<&dyn Preconditioner>,
-        side: PcSide,
-        x: &[f64],
-        y: &mut [f64],
-    ) -> Result<(), KError> {
-        if let Some(p) = pc {
-            p.apply(side, x, y)
-        } else {
-            y.copy_from_slice(x);
-            Ok(())
-        }
-    }
-
-    fn backsolve(h: &[f64], g: &[f64], k: usize) -> Vec<f64> {
-        let ld = g.len();
-        let mut y = vec![0.0; k];
+    fn backsolve(h: &[S], g: &[S], k: usize, ld: usize) -> Vec<S> {
+        let mut y = vec![S::zero(); k];
         for i in (0..k).rev() {
             let mut sum = g[i];
             for l in (i + 1)..k {
@@ -158,7 +137,7 @@ impl GmresSolver {
         y
     }
 
-    fn axpy_update_vcols(x: &mut [f64], ws: &Workspace, k: usize, y: &[f64]) {
+    fn axpy_update_vcols(x: &mut [S], ws: &Workspace, k: usize, y: &[S]) {
         let n = ws.n();
         for j in 0..k {
             let yj = y[j];
@@ -168,7 +147,7 @@ impl GmresSolver {
             }
         }
     }
-    fn axpy_update_zcols(x: &mut [f64], ws: &Workspace, k: usize, y: &[f64]) {
+    fn axpy_update_zcols(x: &mut [S], ws: &Workspace, k: usize, y: &[S]) {
         let n = ws.n();
         for j in 0..k {
             let yj = y[j];
@@ -318,52 +297,68 @@ impl LinearSolver for GmresSolver {
             &mut owned_ws
         };
         self.ensure_workspace(ws, n, pc_side);
+
+        let mons = monitors.unwrap_or(&[]);
+
+        let mut x_s = vec![S::zero(); n];
+        copy_real_to_scalar_in(x, &mut x_s);
+        let mut b_s = vec![S::zero(); n];
+        copy_real_to_scalar_in(b, &mut b_s);
+
         // r0 = b - A x
-        a.matvec(x, &mut ws.tmp1);
+        matvec_s(a, &x_s, &mut ws.tmp1, &mut ws.bridge);
         for i in 0..n {
-            ws.tmp1[i] = b[i] - ws.tmp1[i];
+            ws.tmp1[i] = b_s[i] - ws.tmp1[i];
         }
 
-        ws.h_mem.fill(0.0);
+        ws.h_mem.fill(S::zero());
         ws.cs.fill(0.0);
-        ws.sn.fill(0.0);
-        ws.g.fill(0.0);
+        ws.sn.fill(S::zero());
+        ws.g.fill(S::zero());
 
-        let beta = match pc_side {
+        let mut res: R;
+        let beta: R = match pc_side {
             PcSide::Left => {
-                self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                let beta = Self::nrm2(&ws.tmp2);
+                if let Some(pc) = pc {
+                    let tmp2 = &mut ws.tmp2[..n];
+                    apply_pc_s(pc, PcSide::Left, &ws.tmp1[..n], tmp2, &mut ws.bridge)?;
+                } else {
+                    ws.tmp2[..n].copy_from_slice(&ws.tmp1[..n]);
+                }
+                let beta = nrm2(&ws.tmp2[..n]);
                 if beta > 0.0 {
-                    for i in 0..n {
-                        ws.tmp2[i] /= beta;
+                    let inv = S::from_real(1.0 / beta);
+                    for val in &mut ws.tmp2[..n] {
+                        *val *= inv;
                     }
                     ws.copy_tmp2_into_vcol(0);
                 } else {
-                    ws.v_col(0).fill(0.0);
+                    ws.v_col(0).fill(S::zero());
                 }
                 beta
             }
             PcSide::Right => {
-                let beta = Self::nrm2(&ws.tmp1);
+                let beta = nrm2(&ws.tmp1[..n]);
                 if beta > 0.0 {
-                    for i in 0..n {
-                        ws.tmp2[i] = ws.tmp1[i] / beta;
+                    let inv = S::from_real(1.0 / beta);
+                    for (dst, &src) in ws.tmp2[..n].iter_mut().zip(&ws.tmp1[..n]) {
+                        *dst = src * inv;
                     }
                     ws.copy_tmp2_into_vcol(0);
                 } else {
-                    ws.v_col(0).fill(0.0);
+                    ws.v_col(0).fill(S::zero());
                 }
                 beta
             }
             PcSide::Symmetric => unreachable!(),
         };
 
-        ws.g[0] = beta;
-        let bnorm = Self::nrm2(b).max(1e-32);
+        ws.g[0] = S::from_real(beta);
+        let bnorm = nrm2(&b_s).max(1e-32);
         let thr = self.conv.atol.max(self.conv.rtol * bnorm);
 
         let mut total_iters = 0usize;
-        let mut res = beta;
+        res = beta;
         let mut stats = SolveStats::new(0, res, ConvergedReason::Continued);
         let start_reduct = crate::utils::reduction::test_hooks::wait_counters();
 
@@ -373,10 +368,8 @@ impl LinearSolver for GmresSolver {
             ));
         }
 
-        if let Some(ms) = monitors {
-            for m in ms {
-                m(0, res);
-            }
+        for m in mons {
+            m(0, res);
         }
         if res <= thr {
             stats.reason = if res <= self.conv.atol {
@@ -385,6 +378,10 @@ impl LinearSolver for GmresSolver {
                 ConvergedReason::ConvergedRtol
             };
             stats.final_residual = res;
+            copy_scalar_to_real_in(&x_s, x);
+            let tmp = ws.bridge.xr(n);
+            let true_res = recompute_true_residual_norm(a, b, x, comm, tmp);
+            stats.final_residual = true_res;
             let end_reduct = crate::utils::reduction::test_hooks::wait_counters();
             let reductions = end_reduct.0 + end_reduct.1 - start_reduct.0 - start_reduct.1;
             let counters = crate::utils::convergence::SolverCounters {
@@ -401,98 +398,149 @@ impl LinearSolver for GmresSolver {
                     GmresVariant::Classical => match pc_side {
                         PcSide::Left => {
                             let vk = &ws.v_mem[k * n..(k + 1) * n];
-                            a.matvec(vk, &mut ws.tmp1);
-                            self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                            for i in 0..=k {
-                                let hij;
-                                {
+                            matvec_s(a, vk, &mut ws.tmp1, &mut ws.bridge);
+                            if let Some(pc) = pc {
+                                let tmp2 = &mut ws.tmp2[..n];
+                                apply_pc_s(pc, PcSide::Left, &ws.tmp1[..n], tmp2, &mut ws.bridge)?;
+                            } else {
+                                ws.tmp2[..n].copy_from_slice(&ws.tmp1[..n]);
+                            }
+                            let mut hvals = vec![S::zero(); k + 1];
+                            {
+                                let tmp2 = &mut ws.tmp2[..n];
+                                for i in 0..=k {
                                     let vi = &ws.v_mem[i * n..(i + 1) * n];
-                                    hij = Self::dot(&ws.tmp2, vi);
-                                    for (w, &vi_j) in ws.tmp2.iter_mut().zip(vi) {
+                                    let hij = dot_conj(vi, tmp2);
+                                    hvals[i] = hij;
+                                    for (w, &vi_j) in tmp2.iter_mut().zip(vi) {
                                         *w -= hij * vi_j;
                                     }
                                 }
-                                *ws.h_at_mut(i, k) = hij;
                             }
-                            let hnext = Self::nrm2(&ws.tmp2);
-                            *ws.h_at_mut(k + 1, k) = hnext;
+                            for i in 0..=k {
+                                *ws.h_at_mut(i, k) = hvals[i];
+                            }
+                            let hnext = nrm2(&ws.tmp2[..n]);
+                            *ws.h_at_mut(k + 1, k) = S::from_real(hnext);
                             if hnext > 0.0 {
-                                for i in 0..n {
-                                    ws.tmp2[i] /= hnext;
+                                let inv = S::from_real(1.0 / hnext);
+                                for val in &mut ws.tmp2[..n] {
+                                    *val *= inv;
                                 }
                                 ws.copy_tmp2_into_vcol(k + 1);
                             } else {
-                                ws.v_col(k + 1).fill(0.0);
+                                ws.v_col(k + 1).fill(S::zero());
                             }
                         }
                         PcSide::Right => {
                             let vk = &ws.v_mem[k * n..(k + 1) * n];
-                            self.apply_precond(pc, PcSide::Right, vk, &mut ws.tmp2)?;
-                            {
-                                let zk = &mut ws.z_mem[k * n..(k + 1) * n];
-                                zk.copy_from_slice(&ws.tmp2[..n]);
+                            if let Some(pc) = pc {
+                                let tmp2 = &mut ws.tmp2[..n];
+                                apply_pc_s(pc, PcSide::Right, vk, tmp2, &mut ws.bridge)?;
+                            } else {
+                                ws.tmp2[..n].copy_from_slice(vk);
                             }
-                            a.matvec(&ws.tmp2, &mut ws.tmp1);
-                            for i in 0..=k {
-                                let hij;
-                                {
+                            {
+                                let (tmp2, zk) = ws.tmp2_and_z_mut(k);
+                                zk.copy_from_slice(tmp2);
+                            }
+                            matvec_s(a, &ws.tmp2[..n], &mut ws.tmp1, &mut ws.bridge);
+                            let mut hvals = vec![S::zero(); k + 1];
+                            {
+                                let tmp1 = &mut ws.tmp1[..n];
+                                for i in 0..=k {
                                     let vi = &ws.v_mem[i * n..(i + 1) * n];
-                                    hij = Self::dot(&ws.tmp1, vi);
-                                    for (w, &vi_j) in ws.tmp1.iter_mut().zip(vi) {
+                                    let hij = dot_conj(vi, tmp1);
+                                    hvals[i] = hij;
+                                    for (w, &vi_j) in tmp1.iter_mut().zip(vi) {
                                         *w -= hij * vi_j;
                                     }
                                 }
-                                *ws.h_at_mut(i, k) = hij;
                             }
-                            let hnext = Self::nrm2(&ws.tmp1);
-                            *ws.h_at_mut(k + 1, k) = hnext;
+                            for i in 0..=k {
+                                *ws.h_at_mut(i, k) = hvals[i];
+                            }
+                            let hnext = nrm2(&ws.tmp1[..n]);
+                            *ws.h_at_mut(k + 1, k) = S::from_real(hnext);
                             if hnext > 0.0 {
-                                for i in 0..n {
-                                    ws.tmp1[i] /= hnext;
+                                let inv = S::from_real(1.0 / hnext);
+                                for val in &mut ws.tmp1[..n] {
+                                    *val *= inv;
                                 }
                                 ws.copy_tmp1_into_vcol(k + 1);
                             } else {
-                                ws.v_col(k + 1).fill(0.0);
+                                ws.v_col(k + 1).fill(S::zero());
                             }
                         }
                         PcSide::Symmetric => unreachable!(),
                     },
-                    GmresVariant::Pipelined => match pc_side {
-                        PcSide::Left => {
-                            let vk = &ws.v_mem[k * n..(k + 1) * n];
-                            a.matvec(vk, &mut ws.tmp1);
-                            self.apply_precond(
-                                pc,
-                                PcSide::Left,
-                                &ws.tmp1,
-                                ws.pipelined_w.as_mut_slice(),
-                            )?;
-                            let _ = ws.pipelined_arnoldi_step(
-                                k,
-                                n,
-                                comm,
-                                self.reorth,
-                                self.reorth_tol,
-                            )?;
+                    GmresVariant::Pipelined => {
+                        #[cfg(feature = "complex")]
+                        {
+                            return Err(KError::NotImplemented(
+                                "Pipelined GMRES is not yet implemented for complex scalars",
+                            ));
                         }
-                        PcSide::Right => {
-                            let vk = &ws.v_mem[k * n..(k + 1) * n];
-                            self.apply_precond(pc, PcSide::Right, vk, &mut ws.tmp2)?;
-                            {
-                                let zk = &mut ws.z_mem[k * n..(k + 1) * n];
-                                zk.copy_from_slice(&ws.tmp2[..n]);
+                        #[cfg(not(feature = "complex"))]
+                        {
+                            match pc_side {
+                                PcSide::Left => {
+                                    let vk = &ws.v_mem[k * n..(k + 1) * n];
+                                    matvec_s(a, vk, &mut ws.tmp1, &mut ws.bridge);
+                                    if let Some(pc) = pc {
+                                        apply_pc_s(
+                                            pc,
+                                            PcSide::Left,
+                                            &ws.tmp1[..n],
+                                            ws.pipelined_w.as_mut_slice(),
+                                            &mut ws.bridge,
+                                        )?;
+                                    } else {
+                                        ws.pipelined_w[..n].copy_from_slice(&ws.tmp1[..n]);
+                                    }
+                                    let _ = ws.pipelined_arnoldi_step(
+                                        k,
+                                        n,
+                                        comm,
+                                        self.reorth,
+                                        self.reorth_tol,
+                                    )?;
+                                }
+                                PcSide::Right => {
+                                    let vk = &ws.v_mem[k * n..(k + 1) * n];
+                                    if let Some(pc) = pc {
+                                        apply_pc_s(
+                                            pc,
+                                            PcSide::Right,
+                                            vk,
+                                            &mut ws.tmp2[..n],
+                                            &mut ws.bridge,
+                                        )?;
+                                    } else {
+                                        ws.tmp2[..n].copy_from_slice(vk);
+                                    }
+                                    {
+                                        let (tmp2, zk) = ws.tmp2_and_z_mut(k);
+                                        zk.copy_from_slice(tmp2);
+                                    }
+                                    matvec_s(
+                                        a,
+                                        &ws.tmp2[..n],
+                                        ws.pipelined_w.as_mut_slice(),
+                                        &mut ws.bridge,
+                                    );
+                                    let _ = ws.pipelined_arnoldi_step(
+                                        k,
+                                        n,
+                                        comm,
+                                        self.reorth,
+                                        self.reorth_tol,
+                                    )?;
+                                }
+                                PcSide::Symmetric => unreachable!(),
                             }
-                            a.matvec(&ws.tmp2, ws.pipelined_w.as_mut_slice());
-                            let _ = ws.pipelined_arnoldi_step(
-                                k,
-                                n,
-                                comm,
-                                self.reorth,
-                                self.reorth_tol,
-                            )?;
                         }
-                        PcSide::Symmetric => unreachable!(),
-                    },
+                    }
                     GmresVariant::SStep { .. } => {
                         unreachable!("s-step path should exit before iteration loop")
                     }
@@ -505,88 +553,102 @@ impl LinearSolver for GmresSolver {
                 total_iters += 1;
                 k_steps = k + 1;
 
-                if let Some(ms) = monitors {
-                    for m in ms {
-                        m(total_iters, res);
-                    }
+                for m in mons {
+                    m(total_iters, res);
                 }
 
-                if res <= thr {
-                    break;
-                }
-
-                if total_iters >= self.conv.max_iters {
+                if res <= thr || total_iters >= self.conv.max_iters {
                     break;
                 }
             }
 
-            let y = Self::backsolve(&ws.h_mem, &ws.g, k_steps);
+            if k_steps == 0 {
+                break;
+            }
+
+            let y = Self::backsolve(&ws.h_mem, &ws.g, k_steps, ws.ld_h());
             match pc_side {
-                PcSide::Left => Self::axpy_update_vcols(x, ws, k_steps, &y),
-                PcSide::Right => Self::axpy_update_zcols(x, ws, k_steps, &y),
+                PcSide::Left => Self::axpy_update_vcols(&mut x_s, ws, k_steps, &y),
+                PcSide::Right => Self::axpy_update_zcols(&mut x_s, ws, k_steps, &y),
                 PcSide::Symmetric => unreachable!(),
             }
 
             // Recompute residual
-            a.matvec(x, &mut ws.tmp1);
+            matvec_s(a, &x_s, &mut ws.tmp1, &mut ws.bridge);
             for i in 0..n {
-                ws.tmp1[i] = b[i] - ws.tmp1[i];
+                ws.tmp1[i] = b_s[i] - ws.tmp1[i];
             }
             res = match pc_side {
                 PcSide::Left => {
-                    self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                    Self::nrm2(&ws.tmp2)
+                    if let Some(pc) = pc {
+                        let tmp2 = &mut ws.tmp2[..n];
+                        apply_pc_s(pc, PcSide::Left, &ws.tmp1[..n], tmp2, &mut ws.bridge)?;
+                    } else {
+                        ws.tmp2[..n].copy_from_slice(&ws.tmp1[..n]);
+                    }
+                    nrm2(&ws.tmp2[..n])
                 }
-                PcSide::Right => Self::nrm2(&ws.tmp1),
+                PcSide::Right => nrm2(&ws.tmp1[..n]),
                 PcSide::Symmetric => unreachable!(),
             };
+
+            stats.iterations = total_iters;
+            stats.final_residual = res;
 
             if res <= thr || total_iters >= self.conv.max_iters {
                 break 'outer;
             }
 
             // Prepare next cycle
-            ws.h_mem.fill(0.0);
+            ws.h_mem.fill(S::zero());
             ws.cs.fill(0.0);
-            ws.sn.fill(0.0);
-            ws.g.fill(0.0);
+            ws.sn.fill(S::zero());
+            ws.g.fill(S::zero());
 
-            match pc_side {
+            let beta = match pc_side {
                 PcSide::Left => {
-                    self.apply_precond(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2)?;
-                    let beta = Self::nrm2(&ws.tmp2);
+                    if let Some(pc) = pc {
+                        let tmp2 = &mut ws.tmp2[..n];
+                        apply_pc_s(pc, PcSide::Left, &ws.tmp1[..n], tmp2, &mut ws.bridge)?;
+                    } else {
+                        ws.tmp2[..n].copy_from_slice(&ws.tmp1[..n]);
+                    }
+                    let beta = nrm2(&ws.tmp2[..n]);
                     if beta > 0.0 {
-                        for i in 0..n {
-                            ws.tmp2[i] /= beta;
+                        let inv = S::from_real(1.0 / beta);
+                        for val in &mut ws.tmp2[..n] {
+                            *val *= inv;
                         }
                         ws.copy_tmp2_into_vcol(0);
                     } else {
-                        ws.v_col(0).fill(0.0);
+                        ws.v_col(0).fill(S::zero());
                     }
-                    ws.g[0] = beta;
+                    beta
                 }
                 PcSide::Right => {
-                    let beta = Self::nrm2(&ws.tmp1);
+                    let beta = nrm2(&ws.tmp1[..n]);
                     if beta > 0.0 {
-                        for i in 0..n {
-                            ws.tmp2[i] = ws.tmp1[i] / beta;
+                        let inv = S::from_real(1.0 / beta);
+                        for (dst, &src) in ws.tmp2[..n].iter_mut().zip(&ws.tmp1[..n]) {
+                            *dst = src * inv;
                         }
                         ws.copy_tmp2_into_vcol(0);
                     } else {
-                        ws.v_col(0).fill(0.0);
+                        ws.v_col(0).fill(S::zero());
                     }
-                    ws.g[0] = beta;
+                    beta
                 }
                 PcSide::Symmetric => unreachable!(),
-            }
+            };
+            ws.g[0] = S::from_real(beta);
         }
 
-        // Compute true residual for reporting using the communicator
-        let true_res = recompute_true_residual_norm(a, b, x, comm, &mut ws.tmp1);
+        copy_scalar_to_real_in(&x_s, x);
+        let tmp = ws.bridge.xr(n);
+        let true_res = recompute_true_residual_norm(a, b, x, comm, tmp);
         let (mut reason, mut s) = self.conv.check(true_res, bnorm, total_iters);
         s.final_residual = true_res;
         if matches!(reason, ConvergedReason::Continued) {
-            // Normalize reason based on absolute/relative thresholds
             reason = if true_res <= self.conv.atol {
                 ConvergedReason::ConvergedAtol
             } else if true_res <= self.conv.rtol * bnorm {

--- a/src/solver/pca_gmres.rs
+++ b/src/solver/pca_gmres.rs
@@ -5,6 +5,7 @@ use crate::algebra::blas::{dot_conj, nrm2};
 use crate::algebra::bridge::BridgeScratch;
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
+use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -13,6 +14,7 @@ use crate::parallel::UniverseComm;
 use crate::preconditioner::bridge::apply_pc_s;
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
+use crate::solver::common::givens::{apply_new_givens_and_update_g, apply_prev_givens_to_col};
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -85,12 +87,12 @@ impl PcaGmresSolver {
         }
 
         // Hessenberg
-        if w.h.len() < m + 1 {
-            w.h.resize(m + 1, Vec::new());
+        if w.h_s.len() < m {
+            w.h_s.resize(m, Vec::new());
         }
-        for row in &mut w.h[..m + 1] {
-            if row.len() != m {
-                row.resize(m, 0.0);
+        for col in &mut w.h_s[..m] {
+            if col.len() != m + 1 {
+                col.resize(m + 1, S::zero());
             }
         }
 
@@ -105,7 +107,7 @@ impl PcaGmresSolver {
             w.cs.resize(m, 0.0);
         }
         if w.sn.len() < m {
-            w.sn.resize(m, 0.0);
+            w.sn.resize(m, S::zero());
         }
         if w.g.len() < m + 1 {
             w.g.resize(m + 1, S::zero());
@@ -147,12 +149,13 @@ impl PcaGmresSolver {
         v_basis: &[Vec<S>],
         k: usize,
         w: &mut [S],
-        h: &mut [Vec<f64>],
+        hcols: &mut [Vec<S>],
     ) -> R {
+        let hcol = &mut hcols[k];
         // First pass
         for i in 0..=k {
             let hij: S = dot_conj(&v_basis[i], w);
-            h[i][k] = hij.real();
+            hcol[i] = hij;
             for (wi, &vi) in w.iter_mut().zip(&v_basis[i]) {
                 *wi -= hij * vi;
             }
@@ -162,30 +165,21 @@ impl PcaGmresSolver {
             for i in 0..=k {
                 let corr: S = dot_conj(&v_basis[i], w);
                 if corr.abs() > 1e-12 {
-                    h[i][k] += corr.real();
+                    hcol[i] += corr;
                     for (wi, &vi) in w.iter_mut().zip(&v_basis[i]) {
                         *wi -= corr * vi;
                     }
                 }
             }
         }
-        nrm2(w)
-    }
-
-    #[inline]
-    fn apply_givens(hij: &mut f64, hij1: &mut f64, c: f64, s: f64) {
-        let t = c * (*hij) + s * (*hij1);
-        *hij1 = -s * (*hij) + c * (*hij1);
-        *hij = t;
-    }
-    #[inline]
-    fn givens(a: f64, b: f64) -> (f64, f64) {
-        if b == 0.0 {
-            (1.0, 0.0)
-        } else {
-            let r = (a * a + b * b).sqrt();
-            (a / r, b / r)
+        let hnorm = nrm2(w);
+        if hcol.len() > k + 1 {
+            hcol[k + 1] = S::from_real(hnorm);
+            for val in hcol.iter_mut().skip(k + 2) {
+                *val = S::zero();
+            }
         }
+        hnorm
     }
 }
 
@@ -205,14 +199,14 @@ impl LinearSolver for PcaGmresSolver {
         if w.z_s.len() < m {
             w.z_s.resize(m, Vec::new());
         }
-        if w.h.len() < m + 1 {
-            w.h.resize(m + 1, Vec::new());
+        if w.h_s.len() < m {
+            w.h_s.resize(m, Vec::new());
         }
         if w.cs.len() < m {
             w.cs.resize(m, 0.0);
         }
         if w.sn.len() < m {
-            w.sn.resize(m, 0.0);
+            w.sn.resize(m, S::zero());
         }
         if w.g.len() < m + 1 {
             w.g.resize(m + 1, S::zero());
@@ -268,10 +262,18 @@ impl LinearSolver for PcaGmresSolver {
         };
         self.ensure_workspace(ws, n);
 
+        let mut x_s = vec![S::zero(); n];
+        copy_real_to_scalar_in(&x[..], &mut x_s);
+        let mut write_back = |xs: &[S]| {
+            copy_scalar_to_real_in(xs, x);
+        };
+        let mut b_s = vec![S::zero(); n];
+        copy_real_to_scalar_in(b, &mut b_s);
+
         // r = b - A x
-        matvec_s(a, x, &mut ws.tmp1, &mut ws.bridge);
+        matvec_s(a, &x_s, &mut ws.tmp1, &mut ws.bridge);
         for i in 0..n {
-            ws.tmp1[i] = S::from_real(b[i]) - ws.tmp1[i];
+            ws.tmp1[i] = b_s[i] - ws.tmp1[i];
         }
 
         // Initialize v0 and g[0] according to mode
@@ -320,13 +322,13 @@ impl LinearSolver for PcaGmresSolver {
             }
         };
 
-        ws.h.iter_mut().for_each(|row| row.fill(0.0));
+        ws.h_s.iter_mut().for_each(|row| row.fill(S::zero()));
         ws.cs.fill(0.0);
-        ws.sn.fill(0.0);
+        ws.sn.fill(S::zero());
         ws.g.fill(S::zero());
         ws.g[0] = S::from_real(beta0);
 
-        let bnorm = b.iter().map(|&bi| bi * bi).sum::<R>().sqrt().max(1e-32);
+        let bnorm = nrm2(&b_s).max(1e-32);
         let thr = self.conv.atol.max(self.conv.rtol * bnorm);
 
         let mut total_iters = 0usize;
@@ -345,6 +347,7 @@ impl LinearSolver for PcaGmresSolver {
             } else {
                 ConvergedReason::ConvergedRtol
             };
+            write_back(&x_s);
             return Ok(stats);
         }
 
@@ -380,8 +383,7 @@ impl LinearSolver for PcaGmresSolver {
                 }
 
                 // Orthonormalize against V
-                let hnorm = self.project_and_normalize(&ws.q_s, k, &mut ws.tmp1, &mut ws.h);
-                ws.h[k + 1][k] = hnorm;
+                let hnorm = self.project_and_normalize(&ws.q_s, k, &mut ws.tmp1, &mut ws.h_s);
 
                 // v_{k+1}
                 let vnext = &mut ws.q_s[k + 1][..];
@@ -394,29 +396,15 @@ impl LinearSolver for PcaGmresSolver {
                     vnext.fill(S::zero());
                 }
 
-                // Apply stored Givens
-                for i in 0..k {
-                    let (top, rest) = ws.h.split_at_mut(i + 1);
-                    let hij = &mut top[i][k];
-                    let hij1 = &mut rest[0][k];
-                    Self::apply_givens(hij, hij1, ws.cs[i], ws.sn[i]);
-                }
-                // New Givens
-                let (top, rest) = ws.h.split_at_mut(k + 1);
-                let hjk = &mut top[k][k];
-                let hj1k = &mut rest[0][k];
-                let (c, s) = Self::givens(*hjk, *hj1k);
-                ws.cs[k] = c;
-                ws.sn[k] = s;
-                Self::apply_givens(hjk, hj1k, c, s);
-
-                // Update RHS g
-                let gk = ws.g[k];
-                let gk1 = ws.g[k + 1];
-                let c_s = S::from_real(c);
-                let s_s = S::from_real(s);
-                ws.g[k] = c_s * gk + s_s * gk1;
-                ws.g[k + 1] = -s_s * gk + c_s * gk1;
+                let hcol = &mut ws.h_s[k];
+                apply_prev_givens_to_col(&mut hcol[..=k + 1], k, &ws.cs, &ws.sn);
+                apply_new_givens_and_update_g(
+                    &mut hcol[..=k + 1],
+                    k,
+                    &mut ws.cs,
+                    &mut ws.sn,
+                    &mut ws.g,
+                );
 
                 res = ws.g[k + 1].abs(); // estimate; equals true ||r|| for Right/None, precond ||M^{-1}r|| for Left
                 total_iters += 1;
@@ -445,10 +433,10 @@ impl LinearSolver for PcaGmresSolver {
             let mut y = vec![S::zero(); k];
             for i in (0..k).rev() {
                 let mut sum = ws.g[i];
-                for l in (i + 1)..k {
-                    sum -= S::from_real(ws.h[i][l]) * y[l];
+                for j in (i + 1)..k {
+                    sum -= ws.h_s[j][i] * y[j];
                 }
-                y[i] = sum / S::from_real(ws.h[i][i]);
+                y[i] = sum / ws.h_s[i][i];
             }
 
             // Update x with V or Z depending on mode
@@ -456,7 +444,7 @@ impl LinearSolver for PcaGmresSolver {
                 PcaPcMode::Right => {
                     for i in 0..k {
                         let zi = &ws.z_s[i][..];
-                        for (xj, &zij) in x.iter_mut().zip(zi) {
+                        for (xj, &zij) in x_s.iter_mut().zip(zi) {
                             *xj += y[i] * zij;
                         }
                     }
@@ -464,7 +452,7 @@ impl LinearSolver for PcaGmresSolver {
                 PcaPcMode::None | PcaPcMode::Left => {
                     for i in 0..k {
                         let vi = &ws.q_s[i][..];
-                        for (xj, &vij) in x.iter_mut().zip(vi) {
+                        for (xj, &vij) in x_s.iter_mut().zip(vi) {
                             *xj += y[i] * vij;
                         }
                     }
@@ -472,9 +460,9 @@ impl LinearSolver for PcaGmresSolver {
             }
 
             // Restart: r = b - A x, rebuild v0 based on mode
-            matvec_s(a, x, &mut ws.tmp1, &mut ws.bridge);
+            matvec_s(a, &x_s, &mut ws.tmp1, &mut ws.bridge);
             for i in 0..n {
-                ws.tmp1[i] = S::from_real(b[i]) - ws.tmp1[i];
+                ws.tmp1[i] = b_s[i] - ws.tmp1[i];
             }
             let beta0_new: R = match mode {
                 PcaPcMode::None => {
@@ -520,9 +508,9 @@ impl LinearSolver for PcaGmresSolver {
             };
 
             // Reset Hessenberg and RHS for next cycle
-            ws.h.iter_mut().for_each(|row| row.fill(0.0));
+            ws.h_s.iter_mut().for_each(|row| row.fill(S::zero()));
             ws.cs.fill(0.0);
-            ws.sn.fill(0.0);
+            ws.sn.fill(S::zero());
             ws.g.fill(S::zero());
             ws.g[0] = S::from_real(beta0_new);
 
@@ -541,9 +529,9 @@ impl LinearSolver for PcaGmresSolver {
         }
 
         // Report *true* residual at the end for consistency
-        matvec_s(a, x, &mut ws.tmp1, &mut ws.bridge);
+        matvec_s(a, &x_s, &mut ws.tmp1, &mut ws.bridge);
         for i in 0..n {
-            ws.tmp1[i] = b[i] - ws.tmp1[i];
+            ws.tmp1[i] = b_s[i] - ws.tmp1[i];
         }
         let true_res: R = nrm2(&ws.tmp1);
         let (_r, mut s) = self.conv.check(true_res, bnorm, total_iters);
@@ -560,6 +548,7 @@ impl LinearSolver for PcaGmresSolver {
                 ConvergedReason::DivergedMaxIts
             };
         }
+        write_back(&x_s);
         Ok(s)
     }
 }
@@ -573,5 +562,35 @@ impl PcaGmresSolver {
     }
     pub fn set_reorthog(&mut self, flag: bool) {
         self.modified_gs = flag;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::algebra::blas::{dot_conj, nrm2};
+    use crate::context::ksp_context::Workspace;
+
+    #[test]
+    fn arnoldi_project_and_normalize_orthonormalizes_vector() {
+        let solver = PcaGmresSolver::new(2, 1, 1, 1e-6, 10);
+        let n = 2;
+        let mut ws = Workspace::new(n);
+        solver.ensure_workspace(&mut ws, n);
+
+        ws.q_s[0][0] = S::one();
+        ws.q_s[0][1] = S::zero();
+        ws.h_s.iter_mut().for_each(|col| col.fill(S::zero()));
+
+        let mut w = vec![S::zero(); n];
+        w[1] = S::one();
+
+        let hnorm = solver.project_and_normalize(&ws.q_s, 0, &mut w, &mut ws.h_s);
+
+        assert!((hnorm - 1.0).abs() < 1e-12);
+        assert!((nrm2(&w) - 1.0).abs() < 1e-12);
+        assert!(dot_conj(&ws.q_s[0], &w).abs() < 1e-12);
+        assert!(ws.h_s[0][0].abs() < 1e-12);
+        assert!((ws.h_s[0][1].abs() - 1.0).abs() < 1e-12);
     }
 }

--- a/src/solver/tfqmr.rs
+++ b/src/solver/tfqmr.rs
@@ -5,6 +5,7 @@
 use crate::algebra::blas::{dot_conj, nrm2};
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
+use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
 use crate::matrix::op::LinOp;
@@ -107,7 +108,13 @@ impl LinearSolver for TfqmrSolver {
             w.bridge_tmp.resize(n, S::zero());
         }
 
-        matvec_s(a, x, r, &mut w.bridge);
+        let mut x_s = vec![S::zero(); n];
+        copy_real_to_scalar_in(&x[..], &mut x_s);
+        let mut write_back = |xs: &[S]| {
+            copy_scalar_to_real_in(xs, x);
+        };
+
+        matvec_s(a, &x_s, r, &mut w.bridge);
         for i in 0..n {
             r[i] = S::from_real(b[i]) - r[i];
         }
@@ -127,10 +134,12 @@ impl LinearSolver for TfqmrSolver {
 
         if res0 <= self.conv.atol.max(self.conv.rtol * res0.max(1e-300)) {
             stats.reason = ConvergedReason::ConvergedAtol;
+            write_back(&x_s);
             return Ok(stats);
         }
         if !rho.is_finite() || rho.abs() < self.breakdown_eps {
             stats.reason = ConvergedReason::DivergedDtol;
+            write_back(&x_s);
             return Ok(stats);
         }
 
@@ -156,6 +165,7 @@ impl LinearSolver for TfqmrSolver {
                 stats.iterations = k;
                 stats.final_residual = true_res;
                 stats.reason = ConvergedReason::DivergedDtol;
+                write_back(&x_s);
                 return Ok(stats);
             }
             let alpha = rho / sigma;
@@ -163,6 +173,7 @@ impl LinearSolver for TfqmrSolver {
                 stats.iterations = k;
                 stats.final_residual = true_res;
                 stats.reason = ConvergedReason::DivergedDtol;
+                write_back(&x_s);
                 return Ok(stats);
             }
 
@@ -203,7 +214,7 @@ impl LinearSolver for TfqmrSolver {
                     };
                     for i in 0..n {
                         d[i] = src[i] + cf * d[i];
-                        x[i] += eta * d[i];
+                        x_s[i] += eta * d[i];
                     }
 
                     let iter_count = 2 * (k - 1) + mstep + 1;
@@ -224,7 +235,7 @@ impl LinearSolver for TfqmrSolver {
                                 ConvergedReason::ConvergedRtol | ConvergedReason::ConvergedAtol
                             ))
                     {
-                        matvec_s(a, x, au, &mut w.bridge);
+                        matvec_s(a, &x_s, au, &mut w.bridge);
                         for i in 0..n {
                             au[i] = S::from_real(b[i]) - au[i];
                         }
@@ -243,6 +254,7 @@ impl LinearSolver for TfqmrSolver {
                         reason,
                         ConvergedReason::ConvergedRtol | ConvergedReason::ConvergedAtol
                     ) {
+                        write_back(&x_s);
                         return Ok(stats);
                     }
                 }
@@ -259,6 +271,7 @@ impl LinearSolver for TfqmrSolver {
             if !rho_new.is_finite() || rho_new.abs() < self.breakdown_eps {
                 stats.iterations = k;
                 stats.reason = ConvergedReason::DivergedDtol;
+                write_back(&x_s);
                 return Ok(stats);
             }
             let beta = rho_new / rho;
@@ -272,7 +285,7 @@ impl LinearSolver for TfqmrSolver {
             dpold = nrm2(r);
 
             if self.resid_recalc_every == 1 {
-                matvec_s(a, x, au, &mut w.bridge);
+                matvec_s(a, &x_s, au, &mut w.bridge);
                 for i in 0..n {
                     au[i] = S::from_real(b[i]) - au[i];
                 }
@@ -289,6 +302,7 @@ impl LinearSolver for TfqmrSolver {
                     reason,
                     ConvergedReason::ConvergedRtol | ConvergedReason::ConvergedAtol
                 ) {
+                    write_back(&x_s);
                     return Ok(stats);
                 }
             }
@@ -301,6 +315,7 @@ impl LinearSolver for TfqmrSolver {
         ) {
             stats.reason = ConvergedReason::DivergedMaxIts;
         }
+        write_back(&x_s);
         Ok(stats)
     }
 }


### PR DESCRIPTION
## Summary
- bridge GMRES to operate on scalar work buffers via dot_conj/nrm2, convert inputs/outputs, and gate pipelined mode behind a complex-specific NotImplemented path
- update FGMRES to use the scalar bridges and shared Arnoldi/Givens helpers while copying results back to the caller at exit
- guard the workspace pipelined Arnoldi helper so complex builds surface an explicit NotImplemented error instead of mis-compiling

## Testing
- cargo check

------
https://chatgpt.com/codex/tasks/task_e_68df22f9c83c83299a6789c10a8a48f6