### PR TITLE
Fix generic CSR operator trait bounds

### DIFF
--- a/src/matrix/convert.rs
+++ b/src/matrix/convert.rs
@@ -5,11 +5,12 @@ use faer::Mat;
 use crate::{
     error::KError,
     matrix::{
-        csc::CscMatrix,
-        format::{AsFormat, FormatHint},
-        op::{DenseOp, LinOp, wrap_with_comm},
-        sparse::CsrMatrix,
         DistCsrOp,
+        csc::CscMatrix,
+        csr::CsrMatrix as ScalarCsrMatrix,
+        format::{AsFormat, FormatHint},
+        op::{DenseOp, GenericCsrOp, LinOp, wrap_with_comm},
+        sparse::CsrMatrix,
     },
 };
 
@@ -36,6 +37,9 @@ fn unsupported_linop_err(op: &dyn LinOp<S = f64>, where_: &str, target: &str) ->
         "  • If you have a CSR matrix (`CsrMatrix<f64>`), wrap it with `CsrOp` likewise:\n",
     );
     help.push_str("      let op = CsrOp::new(Arc::new(csr));\n");
+    help.push_str(
+        "  • If you have a generic CSR operator (`GenericCsrOp<f64>`), conversions clone its storage automatically.\n",
+    );
     help.push_str("  • If this is your own LinOp type, implement `matrix::format::AsFormat` for it to enable cached conversions.\n");
     help.push_str(
         "  • If running distributed, attach the communicator with `wrap_with_comm(op, comm)`.\n",
@@ -47,6 +51,16 @@ fn unsupported_linop_err(op: &dyn LinOp<S = f64>, where_: &str, target: &str) ->
     }
 
     KError::InvalidInput(help)
+}
+
+fn scalar_csr_to_sparse(matrix: &ScalarCsrMatrix<f64>) -> CsrMatrix<f64> {
+    CsrMatrix::from_csr(
+        matrix.nrows,
+        matrix.ncols,
+        matrix.rowptr.clone(),
+        matrix.colind.clone(),
+        matrix.values.clone(),
+    )
 }
 
 /// Try to borrow a CSR matrix if the operator is already CSR.
@@ -66,6 +80,10 @@ pub fn to_csr_cached(
 ) -> Result<Arc<CsrMatrix<f64>>, KError> {
     if let Some(csr) = try_as_csr(pmat) {
         return Ok(Arc::new(csr.clone()));
+    }
+    if let Some(generic) = pmat.as_any().downcast_ref::<GenericCsrOp<f64>>() {
+        let csr = scalar_csr_to_sparse(generic.matrix());
+        return Ok(Arc::new(csr));
     }
     if let Some(mat) = pmat.as_any().downcast_ref::<Mat<f64>>() {
         return Ok(mat.to_csr_cached(drop_tol));
@@ -103,6 +121,10 @@ pub fn to_csc_cached(
     if let Some(mat) = pmat.as_any().downcast_ref::<Mat<f64>>() {
         return Ok(mat.to_csc_cached(drop_tol));
     }
+    if let Some(generic) = pmat.as_any().downcast_ref::<GenericCsrOp<f64>>() {
+        let csr = scalar_csr_to_sparse(generic.matrix());
+        return Ok(AsFormat::to_csc_cached(&csr, drop_tol));
+    }
     if let Some(csr) = pmat.as_any().downcast_ref::<CsrMatrix<f64>>() {
         return Ok(csr.to_csc_cached(drop_tol));
     }
@@ -127,6 +149,10 @@ pub fn csc_from_linop(
 pub fn dense_from_linop(op: &dyn LinOp<S = f64>) -> Result<Mat<f64>, KError> {
     if let Some(mat) = op.as_any().downcast_ref::<Mat<f64>>() {
         return Ok(mat.clone());
+    }
+    if let Some(generic) = op.as_any().downcast_ref::<GenericCsrOp<f64>>() {
+        let csr = scalar_csr_to_sparse(generic.matrix());
+        return Ok(csr.to_dense());
     }
     if let Some(csr) = op.as_any().downcast_ref::<CsrMatrix<f64>>() {
         return Ok(csr.to_dense());
@@ -168,6 +194,20 @@ pub fn materialize_linop_with_hint(
     }
 
     // CSR matrix
+    if let Some(generic) = op.as_any().downcast_ref::<GenericCsrOp<f64>>() {
+        let csr = scalar_csr_to_sparse(generic.matrix());
+        return Ok(match hint {
+            FormatHint::Csr => wrap_with_comm(Arc::new(csr.clone()), comm),
+            FormatHint::Csc => {
+                let csc = AsFormat::to_csc_cached(&csr, drop_tol);
+                wrap_with_comm(csc, comm)
+            }
+            FormatHint::Dense => {
+                let dense = csr.to_dense();
+                wrap_with_comm(std::sync::Arc::new(dense), comm)
+            }
+        });
+    }
     if let Some(csr) = op.as_any().downcast_ref::<CsrMatrix<f64>>() {
         return Ok(match hint {
             FormatHint::Csr => wrap_with_comm(std::sync::Arc::new(csr.clone()), comm),
@@ -250,11 +290,7 @@ pub fn materialize_linop_with_hint(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::matrix::{
-        op_shell::MatShell,
-        sparse::CsrMatrix,
-        DistCsrOp,
-    };
+    use crate::matrix::{DistCsrOp, op_shell::MatShell, sparse::CsrMatrix};
     use crate::parallel::{NoComm, UniverseComm};
 
     #[test]

--- a/src/matrix/csr.rs
+++ b/src/matrix/csr.rs
@@ -1,0 +1,54 @@
+use crate::algebra::prelude::*;
+
+/// Compressed Sparse Row matrix with scalar entries of type `S`.
+#[derive(Clone, Debug, PartialEq)]
+pub struct CsrMatrix<S: KrystScalar> {
+    pub nrows: usize,
+    pub ncols: usize,
+    /// CSR `rowptr` length = nrows + 1
+    pub rowptr: Vec<usize>,
+    /// Column indices for each nonzero (same length as `values`)
+    pub colind: Vec<usize>,
+    /// Nonzero values
+    pub values: Vec<S>,
+}
+
+impl<S: KrystScalar> CsrMatrix<S> {
+    #[inline]
+    pub fn nnz(&self) -> usize {
+        self.values.len()
+    }
+
+    #[inline]
+    pub fn dims(&self) -> (usize, usize) {
+        (self.nrows, self.ncols)
+    }
+
+    pub fn new(
+        nrows: usize,
+        ncols: usize,
+        rowptr: Vec<usize>,
+        colind: Vec<usize>,
+        values: Vec<S>,
+    ) -> Self {
+        debug_assert_eq!(rowptr.len(), nrows + 1);
+        debug_assert_eq!(colind.len(), values.len());
+        Self {
+            nrows,
+            ncols,
+            rowptr,
+            colind,
+            values,
+        }
+    }
+
+    pub fn is_valid(&self) -> bool {
+        self.rowptr.len() == self.nrows + 1
+            && self.colind.len() == self.values.len()
+            && self.rowptr.windows(2).all(|w| w[0] <= w[1])
+            && self.colind.iter().all(|&j| j < self.ncols)
+    }
+}
+
+/// Keep a convenient alias for explicitly-real use sites (e.g., file I/O).
+pub type CsrMatrix64 = CsrMatrix<f64>;

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -4,6 +4,7 @@ pub mod dense;
 pub use dense::DenseMatrix;
 pub mod convert;
 pub mod csc;
+pub mod csr;
 pub mod dist_csr;
 pub mod format;
 mod format_impls;
@@ -30,5 +31,5 @@ pub type Csr = crate::matrix::sparse::CsrMatrix<S>;
 pub type Csc = crate::matrix::csc::CscMatrix<S>;
 
 pub use dist_csr::DistCsrOp;
-pub use op::{ChangeIds, CsrOp, DenseOp, LinOp, StructureId, ValuesId};
+pub use op::{ChangeIds, CsrOp, DenseOp, GenericCsrOp, LinOp, LinOpF64, StructureId, ValuesId};
 pub use op_shell::MatShell;

--- a/src/matrix/op.rs
+++ b/src/matrix/op.rs
@@ -1,4 +1,7 @@
+use crate::algebra::scalar::KrystScalar;
 use crate::error::KError;
+use crate::matrix::csr::CsrMatrix as ScalarCsrMatrix;
+use crate::matrix::spmv::plan::{self as spmv_plan, SpmvPlan as ScalarSpmvPlan, SpmvTuning};
 use crate::parallel::{Comm, NoComm, UniverseComm};
 use faer::traits::ComplexField;
 use std::any::Any;
@@ -84,6 +87,135 @@ impl ChangeIds {
     }
     pub fn bump_values(&self) {
         self.vid.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
+/// Scalar-generic CSR linear operator backed by [`ScalarCsrMatrix`].
+///
+/// This lightweight wrapper wires the scalar-polymorphic sparse matrix storage
+/// into the [`LinOp`] trait by constructing an [`SpmvPlan`](ScalarSpmvPlan) at
+/// creation time. Real builds continue to select SIMD kernels when available
+/// while complex builds transparently fall back to the portable scalar path.
+pub struct GenericCsrOp<S: KrystScalar> {
+    matrix: Arc<ScalarCsrMatrix<S>>,
+    plan: ScalarSpmvPlan<S>,
+    ids: ChangeIds,
+    comm: UniverseComm,
+}
+
+impl<S: KrystScalar> GenericCsrOp<S> {
+    /// Wraps an [`Arc`] around the provided matrix and builds an SpMV plan
+    /// using the supplied tuning parameters.
+    pub fn new(matrix: Arc<ScalarCsrMatrix<S>>, tuning: &SpmvTuning) -> Self {
+        let plan = spmv_plan::build(matrix.as_ref(), tuning);
+        let ids = ChangeIds::default();
+        ids.bump_structure();
+        ids.bump_values();
+        Self {
+            matrix,
+            plan,
+            ids,
+            comm: UniverseComm::NoComm(NoComm),
+        }
+    }
+
+    /// Builds an operator from an owned matrix by first wrapping it in an
+    /// [`Arc`] for cheap cloning.
+    pub fn from_matrix(matrix: ScalarCsrMatrix<S>, tuning: &SpmvTuning) -> Self {
+        Self::new(Arc::new(matrix), tuning)
+    }
+
+    /// Returns the underlying CSR matrix.
+    pub fn matrix(&self) -> &ScalarCsrMatrix<S> {
+        self.matrix.as_ref()
+    }
+
+    /// Returns a reference to the cached SpMV plan.
+    pub fn plan(&self) -> &ScalarSpmvPlan<S> {
+        &self.plan
+    }
+
+    /// Rebuilds the internal SpMV plan using the latest tuning parameters.
+    pub fn rebuild_plan(&mut self, tuning: &SpmvTuning) {
+        self.plan = spmv_plan::build(self.matrix.as_ref(), tuning);
+        self.ids.bump_values();
+    }
+
+    /// Attaches a communicator to the operator, mirroring the legacy API.
+    pub fn with_comm(mut self, comm: UniverseComm) -> Self {
+        self.comm = comm;
+        self
+    }
+
+    /// Marks the sparsity pattern as changed for cache bookkeeping.
+    pub fn mark_structure_changed(&self) {
+        self.ids.bump_structure();
+    }
+
+    /// Marks only the numeric values as changed.
+    pub fn mark_values_changed(&self) {
+        self.ids.bump_values();
+    }
+}
+
+impl<S> LinOp for GenericCsrOp<S>
+where
+    S: KrystScalar + ComplexField<Real = f64>,
+{
+    type S = S;
+
+    fn dims(&self) -> (usize, usize) {
+        self.matrix.dims()
+    }
+
+    fn matvec(&self, x: &[S], y: &mut [S]) {
+        let (m, n) = self.matrix.dims();
+        debug_assert_eq!(x.len(), n);
+        debug_assert_eq!(y.len(), m);
+        self.plan.apply_scaled(S::one(), x, S::zero(), y);
+    }
+
+    fn try_matvec(&self, x: &[S], y: &mut [S]) -> Result<(), KError> {
+        let (m, n) = self.matrix.dims();
+        if x.len() != n || y.len() != m {
+            return Err(KError::InvalidInput(format!(
+                "GenericCsrOp::matvec dimension mismatch: A={}x{}, x.len()={}, y.len()={}",
+                m,
+                n,
+                x.len(),
+                y.len()
+            )));
+        }
+        self.plan.apply_scaled(S::one(), x, S::zero(), y);
+        Ok(())
+    }
+
+    fn as_any(&self) -> &dyn Any {
+        self
+    }
+
+    fn structure_id(&self) -> StructureId {
+        self.ids.structure_id()
+    }
+
+    fn values_id(&self) -> ValuesId {
+        self.ids.values_id()
+    }
+
+    fn comm(&self) -> UniverseComm {
+        self.comm.clone()
+    }
+}
+
+/// Convenience trait for callers that only operate on real scalars.
+pub trait LinOpF64 {
+    fn matvec(&self, x: &[f64], y: &mut [f64]);
+}
+
+impl LinOpF64 for GenericCsrOp<f64> {
+    #[inline]
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        <Self as LinOp>::matvec(self, x, y)
     }
 }
 
@@ -322,6 +454,13 @@ impl LinOp for CsrOp {
     }
     fn comm(&self) -> UniverseComm {
         self.comm.clone()
+    }
+}
+
+impl LinOpF64 for CsrOp {
+    #[inline]
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        <Self as LinOp>::matvec(self, x, y)
     }
 }
 
@@ -579,4 +718,75 @@ where
     T: LinOp + ?Sized + 'static,
 {
     Arc::new(WithCommOp::new(op, comm)) as Arc<dyn LinOp<S = T::S>>
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    #[cfg(feature = "complex")]
+    use crate::algebra::prelude::*;
+    use crate::matrix::spmv::scalar::spmv_csr_scalar;
+
+    #[test]
+    fn generic_csr_op_matches_scalar_kernel() {
+        let matrix = Arc::new(ScalarCsrMatrix::new(
+            3,
+            3,
+            vec![0, 2, 4, 5],
+            vec![0, 2, 1, 2, 0],
+            vec![1.0, -2.0, 3.5, 0.5, 4.0],
+        ));
+        let tuning = SpmvTuning {
+            allow_simd: false,
+            ..Default::default()
+        };
+        let op = GenericCsrOp::new(matrix.clone(), &tuning);
+
+        let x = vec![0.75, -1.25, 2.0];
+        let (m, _) = matrix.dims();
+        let mut y = vec![0.0; m];
+        LinOp::matvec(&op, &x, &mut y);
+
+        let mut y_ref = vec![0.0; m];
+        spmv_csr_scalar(matrix.as_ref(), &x, &mut y_ref);
+
+        for (lhs, rhs) in y.iter().zip(y_ref.iter()) {
+            assert!((lhs - rhs).abs() < 1e-12);
+        }
+    }
+
+    #[cfg(feature = "complex")]
+    #[test]
+    fn generic_csr_op_complex_matches_scalar_kernel() {
+        use num_complex::Complex64;
+
+        let matrix = Arc::new(ScalarCsrMatrix::new(
+            2,
+            3,
+            vec![0, 2, 3],
+            vec![0, 1, 2],
+            vec![S::from_real(1.0), S::from_real(-0.5), S::from_real(2.25)],
+        ));
+        let tuning = SpmvTuning {
+            allow_simd: false,
+            ..Default::default()
+        };
+        let op = GenericCsrOp::new(matrix.clone(), &tuning);
+
+        let x: Vec<S> = vec![
+            S::from_real(1.0),
+            S::from_real(-2.0),
+            Complex64::new(0.5, 0.75),
+        ];
+        let (m, _) = matrix.dims();
+        let mut y = vec![S::zero(); m];
+        LinOp::matvec(&op, &x, &mut y);
+
+        let mut y_ref = vec![S::zero(); m];
+        spmv_csr_scalar(matrix.as_ref(), &x, &mut y_ref);
+
+        for (lhs, rhs) in y.iter().zip(y_ref.iter()) {
+            assert!((lhs - rhs).abs() < 1e-12);
+        }
+    }
 }

--- a/src/matrix/sparse.rs
+++ b/src/matrix/sparse.rs
@@ -19,7 +19,7 @@ use faer::traits::ComplexField;
 //use faer::sparse::linalg::matmul::sparse_dense_matmul;
 
 #[cfg(feature = "simd")]
-use crate::matrix::spmv::{SpmvPlan, SpmvTuning, build_plan as build_spmv_plan};
+use crate::matrix::spmv::{SpmvPlan, SpmvTuning, build_plan_owned as build_spmv_plan};
 
 /// CSR matrix wrapper for Faer sparse matrices.
 ///
@@ -40,7 +40,7 @@ pub struct CsrMatrix<T> {
     /// dense representation.
     diag_pos: Vec<Option<usize>>,
     #[cfg(feature = "simd")]
-    spmv_plan: Option<SpmvPlan>,
+    spmv_plan: Option<SpmvPlan<f64>>,
 }
 
 impl<
@@ -211,7 +211,7 @@ impl<
                 let beta = *(&beta as *const T as *const f64);
                 let x = std::slice::from_raw_parts(x.as_ptr() as *const f64, x.len());
                 let y_slice = std::slice::from_raw_parts_mut(y.as_mut_ptr() as *mut f64, y.len());
-                plan.apply(alpha, x, beta, y_slice);
+                plan.apply_scaled(alpha, x, beta, y_slice);
             }
             return Ok(());
         }
@@ -371,7 +371,14 @@ impl<T> CsrMatrix<T> {
 impl CsrMatrix<f64> {
     /// Builds (or rebuilds) the SIMD-aware SpMV plan using the provided tuning.
     pub fn build_spmv_plan(&mut self, tuning: &SpmvTuning) {
-        self.spmv_plan = Some(build_spmv_plan(self, tuning));
+        let owned = crate::matrix::csr::CsrMatrix::new(
+            self.nrows(),
+            self.ncols(),
+            self.row_ptr().to_vec(),
+            self.col_idx().to_vec(),
+            self.values().to_vec(),
+        );
+        self.spmv_plan = Some(build_spmv_plan(owned, tuning));
     }
 
     /// Clears any cached SpMV plan, forcing the scalar fallback on the next

--- a/src/matrix/spmv/mod.rs
+++ b/src/matrix/spmv/mod.rs
@@ -5,8 +5,10 @@ pub mod sellc;
 #[cfg(feature = "simd")]
 pub mod simd_csr;
 
-pub use self::plan::{KernelKind, SpmvPlan, SpmvTuning, build as build_plan};
-pub use self::scalar::{spmv_scaled_csr, spmv_t_scaled_csr};
+pub use self::plan::{
+    SpmvKernel, SpmvPlan, SpmvTuning, build as build_plan, build_owned as build_plan_owned,
+};
+pub use self::scalar::{spmv_csr_scalar, spmv_scaled_csr, spmv_t_scaled_csr};
 
 use crate::context::ksp_context::BlockVec;
 use crate::error::KError;

--- a/src/matrix/spmv/plan.rs
+++ b/src/matrix/spmv/plan.rs
@@ -1,8 +1,11 @@
 //! Runtime SpMV plan selection and metadata.
 
+#[cfg(feature = "simd")]
+use core::any::TypeId;
 use std::time::Instant;
 
-use crate::matrix::sparse::CsrMatrix;
+use crate::algebra::scalar::KrystScalar;
+use crate::matrix::csr::CsrMatrix;
 
 use super::scalar;
 #[cfg(feature = "simd")]
@@ -10,7 +13,7 @@ use super::{sellc, simd_csr};
 
 /// Identifies the selected kernel implementation inside a [`SpmvPlan`].
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
-pub enum KernelKind {
+pub enum SpmvKernel {
     Scalar,
     #[cfg(feature = "simd")]
     CsrSimdGather,
@@ -21,24 +24,26 @@ pub enum KernelKind {
 /// Per-matrix runtime plan describing how sparse matrix-vector products should
 /// be executed.
 #[derive(Clone, Debug)]
-pub struct SpmvPlan {
-    pub kind: KernelKind,
+pub struct SpmvPlan<S: KrystScalar> {
+    pub kernel: SpmvKernel,
+    pub nrows: usize,
+    pub ncols: usize,
     pub row_ptr: Vec<usize>,
     pub col_idx: Vec<usize>,
-    pub vals: Vec<f64>,
+    pub vals: Vec<S>,
     #[cfg(feature = "simd")]
     pub sell: Option<sellc::SellCStorage>,
     #[cfg(feature = "simd")]
     lanes: usize,
 }
 
-impl SpmvPlan {
+impl<S: KrystScalar> SpmvPlan<S> {
     /// Applies the selected kernel to compute `y = alpha * A * x + beta * y`.
     #[inline]
-    pub fn apply(&self, alpha: f64, x: &[f64], beta: f64, y: &mut [f64]) {
-        match self.kind {
-            KernelKind::Scalar => scalar::spmv_scaled_csr(
-                self.nrows(),
+    pub fn apply_scaled(&self, alpha: S, x: &[S], beta: S, y: &mut [S]) {
+        match self.kernel {
+            SpmvKernel::Scalar => scalar::spmv_scaled_csr(
+                self.nrows,
                 &self.row_ptr,
                 &self.col_idx,
                 &self.vals,
@@ -48,13 +53,23 @@ impl SpmvPlan {
                 y,
             ),
             #[cfg(feature = "simd")]
-            KernelKind::CsrSimdGather => {
+            SpmvKernel::CsrSimdGather => {
+                debug_assert_eq!(TypeId::of::<S>(), TypeId::of::<f64>());
+                let alpha = unsafe { *(&alpha as *const S as *const f64) };
+                let beta = unsafe { *(&beta as *const S as *const f64) };
+                let x = unsafe { std::slice::from_raw_parts(x.as_ptr() as *const f64, x.len()) };
+                let y =
+                    unsafe { std::slice::from_raw_parts_mut(y.as_mut_ptr() as *mut f64, y.len()) };
+                let vals = unsafe {
+                    std::slice::from_raw_parts(self.vals.as_ptr() as *const f64, self.vals.len())
+                };
+
                 if self.lanes <= 1 {
                     simd_csr::fallback_scalar(
-                        self.nrows(),
+                        self.nrows,
                         &self.row_ptr,
                         &self.col_idx,
-                        &self.vals,
+                        vals,
                         alpha,
                         x,
                         beta,
@@ -63,10 +78,10 @@ impl SpmvPlan {
                 } else {
                     simd_csr::dispatch_spmv_scaled_csr_simd_gather(
                         self.lanes,
-                        self.nrows(),
+                        self.nrows,
                         &self.row_ptr,
                         &self.col_idx,
-                        &self.vals,
+                        vals,
                         alpha,
                         x,
                         beta,
@@ -75,11 +90,16 @@ impl SpmvPlan {
                 }
             }
             #[cfg(feature = "simd")]
-            KernelKind::SellC => {
+            SpmvKernel::SellC => {
                 let sell = self
                     .sell
                     .as_ref()
                     .expect("SELL-C plan missing storage for SellC kernel");
+                let alpha = unsafe { *(&alpha as *const S as *const f64) };
+                let beta = unsafe { *(&beta as *const S as *const f64) };
+                let x = unsafe { std::slice::from_raw_parts(x.as_ptr() as *const f64, x.len()) };
+                let y =
+                    unsafe { std::slice::from_raw_parts_mut(y.as_mut_ptr() as *mut f64, y.len()) };
                 dispatch_sellc(self.lanes, sell, alpha, x, beta, y);
             }
         }
@@ -88,16 +108,18 @@ impl SpmvPlan {
     /// Returns the number of rows stored in the CSR representation.
     #[inline]
     pub fn nrows(&self) -> usize {
-        self.row_ptr.len().saturating_sub(1)
+        self.nrows
     }
 
-    /// Builds a scalar-only plan.
-    pub fn build_scalar(matrix: &CsrMatrix<f64>) -> Self {
+    /// Builds a scalar-only plan by cloning the CSR structure.
+    pub fn build_scalar(matrix: &CsrMatrix<S>) -> Self {
         Self {
-            kind: KernelKind::Scalar,
-            row_ptr: matrix.row_ptr().to_vec(),
-            col_idx: matrix.col_idx().to_vec(),
-            vals: matrix.values().to_vec(),
+            kernel: SpmvKernel::Scalar,
+            nrows: matrix.nrows,
+            ncols: matrix.ncols,
+            row_ptr: matrix.rowptr.clone(),
+            col_idx: matrix.colind.clone(),
+            vals: matrix.values.clone(),
             #[cfg(feature = "simd")]
             sell: None,
             #[cfg(feature = "simd")]
@@ -130,92 +152,116 @@ impl Default for SpmvTuning {
     }
 }
 
-/// Builds an SpMV plan using the provided tuning configuration.
-pub fn build(matrix: &CsrMatrix<f64>, tuning: &SpmvTuning) -> SpmvPlan {
-    let mut plan = SpmvPlan::build_scalar(matrix);
+/// Builds an SpMV plan from a borrowed CSR matrix.
+pub fn build<S: KrystScalar>(matrix: &CsrMatrix<S>, tuning: &SpmvTuning) -> SpmvPlan<S> {
+    build_owned(matrix.clone(), tuning)
+}
+
+/// Builds an SpMV plan while taking ownership of the CSR storage.
+pub fn build_owned<S: KrystScalar>(matrix: CsrMatrix<S>, tuning: &SpmvTuning) -> SpmvPlan<S> {
+    let CsrMatrix {
+        nrows,
+        ncols,
+        rowptr,
+        colind,
+        values,
+    } = matrix;
+
+    #[allow(unused_mut)]
+    let mut plan = SpmvPlan {
+        kernel: SpmvKernel::Scalar,
+        nrows,
+        ncols,
+        row_ptr: rowptr,
+        col_idx: colind,
+        vals: values,
+        #[cfg(feature = "simd")]
+        sell: None,
+        #[cfg(feature = "simd")]
+        lanes: 1,
+    };
+
+    #[cfg(not(feature = "simd"))]
+    let _ = tuning;
 
     #[cfg(feature = "simd")]
     {
-        if !tuning.allow_simd {
-            return plan;
-        }
-        let nnz = plan.col_idx.len();
-        if nnz < tuning.min_nnz_for_simd {
-            return plan;
-        }
+        if TypeId::of::<S>() == TypeId::of::<f64>() && tuning.allow_simd {
+            let nnz = plan.col_idx.len();
+            if nnz >= tuning.min_nnz_for_simd {
+                let lanes = simd_csr::detect_simd_lanes();
+                if lanes > 1 && plan.nrows > 0 {
+                    let mut lmin = usize::MAX;
+                    let mut lmax = 0usize;
+                    for row in 0..plan.nrows {
+                        let len = plan.row_ptr[row + 1] - plan.row_ptr[row];
+                        if len == 0 {
+                            continue;
+                        }
+                        lmin = lmin.min(len);
+                        lmax = lmax.max(len);
+                    }
+                    let is_uniformish = if lmin == usize::MAX {
+                        true
+                    } else {
+                        lmax <= lmin.saturating_mul(2) && lmax <= 128
+                    };
 
-        let lanes = simd_csr::detect_simd_lanes();
-        if lanes <= 1 {
-            return plan;
-        }
+                    let mut best_kernel = SpmvKernel::CsrSimdGather;
+                    let mut best_sell = None;
+                    let bench_runs = tuning.bench_nsamples;
 
-        let m = matrix.nrows();
-        if m == 0 {
-            return plan;
-        }
+                    let mut y_buf = vec![0.0f64; plan.nrows];
+                    let x_buf = vec![1.0f64; plan.ncols.max(1)];
+                    let vals = unsafe {
+                        std::slice::from_raw_parts(
+                            plan.vals.as_ptr() as *const f64,
+                            plan.vals.len(),
+                        )
+                    };
 
-        let mut lmin = usize::MAX;
-        let mut lmax = 0usize;
-        for row in 0..m {
-            let len = plan.row_ptr[row + 1] - plan.row_ptr[row];
-            if len == 0 {
-                continue;
+                    let gather_time = microbench(bench_runs, || {
+                        simd_csr::dispatch_spmv_scaled_csr_simd_gather(
+                            lanes,
+                            plan.nrows,
+                            &plan.row_ptr,
+                            &plan.col_idx,
+                            vals,
+                            1.0,
+                            &x_buf,
+                            0.0,
+                            &mut y_buf,
+                        );
+                    });
+
+                    let prefer_sell = tuning.prefer_sellc || !is_uniformish;
+                    if prefer_sell {
+                        let sell_c = round_up_to_multiple(tuning.sell_c.max(lanes), lanes);
+                        let sell_sigma = tuning.sell_sigma.max(sell_c);
+                        let sell = sellc::csr_to_sellc(
+                            plan.nrows,
+                            plan.ncols,
+                            &plan.row_ptr,
+                            &plan.col_idx,
+                            vals,
+                            sell_c,
+                            sell_sigma,
+                        );
+                        let sell_time = microbench(bench_runs, || {
+                            dispatch_sellc(lanes, &sell, 1.0, &x_buf, 0.0, &mut y_buf);
+                        });
+                        if sell_time < gather_time {
+                            best_kernel = SpmvKernel::SellC;
+                            best_sell = Some(sell);
+                        }
+                    }
+
+                    plan.kernel = best_kernel;
+                    plan.lanes = lanes;
+                    plan.sell = best_sell;
+                }
             }
-            lmin = lmin.min(len);
-            lmax = lmax.max(len);
         }
-        let is_uniformish = if lmin == usize::MAX {
-            true
-        } else {
-            lmax <= lmin.saturating_mul(2) && lmax <= 128
-        };
-
-        let mut best_kind = KernelKind::CsrSimdGather;
-        let mut best_sell = None;
-        let bench_runs = tuning.bench_nsamples;
-
-        let mut y_buf = vec![0.0f64; matrix.nrows()];
-        let x_buf = vec![1.0f64; matrix.ncols().max(1)];
-
-        let gather_time = microbench(bench_runs, || {
-            simd_csr::dispatch_spmv_scaled_csr_simd_gather(
-                lanes,
-                plan.nrows(),
-                &plan.row_ptr,
-                &plan.col_idx,
-                &plan.vals,
-                1.0,
-                &x_buf,
-                0.0,
-                &mut y_buf,
-            );
-        });
-
-        let prefer_sell = tuning.prefer_sellc || !is_uniformish;
-        if prefer_sell {
-            let sell_c = round_up_to_multiple(tuning.sell_c.max(lanes), lanes);
-            let sell_sigma = tuning.sell_sigma.max(sell_c);
-            let sell = sellc::csr_to_sellc(
-                matrix.nrows(),
-                matrix.ncols(),
-                &plan.row_ptr,
-                &plan.col_idx,
-                &plan.vals,
-                sell_c,
-                sell_sigma,
-            );
-            let sell_time = microbench(bench_runs, || {
-                dispatch_sellc(lanes, &sell, 1.0, &x_buf, 0.0, &mut y_buf);
-            });
-            if sell_time < gather_time {
-                best_kind = KernelKind::SellC;
-                best_sell = Some(sell);
-            }
-        }
-
-        plan.kind = best_kind;
-        plan.lanes = lanes;
-        plan.sell = best_sell;
     }
 
     plan

--- a/src/matrix/spmv/scalar.rs
+++ b/src/matrix/spmv/scalar.rs
@@ -2,6 +2,31 @@
 
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
+use crate::matrix::csr::CsrMatrix;
+
+/// Portable CSR SpMV: computes `y = A * x` without conjugation.
+///
+/// This helper keeps the control flow simple to act as the scalar fallback for
+/// both real and complex builds.  The loops intentionally mirror the
+/// conventional row-wise CSR traversal so it is easy to audit and compare
+/// against the existing `spmv_scaled_csr` entry point which supports
+/// alpha/beta scaling factors.
+#[inline]
+pub fn spmv_csr_scalar<S: KrystScalar>(a: &CsrMatrix<S>, x: &[S], y: &mut [S]) {
+    debug_assert_eq!(x.len(), a.ncols);
+    debug_assert_eq!(y.len(), a.nrows);
+
+    for i in 0..a.nrows {
+        let start = a.rowptr[i];
+        let end = a.rowptr[i + 1];
+        let mut acc = S::zero();
+        for k in start..end {
+            let j = a.colind[k];
+            acc = acc + a.values[k] * x[j];
+        }
+        y[i] = acc;
+    }
+}
 
 /// Computes `y = alpha * A * x + beta * y` for a matrix stored in CSR format.
 ///
@@ -10,7 +35,7 @@ use crate::algebra::prelude::*;
 /// keeps the loop order deterministic and performs a small unrolled
 /// accumulation to improve ILP on modern CPUs without depending on explicit
 /// SIMD instructions.
-pub fn spmv_scaled_csr(
+pub fn spmv_scaled_csr<S: KrystScalar>(
     m: usize,
     row_ptr: &[usize],
     col_idx: &[usize],
@@ -31,7 +56,7 @@ pub fn spmv_scaled_csr(
         y[..m].fill(S::zero());
     } else if beta != S::one() {
         for yi in &mut y[..m] {
-            *yi *= beta;
+            *yi = (*yi) * beta;
         }
     }
 
@@ -53,12 +78,12 @@ pub fn spmv_scaled_csr(
             p += 1;
         }
 
-        y[i] += alpha * acc;
+        y[i] = y[i] + alpha * acc;
     }
 }
 
 /// Computes `y = alpha * A^T * x + beta * y` for a CSR matrix.
-pub fn spmv_t_scaled_csr(
+pub fn spmv_t_scaled_csr<S: KrystScalar>(
     m: usize,
     row_ptr: &[usize],
     col_idx: &[usize],
@@ -75,7 +100,7 @@ pub fn spmv_t_scaled_csr(
         y.fill(S::zero());
     } else if beta != S::one() {
         for yi in y.iter_mut() {
-            *yi *= beta;
+            *yi = (*yi) * beta;
         }
     }
 
@@ -87,7 +112,8 @@ pub fn spmv_t_scaled_csr(
         let rs = row_ptr[i];
         let re = row_ptr[i + 1];
         for p in rs..re {
-            y[col_idx[p]] += alpha * vals[p] * xi;
+            let idx = col_idx[p];
+            y[idx] = y[idx] + alpha * vals[p] * xi;
         }
     }
 }

--- a/src/matrix/spmv/tests.rs
+++ b/src/matrix/spmv/tests.rs
@@ -1,7 +1,9 @@
+use crate::matrix::spmv::SpmvTuning;
 #[cfg(feature = "simd")]
-use crate::matrix::spmv::{SpmvTuning, sellc, simd_csr};
+use crate::matrix::spmv::{sellc, simd_csr};
 use crate::matrix::{
     csc::CscMatrix,
+    csr::CsrMatrix as GenericCsrMatrix,
     sparse::{CsrMatrix, SparseMatrix},
     spmv::{
         TBackend, spmm_csr_block, spmv_csr_parallel, spmv_scaled_csr, spmv_t_scaled_csr,
@@ -49,6 +51,93 @@ fn scalar_kernel_matches_matrix_apply() {
     );
     for (lhs, rhs) in y_scale.iter().zip(y_ref.iter()) {
         assert!((lhs - (2.0 * 2.0 + 0.5 * rhs)).abs() < 1e-12);
+    }
+}
+
+#[test]
+fn spmv_plan_scalar_matches_kernel() {
+    use crate::matrix::spmv::plan;
+
+    let matrix = GenericCsrMatrix::new(
+        4,
+        4,
+        vec![0, 2, 4, 7, 8],
+        vec![0, 3, 1, 2, 0, 2, 3, 1],
+        vec![1.0, -2.0, 3.0, 4.0, 0.5, -1.5, 2.0, 1.25],
+    );
+    let tuning = SpmvTuning {
+        allow_simd: false,
+        ..Default::default()
+    };
+    let plan = plan::build(&matrix, &tuning);
+
+    let x = vec![0.75, -1.0, 0.5, 2.0];
+    let mut y_plan = vec![0.0; matrix.nrows];
+    plan.apply_scaled(1.0, &x, 0.0, &mut y_plan);
+
+    let mut y_ref = vec![0.0; matrix.nrows];
+    crate::matrix::spmv::spmv_scaled_csr(
+        matrix.nrows,
+        &matrix.rowptr,
+        &matrix.colind,
+        &matrix.values,
+        1.0,
+        &x,
+        0.0,
+        &mut y_ref,
+    );
+
+    for (lhs, rhs) in y_plan.iter().zip(y_ref.iter()) {
+        assert!((lhs - rhs).abs() < 1e-12);
+    }
+}
+
+#[test]
+fn spmv_csr_scalar_matches_real_reference() {
+    use crate::algebra::prelude::*;
+
+    let a_real = GenericCsrMatrix::new(
+        3,
+        3,
+        vec![0, 2, 3, 4],
+        vec![0, 2, 1, 2],
+        vec![1.0, 2.0, -3.0, 4.0],
+    );
+    let x_real = vec![1.0, 2.0, -1.0];
+    let mut y_real = vec![0.0; 3];
+    spmv_scaled_csr(
+        a_real.nrows,
+        &a_real.rowptr,
+        &a_real.colind,
+        &a_real.values,
+        1.0,
+        &x_real,
+        0.0,
+        &mut y_real,
+    );
+
+    let a_scalar = GenericCsrMatrix::new(
+        3,
+        3,
+        vec![0, 2, 3, 4],
+        vec![0, 2, 1, 2],
+        vec![
+            S::from_real(1.0),
+            S::from_real(2.0),
+            S::from_real(-3.0),
+            S::from_real(4.0),
+        ],
+    );
+    let x_scalar: Vec<S> = x_real.iter().copied().map(S::from_real).collect();
+    let mut y_scalar = vec![S::zero(); 3];
+    crate::matrix::spmv::spmv_csr_scalar(&a_scalar, &x_scalar, &mut y_scalar);
+
+    for i in 0..3 {
+        assert!((y_scalar[i].real() - y_real[i]).abs() < 1e-12);
+        #[cfg(feature = "complex")]
+        {
+            assert_eq!(y_scalar[i], y_scalar[i].conj());
+        }
     }
 }
 

--- a/tests/generic_csr_bridge.rs
+++ b/tests/generic_csr_bridge.rs
@@ -1,0 +1,68 @@
+use std::sync::Arc;
+
+use kryst::matrix::convert::{dense_from_linop, to_csc_cached, to_csr_cached};
+use kryst::matrix::csr::CsrMatrix as ScalarCsrMatrix;
+use kryst::matrix::format::AsFormat;
+use kryst::matrix::op::{GenericCsrOp, LinOp};
+use kryst::matrix::spmv::plan::SpmvTuning;
+
+fn make_generic_op() -> (Arc<GenericCsrOp<f64>>, Vec<usize>, Vec<usize>, Vec<f64>) {
+    let matrix = ScalarCsrMatrix::new(
+        3,
+        3,
+        vec![0, 2, 4, 5],
+        vec![0, 2, 1, 2, 0],
+        vec![1.0, -2.0, 3.5, 4.0, -1.5],
+    );
+    let rowptr = matrix.rowptr.clone();
+    let colind = matrix.colind.clone();
+    let values = matrix.values.clone();
+    let tuning = SpmvTuning {
+        allow_simd: false,
+        ..Default::default()
+    };
+    let op = Arc::new(GenericCsrOp::new(Arc::new(matrix), &tuning));
+    (op, rowptr, colind, values)
+}
+
+#[test]
+fn generic_csr_to_csr_cached_preserves_storage() {
+    let (op, rowptr, colind, values) = make_generic_op();
+    let csr =
+        to_csr_cached(op.as_ref() as &dyn LinOp<S = f64>, 0.0).expect("conversion should succeed");
+    assert_eq!(csr.row_ptr(), rowptr);
+    assert_eq!(csr.col_idx(), colind);
+    assert_eq!(csr.values(), values);
+}
+
+#[test]
+fn generic_csr_to_csc_cached_roundtrips() {
+    let (op, rowptr, colind, values) = make_generic_op();
+    let csc =
+        to_csc_cached(op.as_ref() as &dyn LinOp<S = f64>, 0.0).expect("conversion should succeed");
+    let csr = AsFormat::to_csr_cached(csc.as_ref(), 0.0);
+    assert_eq!(csr.row_ptr(), rowptr);
+    assert_eq!(csr.col_idx(), colind);
+    assert_eq!(csr.values(), values);
+}
+
+#[test]
+fn generic_csr_dense_conversion_matches_reference() {
+    let (op, rowptr, colind, values) = make_generic_op();
+    let dense =
+        dense_from_linop(op.as_ref() as &dyn LinOp<S = f64>).expect("conversion should succeed");
+    let mut expected = vec![0.0; 9];
+    for i in 0..3 {
+        for idx in rowptr[i]..rowptr[i + 1] {
+            let j = colind[idx];
+            expected[i * 3 + j] = values[idx];
+        }
+    }
+    let mut actual = vec![0.0; 9];
+    for i in 0..3 {
+        for j in 0..3 {
+            actual[i * 3 + j] = dense[(i, j)];
+        }
+    }
+    assert_eq!(actual, expected);
+}


### PR DESCRIPTION
## Summary
- require generic CSR operators to satisfy `ComplexField` when implementing `LinOp` and update regression tests to call the trait method explicitly
- adjust scalar CSR kernels to avoid assignment-operator bounds on `KrystScalar`
- silence plan-builder warnings when SIMD support is disabled

## Testing
- `cargo check`
- `cargo test --no-run`


------
https://chatgpt.com/codex/tasks/task_e_68df5360f9188329a386fa1b52f81474