### PR TITLE
Add initial testkit module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,8 @@ pub mod matrix;
 pub mod preconditioner;
 pub mod reduction;
 pub mod solver;
+#[cfg(any(test, feature = "examples"))]
+pub mod testkit;
 pub mod utils;
 
 // Re-exports for convenience

--- a/src/testkit/mod.rs
+++ b/src/testkit/mod.rs
@@ -1,0 +1,113 @@
+//! Shared helpers so tests & examples work with S=f64 or S=Complex64.
+
+use crate::algebra::blas::{dot_conj, nrm2};
+use crate::algebra::prelude::*;
+
+/// Default tolerances (tweak to your solver accuracy)
+pub const ATOL: R = 1e-12;
+pub const RTOL: R = 1e-10;
+
+/// Turn an f64 into S (real -> complex with im=0 under `complex`)
+#[inline]
+pub fn s(x: f64) -> S {
+    S::from_real(x)
+}
+
+/// Is a scalar essentially zero? (`|z| < eps`)
+#[inline]
+pub fn is_zero(z: S, eps: R) -> bool {
+    z.abs() < eps
+}
+
+/// Scalar approx equality using |a-b| <= atol + rtol*max(|a|,|b|)
+#[inline]
+pub fn approx_s(a: S, b: S, atol: R, rtol: R) -> bool {
+    let diff = (a - b).abs();
+    let scale = a.abs().max(b.abs());
+    diff <= atol + rtol * scale
+}
+
+/// Assert scalar closeness (pretty message in both modes)
+#[track_caller]
+pub fn assert_s_close(label: &str, a: S, b: S, atol: R, rtol: R) {
+    if !approx_s(a, b, atol, rtol) {
+        panic!(
+            "{label}: |a-b|={} (a={:?}, b={:?}) > atol+rtol*scale (atol={:.3e}, rtol={:.3e})",
+            (a - b).abs(),
+            a,
+            b,
+            atol,
+            rtol
+        );
+    }
+}
+
+/// Vector 2-norm of difference (returns R)
+#[inline]
+pub fn vec_err(a: &[S], b: &[S]) -> R {
+    let mut tmp = Vec::<S>::with_capacity(a.len());
+    unsafe {
+        tmp.set_len(a.len());
+    }
+    for i in 0..a.len() {
+        tmp[i] = a[i] - b[i];
+    }
+    nrm2(&tmp)
+}
+
+/// Conjugate dot product helper (matches BLAS dot for reals)
+#[inline]
+pub fn vec_dot(a: &[S], b: &[S]) -> S {
+    dot_conj(a, b)
+}
+
+/// Assert vector closeness via 2-norm
+#[track_caller]
+pub fn assert_vec_close(label: &str, a: &[S], b: &[S], atol: R, rtol: R) {
+    assert_eq!(
+        a.len(),
+        b.len(),
+        "{label}: length mismatch {} != {}",
+        a.len(),
+        b.len()
+    );
+    let err = vec_err(a, b);
+    let na = nrm2(a);
+    let nb = nrm2(b);
+    let scale = na.max(nb);
+    if err > atol + rtol * scale {
+        panic!(
+            "{label}: ||a-b||2={:.3e} > {:.3e} (atol+rtol*max(||a||,||b||))",
+            err,
+            atol + rtol * scale
+        );
+    }
+}
+
+/// Convenience macro: scalar close with defaults
+#[macro_export]
+macro_rules! assert_s_close {
+    ($label:expr, $a:expr, $b:expr) => {{
+        $crate::testkit::assert_s_close(
+            $label,
+            $a,
+            $b,
+            $crate::testkit::ATOL,
+            $crate::testkit::RTOL,
+        )
+    }};
+}
+
+/// Convenience macro: vector close with defaults
+#[macro_export]
+macro_rules! assert_vec_close {
+    ($label:expr, $a:expr, $b:expr) => {{
+        $crate::testkit::assert_vec_close(
+            $label,
+            $a,
+            $b,
+            $crate::testkit::ATOL,
+            $crate::testkit::RTOL,
+        )
+    }};
+}

--- a/tests/solver_async_dot.rs
+++ b/tests/solver_async_dot.rs
@@ -1,6 +1,10 @@
+use kryst::algebra::blas::dot_conj;
+use kryst::algebra::prelude::*;
 use kryst::parallel::NoComm;
 use kryst::solver::common::{dot2_async, dotn_async, nrm2_async};
+use kryst::testkit::{ATOL, is_zero, s};
 use kryst::utils::reduction::{AllreduceOps, ReductOptions};
+use kryst::{assert_s_close, assert_vec_close};
 
 #[test]
 fn async_dot2_matches_blocking() {
@@ -9,22 +13,23 @@ fn async_dot2_matches_blocking() {
     let y1 = [4.0, 5.0, 6.0];
     let x2 = [0.5, 1.5, -2.5];
     let y2 = [2.0, -3.0, 4.0];
+    let xs1: Vec<S> = x1.iter().copied().map(s).collect();
+    let ys1: Vec<S> = y1.iter().copied().map(s).collect();
+    let xs2: Vec<S> = x2.iter().copied().map(s).collect();
+    let ys2: Vec<S> = y2.iter().copied().map(s).collect();
     let opts = ReductOptions::default();
     let mut async_pair = dot2_async(&comm, &x1, &y1, &x2, &y2, &opts);
-    assert_eq!(
-        async_pair.local.0,
-        x1.iter().zip(&y1).map(|(a, b)| a * b).sum::<f64>()
-    );
-    assert_eq!(
-        async_pair.local.1,
-        x2.iter().zip(&y2).map(|(a, b)| a * b).sum::<f64>()
-    );
+    let expected0 = dot_conj(&xs1, &ys1);
+    let expected1 = dot_conj(&xs2, &ys2);
+    assert_s_close!("async dot2 local[0]", expected0, s(async_pair.local.0));
+    assert_s_close!("async dot2 local[1]", expected1, s(async_pair.local.1));
     assert_eq!(
         NoComm::test_pair(&mut async_pair.handle),
         Some(async_pair.local)
     );
     let global = <NoComm as AllreduceOps>::wait_pair(async_pair.handle);
-    assert_eq!(global, async_pair.local);
+    assert_s_close!("async dot2 global[0]", expected0, s(global.0));
+    assert_s_close!("async dot2 global[1]", expected1, s(global.1));
 }
 
 #[test]
@@ -34,27 +39,35 @@ fn async_dotn_matches_blocking() {
     let w1 = [3.0, 0.5, -4.0];
     let v2 = [0.0, 2.0, 1.0];
     let w2 = [1.0, 1.0, 1.0];
+    let v1s: Vec<S> = v1.iter().copied().map(s).collect();
+    let w1s: Vec<S> = w1.iter().copied().map(s).collect();
+    let v2s: Vec<S> = v2.iter().copied().map(s).collect();
+    let w2s: Vec<S> = w2.iter().copied().map(s).collect();
     let opts = ReductOptions::default();
     let mut async_vec = dotn_async(&comm, &[(&v1[..], &w1[..]), (&v2[..], &w2[..])], &opts);
-    let expected0 = v1.iter().zip(&w1).map(|(a, b)| a * b).sum::<f64>();
-    let expected1 = v2.iter().zip(&w2).map(|(a, b)| a * b).sum::<f64>();
-    assert_eq!(async_vec.local, vec![expected0, expected1]);
+    let expected0 = dot_conj(&v1s, &w1s);
+    let expected1 = dot_conj(&v2s, &w2s);
+    let local: Vec<S> = async_vec.local.iter().copied().map(s).collect();
+    assert_vec_close!("async dotn local", &local, &[expected0, expected1]);
     assert_eq!(
         NoComm::test_vec(&mut async_vec.handle),
         Some(async_vec.local.clone())
     );
     let global = <NoComm as AllreduceOps>::wait_vec(async_vec.handle);
-    assert_eq!(global, vec![expected0, expected1]);
+    let global_s: Vec<S> = global.iter().copied().map(s).collect();
+    assert_vec_close!("async dotn global", &global_s, &[expected0, expected1]);
 }
 
 #[test]
 fn async_norm_matches_blocking() {
     let comm = NoComm;
     let x = [1.0, 2.0, 2.0];
+    let xs: Vec<S> = x.iter().copied().map(s).collect();
     let opts = ReductOptions::default();
     let (handle, local) = nrm2_async(&comm, &x, &opts);
-    let expected = x.iter().map(|v| v * v).sum::<f64>();
-    assert_eq!(local, expected);
+    let expected = dot_conj(&xs, &xs);
+    assert_s_close!("async norm local", expected, s(local));
     let sumsq = <NoComm as AllreduceOps>::wait_pair(handle);
-    assert_eq!(sumsq, (expected, 0.0));
+    assert_s_close!("async norm global sum", expected, s(sumsq.0));
+    assert!(is_zero(s(sumsq.1), ATOL));
 }


### PR DESCRIPTION
## Summary
- add a shared testkit module that provides scalar-aware helpers and macros for tests
- expose the testkit only when running tests or examples
- refactor the async dot integration tests to use the shared scalar helpers and magnitude-based assertions

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e00b7b19e48329bd3ea3f68f71a017