### PR TITLE
Make bridge adapters generic and cover GMRES paths

### DIFF
--- a/src/matrix/op_bridge.rs
+++ b/src/matrix/op_bridge.rs
@@ -5,7 +5,10 @@ use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
 use crate::matrix::op::LinOp;
 
 #[inline]
-pub fn matvec_s(a: &(dyn LinOp<S = f64> + '_), x: &[S], y: &mut [S], scratch: &mut BridgeScratch) {
+pub fn matvec_s<A>(a: &A, x: &[S], y: &mut [S], scratch: &mut BridgeScratch)
+where
+    A: LinOp<S = f64> + ?Sized,
+{
     debug_assert_eq!(x.len(), y.len());
 
     #[cfg(not(feature = "complex"))]

--- a/src/matrix/op_shell.rs
+++ b/src/matrix/op_shell.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
-use super::op::{LinOp, StructureId, ValuesId};
+use super::op::{LinOp, LinOpF64, StructureId, ValuesId};
 
 /// Matrix-free "shell" operator.
 pub struct MatShell<S> {
@@ -77,5 +77,17 @@ impl LinOp for MatShell<f64> {
     }
     fn as_any(&self) -> &dyn std::any::Any {
         self
+    }
+}
+
+impl LinOpF64 for MatShell<f64> {
+    #[inline]
+    fn dims(&self) -> (usize, usize) {
+        LinOp::dims(self)
+    }
+
+    #[inline]
+    fn matvec(&self, x: &[f64], y: &mut [f64]) {
+        LinOp::matvec(self, x, y)
     }
 }

--- a/src/ops/klinop.rs
+++ b/src/ops/klinop.rs
@@ -1,5 +1,6 @@
 use crate::algebra::bridge::BridgeScratch;
 use crate::algebra::prelude::*;
+use crate::matrix::op::{LinOp, LinOpF64};
 
 /// Internal, scalar-generic linear operator for solvers.
 ///
@@ -36,5 +37,32 @@ pub trait KLinOp: Send + Sync {
         _scratch: &mut BridgeScratch,
     ) {
         panic!("KLinOp::t_matvec_s called but supports_t_matvec_s() == false");
+    }
+}
+
+impl<T> KLinOp for T
+where
+    T: LinOpF64 + LinOp<S = f64> + Send + Sync,
+{
+    type Scalar = f64;
+
+    #[inline]
+    fn dims(&self) -> (usize, usize) {
+        <T as LinOpF64>::dims(self)
+    }
+
+    #[inline]
+    fn matvec_s(&self, x: &[f64], y: &mut [f64], _scratch: &mut BridgeScratch) {
+        <T as LinOpF64>::matvec(self, x, y)
+    }
+
+    #[inline]
+    fn supports_t_matvec_s(&self) -> bool {
+        <T as LinOp>::supports_transpose(self)
+    }
+
+    #[inline]
+    fn t_matvec_s(&self, x: &[f64], y: &mut [f64], _scratch: &mut BridgeScratch) {
+        <T as LinOp>::t_matvec(self, x, y)
     }
 }

--- a/src/ops/kpc.rs
+++ b/src/ops/kpc.rs
@@ -2,6 +2,7 @@ use crate::algebra::bridge::BridgeScratch;
 use crate::algebra::prelude::*;
 use crate::error::KError;
 use crate::preconditioner::PcSide;
+use crate::preconditioner::Preconditioner as PreconditionerF64;
 
 /// Internal, scalar-generic preconditioner interface.
 ///
@@ -47,5 +48,48 @@ pub trait KPreconditioner: Send + Sync {
     ) -> Result<(), KError> {
         let _ = (outer_iter, residual_norm);
         Ok(())
+    }
+}
+
+impl<T> KPreconditioner for T
+where
+    T: PreconditionerF64 + Send + Sync,
+{
+    type Scalar = f64;
+
+    #[inline]
+    fn dims(&self) -> (usize, usize) {
+        <T as PreconditionerF64>::dims(self)
+    }
+
+    #[inline]
+    fn apply_s(
+        &self,
+        side: PcSide,
+        x: &[f64],
+        y: &mut [f64],
+        _scratch: &mut BridgeScratch,
+    ) -> Result<(), KError> {
+        <T as PreconditionerF64>::apply(self, side, x, y)
+    }
+
+    #[inline]
+    fn apply_mut_s(
+        &mut self,
+        side: PcSide,
+        x: &[f64],
+        y: &mut [f64],
+        _scratch: &mut BridgeScratch,
+    ) -> Result<(), KError> {
+        <T as PreconditionerF64>::apply_mut(self, side, x, y)
+    }
+
+    #[inline]
+    fn on_restart_s(
+        &mut self,
+        outer_iter: usize,
+        residual_norm: <Self::Scalar as KrystScalar>::Real,
+    ) -> Result<(), KError> {
+        <T as PreconditionerF64>::on_restart(self, outer_iter, residual_norm)
     }
 }

--- a/src/ops/wrap.rs
+++ b/src/ops/wrap.rs
@@ -4,8 +4,12 @@ use crate::algebra::prelude::*;
 use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
 use crate::error::KError;
 use crate::matrix::op::{LinOp, LinOpF64};
+use crate::matrix::op_bridge::matvec_s as bridge_matvec_s;
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
+use crate::preconditioner::bridge::{
+    apply_pc_mut_s as bridge_apply_pc_mut_s, apply_pc_s as bridge_apply_pc_s,
+};
 use crate::preconditioner::{PcSide, Preconditioner as PreconditionerF64};
 use core::marker::PhantomData;
 
@@ -45,22 +49,7 @@ where
 
     #[inline]
     fn matvec_s(&self, x: &[S], y: &mut [S], scratch: &mut BridgeScratch) {
-        #[cfg(not(feature = "complex"))]
-        {
-            let _ = scratch;
-            let x_r: &[f64] = unsafe { &*(x as *const [S] as *const [f64]) };
-            let y_r: &mut [f64] = unsafe { &mut *(y as *mut [S] as *mut [f64]) };
-            <A as LinOpF64>::matvec(self.inner, x_r, y_r);
-        }
-
-        #[cfg(feature = "complex")]
-        {
-            let n = x.len();
-            let (xr, yr) = scratch.real_pair(n);
-            copy_scalar_to_real_in(x, xr);
-            <A as LinOpF64>::matvec(self.inner, xr, yr);
-            copy_real_to_scalar_in(yr, y);
-        }
+        bridge_matvec_s(self.inner, x, y, scratch);
     }
 
     #[inline]
@@ -125,23 +114,7 @@ where
         y: &mut [S],
         scratch: &mut BridgeScratch,
     ) -> Result<(), KError> {
-        #[cfg(not(feature = "complex"))]
-        {
-            let _ = scratch;
-            let x_r: &[f64] = unsafe { &*(x as *const [S] as *const [f64]) };
-            let y_r: &mut [f64] = unsafe { &mut *(y as *mut [S] as *mut [f64]) };
-            return <P as PreconditionerF64>::apply(self.inner, side, x_r, y_r);
-        }
-
-        #[cfg(feature = "complex")]
-        {
-            let n = x.len();
-            let (xr, yr) = scratch.real_pair(n);
-            copy_scalar_to_real_in(x, xr);
-            <P as PreconditionerF64>::apply(self.inner, side, xr, yr)?;
-            copy_real_to_scalar_in(yr, y);
-            Ok(())
-        }
+        bridge_apply_pc_s(self.inner, side, x, y, scratch)
     }
 }
 
@@ -188,25 +161,7 @@ where
         y: &mut [S],
         scratch: &mut BridgeScratch,
     ) -> Result<(), KError> {
-        #[cfg(not(feature = "complex"))]
-        {
-            let _ = scratch;
-            let x_r: &[f64] = unsafe { &*(x as *const [S] as *const [f64]) };
-            let y_r: &mut [f64] = unsafe { &mut *(y as *mut [S] as *mut [f64]) };
-            return unsafe { <P as PreconditionerF64>::apply(&*self.inner, side, x_r, y_r) };
-        }
-
-        #[cfg(feature = "complex")]
-        {
-            let n = x.len();
-            let (xr, yr) = scratch.real_pair(n);
-            copy_scalar_to_real_in(x, xr);
-            unsafe {
-                <P as PreconditionerF64>::apply(&*self.inner, side, xr, yr)?;
-            }
-            copy_real_to_scalar_in(yr, y);
-            Ok(())
-        }
+        bridge_apply_pc_s(unsafe { &*self.inner }, side, x, y, scratch)
     }
 
     #[inline]
@@ -217,25 +172,7 @@ where
         y: &mut [S],
         scratch: &mut BridgeScratch,
     ) -> Result<(), KError> {
-        #[cfg(not(feature = "complex"))]
-        {
-            let _ = scratch;
-            let x_r: &[f64] = unsafe { &*(x as *const [S] as *const [f64]) };
-            let y_r: &mut [f64] = unsafe { &mut *(y as *mut [S] as *mut [f64]) };
-            unsafe { <P as PreconditionerF64>::apply_mut(&mut *self.inner, side, x_r, y_r) }
-        }
-
-        #[cfg(feature = "complex")]
-        {
-            let n = x.len();
-            let (xr, yr) = scratch.real_pair(n);
-            copy_scalar_to_real_in(x, xr);
-            unsafe {
-                <P as PreconditionerF64>::apply_mut(&mut *self.inner, side, xr, yr)?;
-            }
-            copy_real_to_scalar_in(yr, y);
-            Ok(())
-        }
+        bridge_apply_pc_mut_s(unsafe { &mut *self.inner }, side, x, y, scratch)
     }
 
     #[inline]

--- a/src/preconditioner/block_jacobi.rs
+++ b/src/preconditioner/block_jacobi.rs
@@ -241,6 +241,7 @@ mod tests {
     use crate::algebra::bridge::BridgeScratch;
     use crate::algebra::prelude::*;
     use crate::core::traits::{MatrixGet, RowPattern};
+    use crate::error::KError;
     use crate::ops::kpc::KPreconditioner;
     use crate::preconditioner::PcSide;
     use std::marker::PhantomData;
@@ -266,6 +267,21 @@ mod tests {
     impl MatrixGet<f64> for TestDiagMatrix {
         fn get(&self, i: usize, j: usize) -> f64 {
             if i == j { self.diag[i] } else { 0.0 }
+        }
+    }
+
+    impl crate::preconditioner::Preconditioner for BlockJacobi<f64> {
+        fn dims(&self) -> (usize, usize) {
+            Self::dims(self)
+        }
+
+        fn setup(&mut self, _a: &dyn crate::matrix::op::LinOp<S = f64>) -> Result<(), KError> {
+            Ok(())
+        }
+
+        fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+            BlockJacobi::apply(self, x, y);
+            Ok(())
         }
     }
 

--- a/src/preconditioner/bridge.rs
+++ b/src/preconditioner/bridge.rs
@@ -6,13 +6,16 @@ use crate::error::KError;
 use crate::preconditioner::{PcSide, Preconditioner};
 
 #[inline]
-pub fn apply_pc_s(
-    pc: &(dyn Preconditioner + '_),
+pub fn apply_pc_s<P>(
+    pc: &P,
     side: PcSide,
     x: &[S],
     y: &mut [S],
     scratch: &mut BridgeScratch,
-) -> Result<(), KError> {
+) -> Result<(), KError>
+where
+    P: Preconditioner + ?Sized,
+{
     debug_assert_eq!(x.len(), y.len());
 
     #[cfg(not(feature = "complex"))]
@@ -30,6 +33,39 @@ pub fn apply_pc_s(
         let (xr, yr) = scratch.real_pair(n);
         copy_scalar_to_real_in(x, xr);
         pc.apply(side, xr, yr)?;
+        copy_real_to_scalar_in(yr, y);
+        Ok(())
+    }
+}
+
+#[inline]
+pub fn apply_pc_mut_s<P>(
+    pc: &mut P,
+    side: PcSide,
+    x: &[S],
+    y: &mut [S],
+    scratch: &mut BridgeScratch,
+) -> Result<(), KError>
+where
+    P: Preconditioner + ?Sized,
+{
+    debug_assert_eq!(x.len(), y.len());
+
+    #[cfg(not(feature = "complex"))]
+    {
+        let _ = scratch;
+        // SAFETY: when the complex feature is disabled we have S == f64.
+        let x_r: &[f64] = unsafe { &*(x as *const [S] as *const [f64]) };
+        let y_r: &mut [f64] = unsafe { &mut *(y as *mut [S] as *mut [f64]) };
+        return pc.apply_mut(side, x_r, y_r);
+    }
+
+    #[cfg(feature = "complex")]
+    {
+        let n = x.len();
+        let (xr, yr) = scratch.real_pair(n);
+        copy_scalar_to_real_in(x, xr);
+        pc.apply_mut(side, xr, yr)?;
         copy_real_to_scalar_in(yr, y);
         Ok(())
     }

--- a/src/solver/tfqmr.rs
+++ b/src/solver/tfqmr.rs
@@ -447,6 +447,7 @@ impl<'a> TfqmrWorkspace<'a> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::matrix::op::LinOpF64;
     use std::sync::{Arc, Mutex};
 
     struct Dense {
@@ -472,6 +473,18 @@ mod tests {
 
         fn as_any(&self) -> &dyn Any {
             self
+        }
+    }
+
+    impl LinOpF64 for Dense {
+        #[inline]
+        fn dims(&self) -> (usize, usize) {
+            LinOp::dims(self)
+        }
+
+        #[inline]
+        fn matvec(&self, x: &[f64], y: &mut [f64]) {
+            LinOp::matvec(self, x, y)
         }
     }
 

--- a/tests/solver_bridge.rs
+++ b/tests/solver_bridge.rs
@@ -13,7 +13,7 @@ use kryst::preconditioner::Jacobi;
 use kryst::preconditioner::amg::{AMGBuilder, RelaxType};
 use kryst::preconditioner::ilu_csr::{IluCsr, IluCsrConfig};
 use kryst::preconditioner::{PcSide, Preconditioner};
-use kryst::solver::{BiCgStabSolver, CgSolver, LinearSolver};
+use kryst::solver::{BiCgStabSolver, CgSolver, GmresSolver, LinearSolver};
 
 use faer::Mat;
 use std::sync::Arc;
@@ -41,6 +41,47 @@ impl KLinOp for NativeDiagOp {
         for ((yi, &di), &xi) in y.iter_mut().zip(self.diag.iter()).zip(x.iter()) {
             *yi = di * xi;
         }
+    }
+}
+
+struct NativeJacobiPc {
+    inv_diag: Vec<S>,
+}
+
+impl NativeJacobiPc {
+    fn new(diag: &[S]) -> Self {
+        let inv_diag = diag.iter().map(|&d| d.inv()).collect();
+        Self { inv_diag }
+    }
+}
+
+impl KPreconditioner for NativeJacobiPc {
+    type Scalar = S;
+
+    fn dims(&self) -> (usize, usize) {
+        let n = self.inv_diag.len();
+        (n, n)
+    }
+
+    fn apply_s(
+        &self,
+        _side: PcSide,
+        x: &[S],
+        y: &mut [S],
+        _scratch: &mut BridgeScratch,
+    ) -> Result<(), KError> {
+        if x.len() != self.inv_diag.len() || y.len() != self.inv_diag.len() {
+            return Err(KError::InvalidInput(format!(
+                "NativeJacobiPc::apply_s dimension mismatch: n={}, x.len()={}, y.len()={}",
+                self.inv_diag.len(),
+                x.len(),
+                y.len()
+            )));
+        }
+        for ((yi, &wi), &xi) in y.iter_mut().zip(self.inv_diag.iter()).zip(x.iter()) {
+            *yi = wi * xi;
+        }
+        Ok(())
     }
 }
 
@@ -172,6 +213,105 @@ fn cg_runs_with_native_and_wrapped_backends() {
         assert!(yi.real().is_finite(), "pc output {i} should be finite");
         assert!(bi.real().is_finite());
     }
+}
+
+#[test]
+fn gmres_runs_with_native_s_backend() {
+    let diag = vec![4.0, 5.0, 6.0, 7.0];
+    let diag_s: Vec<S> = diag.iter().copied().map(S::from_real).collect();
+    let x_true: Vec<S> = vec![
+        S::from_real(1.0),
+        S::from_real(-1.0),
+        S::from_real(2.0),
+        S::from_real(0.5),
+    ];
+    let b: Vec<S> = diag_s
+        .iter()
+        .zip(x_true.iter())
+        .map(|(&d, &x)| d * x)
+        .collect();
+    let mut x = vec![S::zero(); diag.len()];
+
+    let mut gmres = GmresSolver::new(8, 1e-12, 64);
+    let comm = UniverseComm::NoComm(NoComm);
+    let mut workspace = Workspace::new(diag.len());
+    gmres.setup_workspace(&mut workspace);
+
+    let op = NativeDiagOp::new(diag_s.clone());
+    let pc = NativeJacobiPc::new(&diag_s);
+
+    let _stats = gmres
+        .solve(
+            &op,
+            Some(&pc),
+            &b,
+            &mut x,
+            PcSide::Left,
+            &comm,
+            None,
+            Some(&mut workspace),
+        )
+        .expect("native GMRES solve");
+
+    let mut scratch = BridgeScratch::default();
+    let mut ax = vec![S::zero(); diag.len()];
+    op.matvec_s(&x, &mut ax, &mut scratch);
+    for (ai, bi) in ax.iter_mut().zip(b.iter()) {
+        *ai -= *bi;
+    }
+    assert!(nrm2(&ax) < 1e-10);
+}
+
+#[test]
+fn gmres_runs_with_wrapped_f64_backends() {
+    let diag = vec![3.0, 4.0, 5.0];
+    let x_true = vec![1.0, -2.0, 0.5];
+    let n = diag.len();
+
+    let row_ptr: Vec<usize> = (0..=n).collect();
+    let col_idx: Vec<usize> = (0..n).collect();
+    let values = diag.clone();
+    let csr = Arc::new(RealCsrMatrix::from_csr(n, n, row_ptr, col_idx, values));
+    let op_f64 = CsrOp::new(csr);
+
+    let mut jacobi = Jacobi::new();
+    jacobi.setup(&op_f64).expect("jacobi setup");
+
+    let op = as_s_op(&op_f64);
+    let pc = as_s_pc(&jacobi);
+
+    let b: Vec<S> = diag
+        .iter()
+        .zip(x_true.iter())
+        .map(|(&d, &x)| S::from_real(d * x))
+        .collect();
+    let mut x = vec![S::zero(); n];
+
+    let mut gmres = GmresSolver::new(6, 1e-12, 64);
+    let comm = UniverseComm::NoComm(NoComm);
+    let mut workspace = Workspace::new(n);
+    gmres.setup_workspace(&mut workspace);
+
+    let _stats = gmres
+        .solve(
+            &op,
+            Some(&pc),
+            &b,
+            &mut x,
+            PcSide::Left,
+            &comm,
+            None,
+            Some(&mut workspace),
+        )
+        .expect("wrapped GMRES solve");
+
+    let mut scratch = BridgeScratch::default();
+    let mut ax = vec![S::zero(); n];
+    op.matvec_s(&x, &mut ax, &mut scratch);
+    for (ai, bi) in ax.iter_mut().zip(b.iter()) {
+        *ai -= *bi;
+    }
+    assert!(nrm2(&ax) < 1e-10);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- make the matrix and preconditioner bridge helpers accept generic `LinOp`/`Preconditioner` implementors and update the f64 wrapper adapters to reuse them
- implement `LinOpF64` for `MatShell` and the TFQMR dense test harness so they continue to satisfy the blanket trait bounds
- add native and wrapped GMRES smoke tests with a lightweight scalar preconditioner to exercise both adapter paths

## Testing
- `cargo test --test solver_bridge`


------
https://chatgpt.com/codex/tasks/task_e_68e0a7e9826c8329b23315a585b2bcb2