### PR TITLE
Batch PCG reductions through dot engine helpers

### DIFF
--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -26,7 +26,7 @@ pub struct KspOptions {
     pub dtol: Option<f64>,
     pub maxits: Option<usize>,
     pub restart: Option<usize>,
-    /// Reduction mode for global dot products: "fast" | "deterministic"
+    /// Reduction mode for global dot products: "fast" | "deterministic" | "deterministic-accurate"
     pub reduction: Option<String>,
     // GMRES/FGMRES-specific (backward-compatible; all optional)
     /// Override restart for GMRES; falls back to `restart` if unset
@@ -1419,6 +1419,9 @@ mod old_tests {
     fn cli_sets_ksp_reduction_mode() {
         let opts = KspOptions::from_args(&["-ksp_reduction", "deterministic"]).unwrap();
         assert_eq!(opts.reduction.as_deref(), Some("deterministic"));
+
+        let opts = KspOptions::from_args(&["-ksp_reduction", "deterministic-accurate"]).unwrap();
+        assert_eq!(opts.reduction.as_deref(), Some("deterministic-accurate"));
     }
 
     #[test]

--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -40,8 +40,9 @@ use crate::context::pc_context::{DeferredPcInfo, PcFactory, PcType};
 use crate::error::KError;
 use crate::matrix::convert::materialize_linop_with_hint;
 use crate::matrix::op::{LinOp, StructureId, ValuesId, wrap_with_comm};
-use crate::parallel::Comm;
+use crate::parallel::{Comm, set_global_reduction_mode, set_global_reduction_mode_scoped};
 use crate::preconditioner::{PcReusePolicy, PcSide, Preconditioner};
+use crate::reduction::ReproMode;
 use crate::solver::{
     BiCgStabSolver, CgSolver, CgnrSolver, CgsSolver, FgmresSolver, GmresSolver, LinearSolver,
     MinresSolver, PCG_PIPELINED_DEFAULT_REPLACE_EVERY, PcaGmresSolver, PcaPcMode, PcgSolver,
@@ -187,11 +188,26 @@ impl KspContext {
     fn parse_reduction_mode(label: &str) -> Result<ReductMode, KError> {
         match label.to_lowercase().as_str() {
             "fast" => Ok(ReductMode::Fast),
-            "deterministic" => Ok(ReductMode::Deterministic),
+            "deterministic" | "det" => Ok(ReductMode::Deterministic),
+            "deterministic-accurate" | "deterministic_accurate" | "accurate" => {
+                Ok(ReductMode::DeterministicAccurate)
+            }
             other => Err(KError::SolveError(format!(
-                "Unrecognized ksp_reduction mode: {other} (expected 'fast'|'deterministic')"
+                "Unrecognized ksp_reduction mode: {other} (expected 'fast'|'deterministic'|'deterministic-accurate')"
             ))),
         }
+    }
+
+    fn repro_from_mode(mode: ReductMode) -> ReproMode {
+        match mode {
+            ReductMode::Fast => ReproMode::Fast,
+            ReductMode::Deterministic => ReproMode::Deterministic,
+            ReductMode::DeterministicAccurate => ReproMode::DeterministicAccurate,
+        }
+    }
+
+    fn apply_global_reduction_mode(&self) {
+        set_global_reduction_mode(Self::repro_from_mode(self.reduction_opts.mode));
     }
 
     /// Validate that `side` is compatible with `solver_type` (if set).
@@ -298,6 +314,7 @@ impl KspContext {
             }
         };
         self.solver = solver;
+        self.apply_global_reduction_mode();
         // Fail fast if an explicit side was set and is incompatible with the selected solver
         if self.pc_side_explicit {
             self.check_pc_side_now(self.pc_side)?
@@ -402,6 +419,7 @@ impl KspContext {
             if let Some(ref mut w) = self.work {
                 w.set_reduction_mode(parsed);
             }
+            self.apply_global_reduction_mode();
         }
 
         // --- GMRES options ---
@@ -1048,7 +1066,10 @@ impl KspContext {
             return Ok(SolveStats::new(1, 0.0, ConvergedReason::ConvergedAtol));
         }
 
-        // Configure solver preconditioning side and validate compatibility
+        // Ensure the configured reduction mode is active while solving and configure
+        // solver preconditioning side, validating compatibility along the way.
+        let _reduction_mode_guard =
+            set_global_reduction_mode_scoped(Self::repro_from_mode(self.reduction_opts.mode));
         self.configure_pc_side()?;
 
         let amat = self
@@ -1421,6 +1442,17 @@ mod tests {
         assert!(matches!(
             ws.reduction_options().mode,
             ReductMode::Deterministic
+        ));
+
+        let opts = KspOptions {
+            reduction: Some("deterministic-accurate".into()),
+            ..Default::default()
+        };
+        ksp.set_from_options(&opts).unwrap();
+        let ws = ksp.work.as_ref().unwrap();
+        assert!(matches!(
+            ws.reduction_options().mode,
+            ReductMode::DeterministicAccurate
         ));
     }
 }

--- a/src/parallel/mod.rs
+++ b/src/parallel/mod.rs
@@ -1,4 +1,5 @@
 use crate::algebra::prelude::*;
+use crate::reduction::ReproMode;
 #[cfg(feature = "mpi")]
 use mpi::datatype::Equivalence;
 #[cfg(feature = "mpi")]
@@ -8,7 +9,21 @@ use std::marker::PhantomData;
 use std::sync::Arc;
 
 mod reduce;
-pub use reduce::{allreduce_sum_scalar_slice_in_place, global_dot_conj, global_dot_conj_repro};
+#[cfg(feature = "mpi")]
+pub use reduce::allreduce_sum_scalar_mpi_sys;
+pub use reduce::{
+    GlobalReductionModeGuard, allreduce_sum_scalar_slice_in_place,
+    allreduce_sum_scalar_slice_owned, allreduce_sum_scalar_slice_owned_with_mode,
+    allreduce_sum_scalar_slice_with_mode, allreduce_sum_scalar_with_mode, global_dot_conj,
+    global_dot_conj_accurate, global_dot_conj_many, global_dot_conj_many_accurate,
+    global_dot_conj_many_into, global_dot_conj_many_into_accurate, global_dot_conj_many_into_repro,
+    global_dot_conj_many_into_with_mode, global_dot_conj_many_repro,
+    global_dot_conj_many_with_mode, global_dot_conj_repro, global_dot_conj_with_mode, global_nrm2,
+    global_nrm2_accurate, global_nrm2_many, global_nrm2_many_accurate, global_nrm2_many_into,
+    global_nrm2_many_into_accurate, global_nrm2_many_into_repro, global_nrm2_many_into_with_mode,
+    global_nrm2_many_repro, global_nrm2_many_with_mode, global_nrm2_repro, global_nrm2_with_mode,
+    global_reduction_mode, set_global_reduction_mode, set_global_reduction_mode_scoped,
+};
 
 // Opaque request that can represent multiple backends. Use a `PhantomData`
 // to tie the lifetime when MPI support is disabled.
@@ -235,6 +250,14 @@ impl PartialEq for UniverseComm {
 impl Eq for UniverseComm {}
 
 impl UniverseComm {
+    #[cfg(feature = "mpi")]
+    pub(crate) fn as_mpi(&self) -> Option<&mpi::topology::SimpleCommunicator> {
+        match self {
+            UniverseComm::Mpi(comm) => Some(&comm.world),
+            _ => None,
+        }
+    }
+
     pub fn id(&self) -> u64 {
         match self {
             UniverseComm::NoComm(_) => 0,
@@ -256,13 +279,49 @@ impl UniverseComm {
     /// Deterministic scalar sum across all ranks.
     #[inline]
     pub fn allreduce_sum_scalar_repro(&self, z: S) -> S {
-        reduce::allreduce_sum_scalar_repro_impl(self, z)
+        reduce::allreduce_sum_scalar_repro_impl(self, z, ReproMode::Deterministic)
+    }
+
+    /// Accurate scalar sum across all ranks.
+    #[inline]
+    pub fn allreduce_sum_scalar_accurate(&self, z: S) -> S {
+        reduce::allreduce_sum_scalar_repro_impl(self, z, ReproMode::DeterministicAccurate)
+    }
+
+    /// Deterministic scalar sum across all ranks using the requested reproducibility mode.
+    #[inline]
+    pub fn allreduce_sum_scalar_repro_with_mode(&self, z: S, mode: ReproMode) -> S {
+        reduce::allreduce_sum_scalar_repro_impl(self, z, mode)
+    }
+
+    /// Sum a single scalar across all ranks using the raw `mpi_sys` interface.
+    #[cfg(feature = "mpi")]
+    #[inline]
+    pub fn allreduce_sum_scalar_raw(&self, z: S) -> S {
+        reduce::allreduce_sum_scalar_mpi_sys(self, z)
     }
 
     /// Sum a slice of scalars in place across all ranks (fast path).
     #[inline]
     pub fn allreduce_sum_scalar_slice(&self, data: &mut [S]) {
         reduce::allreduce_sum_scalar_slice_in_place(self, data)
+    }
+
+    /// Sum a slice of scalars across all ranks and return the result in a new buffer.
+    #[inline]
+    pub fn allreduce_sum_scalar_slice_owned(&self, data: &[S]) -> Vec<S> {
+        reduce::allreduce_sum_scalar_slice_owned(self, data)
+    }
+
+    /// Sum a slice of scalars across all ranks using the requested reproducibility mode and
+    /// return the result in a new buffer.
+    #[inline]
+    pub fn allreduce_sum_scalar_slice_owned_with_mode(
+        &self,
+        data: &[S],
+        mode: ReproMode,
+    ) -> Vec<S> {
+        reduce::allreduce_sum_scalar_slice_owned_with_mode(self, data, mode)
     }
 }
 

--- a/src/parallel/reduce.rs
+++ b/src/parallel/reduce.rs
@@ -2,6 +2,17 @@ use crate::algebra::blas::dot_conj;
 use crate::algebra::prelude::*;
 use crate::parallel::{Comm, UniverseComm};
 use crate::reduction::{CommDeterministic, Packet, ReproMode};
+use core::sync::atomic::{AtomicU8, Ordering};
+use smallvec::SmallVec;
+
+#[cfg(feature = "mpi")]
+use core::ffi::c_void;
+#[cfg(feature = "mpi")]
+use mpi::collective::SystemOperation;
+#[cfg(feature = "mpi")]
+use mpi::traits::CommunicatorCollectives;
+#[cfg(feature = "mpi")]
+use mpi::{ffi, raw::AsRaw};
 
 #[cfg(feature = "complex")]
 #[inline]
@@ -20,16 +31,22 @@ pub(crate) fn allreduce_sum_scalar_impl(comm: &UniverseComm, z: S) -> S {
     match comm {
         UniverseComm::NoComm(_) => z,
         #[cfg(feature = "mpi")]
-        UniverseComm::Mpi(inner) => {
+        UniverseComm::Mpi(_) => {
+            let world = comm
+                .as_mpi()
+                .expect("MPI communicator should be available for this variant");
             #[cfg(feature = "complex")]
             {
-                let parts = pack_scalar(z);
-                let (re, im) = inner.allreduce_sum2(parts[0], parts[1]);
-                S::from_parts(re, im)
+                let send = pack_scalar(z);
+                let mut recv = [0.0f64; 2];
+                world.all_reduce_into(&send, &mut recv, SystemOperation::sum());
+                unpack_scalar(recv)
             }
             #[cfg(not(feature = "complex"))]
             {
-                inner.all_reduce_f64(z)
+                let mut out = z;
+                world.all_reduce_into(&z, &mut out, SystemOperation::sum());
+                out
             }
         }
         #[cfg(feature = "rayon")]
@@ -39,65 +56,433 @@ pub(crate) fn allreduce_sum_scalar_impl(comm: &UniverseComm, z: S) -> S {
     }
 }
 
+#[cfg(feature = "mpi")]
 #[inline]
-pub(crate) fn allreduce_sum_scalar_repro_impl(comm: &UniverseComm, z: S) -> S {
+pub fn allreduce_sum_scalar_mpi_sys(comm: &UniverseComm, z: S) -> S {
+    if comm.size() <= 1 {
+        return z;
+    }
+
+    let Some(world) = comm.as_mpi() else {
+        return z;
+    };
+
+    unsafe { mpi_allreduce_sum_scalar_raw(world, z) }
+}
+
+#[cfg(feature = "mpi")]
+unsafe fn mpi_allreduce_sum_scalar_raw(world: &mpi::topology::SimpleCommunicator, z: S) -> S {
+    let raw_comm = world.as_raw();
+
+    #[cfg(not(feature = "complex"))]
+    {
+        let send = [z.real()];
+        let mut recv = [0.0f64; 1];
+        let datatype = unsafe { ffi::RSMPI_DOUBLE };
+        let op = unsafe { ffi::RSMPI_SUM };
+        let status = unsafe {
+            ffi::MPI_Allreduce(
+                send.as_ptr() as *const c_void,
+                recv.as_mut_ptr() as *mut c_void,
+                1,
+                datatype,
+                op,
+                raw_comm,
+            )
+        };
+        debug_assert_eq!(status, 0);
+        return S::from_real(recv[0]);
+    }
+
+    #[cfg(feature = "complex")]
+    {
+        let send = [z.real(), z.imag()];
+        let mut recv = [0.0f64; 2];
+        let datatype = unsafe { ffi::RSMPI_DOUBLE_COMPLEX };
+        let op = unsafe { ffi::RSMPI_SUM };
+        let status = unsafe {
+            ffi::MPI_Allreduce(
+                send.as_ptr() as *const c_void,
+                recv.as_mut_ptr() as *mut c_void,
+                1,
+                datatype,
+                op,
+                raw_comm,
+            )
+        };
+        debug_assert_eq!(status, 0);
+        return S::from_parts(recv[0], recv[1]);
+    }
+}
+
+#[inline]
+pub(crate) fn allreduce_sum_scalar_repro_impl(comm: &UniverseComm, z: S, mode: ReproMode) -> S {
+    if comm.size() <= 1 {
+        return z;
+    }
+
     #[cfg(feature = "complex")]
     {
         let packet = Packet::<2> {
             v: [z.real(), z.imag()],
         };
-        let reduced = comm.allreduce_det(&packet, ReproMode::Deterministic);
+        let reduced = comm.allreduce_det(&packet, mode);
         return S::from_parts(reduced.v[0], reduced.v[1]);
     }
 
     #[cfg(not(feature = "complex"))]
     {
-        let packet = Packet::<1> { v: [z] };
-        let reduced = comm.allreduce_det(&packet, ReproMode::Deterministic);
-        return reduced.v[0];
+        let packet = Packet::<1> { v: [z.real()] };
+        let reduced = comm.allreduce_det(&packet, mode);
+        return S::from_real(reduced.v[0]);
     }
+}
+
+const MODE_FAST: u8 = 0;
+const MODE_DETERMINISTIC: u8 = 1;
+const MODE_DETERMINISTIC_ACCURATE: u8 = 2;
+
+static GLOBAL_REDUCTION_MODE: AtomicU8 = AtomicU8::new(MODE_FAST);
+
+/// Guard that restores the previous global reduction mode when dropped.
+#[derive(Debug)]
+pub struct GlobalReductionModeGuard {
+    previous: ReproMode,
+}
+
+impl Drop for GlobalReductionModeGuard {
+    fn drop(&mut self) {
+        set_global_reduction_mode(self.previous);
+    }
+}
+
+#[inline]
+fn encode_mode(mode: ReproMode) -> u8 {
+    match mode {
+        ReproMode::Fast => MODE_FAST,
+        ReproMode::Deterministic => MODE_DETERMINISTIC,
+        ReproMode::DeterministicAccurate => MODE_DETERMINISTIC_ACCURATE,
+    }
+}
+
+#[inline]
+fn decode_mode(tag: u8) -> ReproMode {
+    match tag {
+        MODE_DETERMINISTIC => ReproMode::Deterministic,
+        MODE_DETERMINISTIC_ACCURATE => ReproMode::DeterministicAccurate,
+        _ => ReproMode::Fast,
+    }
+}
+
+/// Update the process-wide reduction mode used by the global helpers.
+#[inline]
+pub fn set_global_reduction_mode(mode: ReproMode) {
+    GLOBAL_REDUCTION_MODE.store(encode_mode(mode), Ordering::Relaxed);
+}
+
+/// Current process-wide reduction mode.
+#[inline]
+pub fn global_reduction_mode() -> ReproMode {
+    decode_mode(GLOBAL_REDUCTION_MODE.load(Ordering::Relaxed))
+}
+
+/// Temporarily install a new global reduction mode, restoring the previous
+/// configuration when the returned guard is dropped.
+#[inline]
+pub fn set_global_reduction_mode_scoped(mode: ReproMode) -> GlobalReductionModeGuard {
+    let prev = global_reduction_mode();
+    set_global_reduction_mode(mode);
+    GlobalReductionModeGuard { previous: prev }
+}
+
+/// Sum a single scalar across all ranks using the requested reproducibility mode.
+#[inline]
+pub fn allreduce_sum_scalar_with_mode(comm: &UniverseComm, z: S, mode: ReproMode) -> S {
+    match mode {
+        ReproMode::Fast => comm.allreduce_sum_scalar(z),
+        ReproMode::Deterministic | ReproMode::DeterministicAccurate => {
+            comm.allreduce_sum_scalar_repro_with_mode(z, mode)
+        }
+    }
+}
+
+/// Global conjugated dot product across all ranks using the requested mode.
+#[inline]
+pub fn global_dot_conj_with_mode(comm: &UniverseComm, x: &[S], y: &[S], mode: ReproMode) -> S {
+    assert_eq!(
+        x.len(),
+        y.len(),
+        "global_dot_conj length mismatch: {} vs {}",
+        x.len(),
+        y.len()
+    );
+    let local = dot_conj(x, y);
+    allreduce_sum_scalar_with_mode(comm, local, mode)
+}
+
+/// Compute multiple global conjugated dot products in a single collective.
+#[inline]
+pub fn global_dot_conj_many_with_mode(
+    comm: &UniverseComm,
+    pairs: &[(&[S], &[S])],
+    mode: ReproMode,
+) -> Vec<S> {
+    if pairs.is_empty() {
+        return Vec::new();
+    }
+
+    let mut results: SmallVec<[S; 8]> = SmallVec::with_capacity(pairs.len());
+    results.resize(pairs.len(), S::zero());
+    global_dot_conj_many_into_with_mode(comm, pairs, results.as_mut_slice(), mode);
+    results.into_vec()
+}
+
+/// Compute multiple global conjugated dot products, writing the results into the
+/// provided output slice.
+#[inline]
+pub fn global_dot_conj_many_into_with_mode(
+    comm: &UniverseComm,
+    pairs: &[(&[S], &[S])],
+    out: &mut [S],
+    mode: ReproMode,
+) {
+    assert_eq!(
+        pairs.len(),
+        out.len(),
+        "global_dot_conj_many_into output length mismatch: {} pairs for {} slots",
+        pairs.len(),
+        out.len()
+    );
+
+    if pairs.is_empty() {
+        return;
+    }
+
+    for (idx, ((x, y), slot)) in pairs.iter().zip(out.iter_mut()).enumerate() {
+        assert_eq!(
+            x.len(),
+            y.len(),
+            "global_dot_conj_many length mismatch at pair {}: {} vs {}",
+            idx,
+            x.len(),
+            y.len()
+        );
+        *slot = dot_conj(x, y);
+    }
+
+    allreduce_sum_scalar_slice_with_mode(comm, out, mode);
+}
+
+/// Global Euclidean norm of a vector across all ranks using the requested mode.
+#[inline]
+pub fn global_nrm2_with_mode(comm: &UniverseComm, x: &[S], mode: ReproMode) -> R {
+    let squared = global_dot_conj_with_mode(comm, x, x, mode).real();
+    let clamped = if squared >= 0.0 { squared } else { 0.0 };
+    clamped.sqrt()
+}
+
+/// Global Euclidean norm of a vector across all ranks.
+#[inline]
+pub fn global_nrm2(comm: &UniverseComm, x: &[S]) -> R {
+    global_nrm2_with_mode(comm, x, global_reduction_mode())
+}
+
+/// Accurate global Euclidean norm of a vector across all ranks.
+#[inline]
+pub fn global_nrm2_accurate(comm: &UniverseComm, x: &[S]) -> R {
+    global_nrm2_with_mode(comm, x, ReproMode::DeterministicAccurate)
+}
+
+/// Deterministic global Euclidean norm of a vector across all ranks.
+#[inline]
+pub fn global_nrm2_repro(comm: &UniverseComm, x: &[S]) -> R {
+    global_nrm2_with_mode(comm, x, ReproMode::Deterministic)
+}
+
+#[inline]
+fn clamp_and_sqrt(values: &mut [R]) {
+    for value in values.iter_mut() {
+        if *value < 0.0 {
+            *value = 0.0;
+        }
+        *value = (*value).sqrt();
+    }
+}
+
+/// Compute multiple global Euclidean norms using the requested mode.
+#[inline]
+pub fn global_nrm2_many_with_mode(comm: &UniverseComm, vecs: &[&[S]], mode: ReproMode) -> Vec<R> {
+    if vecs.is_empty() {
+        return Vec::new();
+    }
+
+    let mut pairs: SmallVec<[(&[S], &[S]); 8]> = SmallVec::with_capacity(vecs.len());
+    for &vec in vecs.iter() {
+        pairs.push((vec, vec));
+    }
+
+    let dots = global_dot_conj_many_with_mode(comm, pairs.as_slice(), mode);
+    let mut norms: Vec<R> = dots.into_iter().map(|dot| dot.real()).collect();
+    clamp_and_sqrt(norms.as_mut_slice());
+    norms
+}
+
+/// Compute multiple global Euclidean norms into an output slice using the requested mode.
+#[inline]
+pub fn global_nrm2_many_into_with_mode(
+    comm: &UniverseComm,
+    vecs: &[&[S]],
+    out: &mut [R],
+    mode: ReproMode,
+) {
+    assert_eq!(
+        vecs.len(),
+        out.len(),
+        "global_nrm2_many_into output length mismatch: {} vectors for {} slots",
+        vecs.len(),
+        out.len()
+    );
+
+    if vecs.is_empty() {
+        return;
+    }
+
+    let mut pairs: SmallVec<[(&[S], &[S]); 8]> = SmallVec::with_capacity(vecs.len());
+    for &vec in vecs.iter() {
+        pairs.push((vec, vec));
+    }
+
+    let mut dots: SmallVec<[S; 8]> = SmallVec::with_capacity(vecs.len());
+    dots.resize(vecs.len(), S::zero());
+    global_dot_conj_many_into_with_mode(comm, pairs.as_slice(), dots.as_mut_slice(), mode);
+
+    for (slot, dot) in out.iter_mut().zip(dots.iter()) {
+        *slot = dot.real();
+    }
+    clamp_and_sqrt(out);
+}
+
+/// Compute multiple global Euclidean norms using the current global reduction mode.
+#[inline]
+pub fn global_nrm2_many(comm: &UniverseComm, vecs: &[&[S]]) -> Vec<R> {
+    global_nrm2_many_with_mode(comm, vecs, global_reduction_mode())
+}
+
+/// Compute multiple accurate global Euclidean norms across all ranks.
+#[inline]
+pub fn global_nrm2_many_accurate(comm: &UniverseComm, vecs: &[&[S]]) -> Vec<R> {
+    global_nrm2_many_with_mode(comm, vecs, ReproMode::DeterministicAccurate)
+}
+
+/// Compute multiple deterministic global Euclidean norms across all ranks.
+#[inline]
+pub fn global_nrm2_many_repro(comm: &UniverseComm, vecs: &[&[S]]) -> Vec<R> {
+    global_nrm2_many_with_mode(comm, vecs, ReproMode::Deterministic)
+}
+
+/// Compute multiple global Euclidean norms into an output slice using the current mode.
+#[inline]
+pub fn global_nrm2_many_into(comm: &UniverseComm, vecs: &[&[S]], out: &mut [R]) {
+    let mode = global_reduction_mode();
+    global_nrm2_many_into_with_mode(comm, vecs, out, mode);
+}
+
+/// Compute multiple accurate global Euclidean norms into an output slice.
+#[inline]
+pub fn global_nrm2_many_into_accurate(comm: &UniverseComm, vecs: &[&[S]], out: &mut [R]) {
+    global_nrm2_many_into_with_mode(comm, vecs, out, ReproMode::DeterministicAccurate);
+}
+
+/// Compute multiple deterministic global Euclidean norms into an output slice.
+#[inline]
+pub fn global_nrm2_many_into_repro(comm: &UniverseComm, vecs: &[&[S]], out: &mut [R]) {
+    global_nrm2_many_into_with_mode(comm, vecs, out, ReproMode::Deterministic);
 }
 
 /// Global conjugated dot product across all ranks.
 #[inline]
 pub fn global_dot_conj(comm: &UniverseComm, x: &[S], y: &[S]) -> S {
-    let local = dot_conj(x, y);
-    comm.allreduce_sum_scalar(local)
+    global_dot_conj_with_mode(comm, x, y, global_reduction_mode())
+}
+
+/// Accurate global conjugated dot product across all ranks.
+#[inline]
+pub fn global_dot_conj_accurate(comm: &UniverseComm, x: &[S], y: &[S]) -> S {
+    global_dot_conj_with_mode(comm, x, y, ReproMode::DeterministicAccurate)
 }
 
 /// Deterministic global conjugated dot product across all ranks.
 #[inline]
 pub fn global_dot_conj_repro(comm: &UniverseComm, x: &[S], y: &[S]) -> S {
-    let local = dot_conj(x, y);
-    comm.allreduce_sum_scalar_repro(local)
+    global_dot_conj_with_mode(comm, x, y, ReproMode::Deterministic)
 }
 
+/// Compute multiple global conjugated dot products in the current global mode.
 #[inline]
-pub fn allreduce_sum_scalar_slice_in_place(comm: &UniverseComm, data: &mut [S]) {
+pub fn global_dot_conj_many(comm: &UniverseComm, pairs: &[(&[S], &[S])]) -> Vec<S> {
+    global_dot_conj_many_with_mode(comm, pairs, global_reduction_mode())
+}
+
+/// Compute multiple accurate global conjugated dot products.
+#[inline]
+pub fn global_dot_conj_many_accurate(comm: &UniverseComm, pairs: &[(&[S], &[S])]) -> Vec<S> {
+    global_dot_conj_many_with_mode(comm, pairs, ReproMode::DeterministicAccurate)
+}
+
+/// Compute multiple deterministic global conjugated dot products.
+#[inline]
+pub fn global_dot_conj_many_repro(comm: &UniverseComm, pairs: &[(&[S], &[S])]) -> Vec<S> {
+    global_dot_conj_many_with_mode(comm, pairs, ReproMode::Deterministic)
+}
+
+/// Compute multiple global conjugated dot products into an output slice using
+/// the current global reduction mode.
+#[inline]
+pub fn global_dot_conj_many_into(comm: &UniverseComm, pairs: &[(&[S], &[S])], out: &mut [S]) {
+    let mode = global_reduction_mode();
+    global_dot_conj_many_into_with_mode(comm, pairs, out, mode);
+}
+
+/// Compute multiple accurate global conjugated dot products into an output slice.
+#[inline]
+pub fn global_dot_conj_many_into_accurate(
+    comm: &UniverseComm,
+    pairs: &[(&[S], &[S])],
+    out: &mut [S],
+) {
+    global_dot_conj_many_into_with_mode(comm, pairs, out, ReproMode::DeterministicAccurate);
+}
+
+/// Compute multiple deterministic global conjugated dot products into an output slice.
+#[inline]
+pub fn global_dot_conj_many_into_repro(comm: &UniverseComm, pairs: &[(&[S], &[S])], out: &mut [S]) {
+    global_dot_conj_many_into_with_mode(comm, pairs, out, ReproMode::Deterministic);
+}
+
+fn allreduce_sum_scalar_slice_fast(comm: &UniverseComm, data: &mut [S]) {
+    if data.is_empty() || comm.size() <= 1 {
+        return;
+    }
+
     match comm {
         UniverseComm::NoComm(_) => {}
         #[cfg(feature = "mpi")]
         UniverseComm::Mpi(inner) => {
-            if data.is_empty() {
-                return;
-            }
             #[cfg(feature = "complex")]
             {
-                let mut packed = vec![0.0f64; data.len() * 2];
-                for (idx, &value) in data.iter().enumerate() {
+                let mut packed: SmallVec<[f64; 16]> = SmallVec::with_capacity(data.len() * 2);
+                for &value in data.iter() {
                     let parts = pack_scalar(value);
-                    packed[2 * idx] = parts[0];
-                    packed[2 * idx + 1] = parts[1];
+                    packed.extend_from_slice(&parts);
                 }
-                inner.allreduce_sum_slice(&mut packed);
-                for (idx, slot) in data.iter_mut().enumerate() {
-                    *slot = S::from_parts(packed[2 * idx], packed[2 * idx + 1]);
+                inner.allreduce_sum_slice(packed.as_mut_slice());
+                for (slot, chunk) in data.iter_mut().zip(packed.chunks_exact(2)) {
+                    *slot = S::from_parts(chunk[0], chunk[1]);
                 }
             }
             #[cfg(not(feature = "complex"))]
             {
-                let slice: &mut [f64] = unsafe { &mut *(data as *mut [S] as *mut [f64]) };
-                inner.allreduce_sum_slice(slice);
+                inner.allreduce_sum_slice(data);
             }
         }
         #[cfg(feature = "rayon")]
@@ -105,6 +490,140 @@ pub fn allreduce_sum_scalar_slice_in_place(comm: &UniverseComm, data: &mut [S]) 
         #[cfg(not(any(feature = "mpi", feature = "rayon")))]
         UniverseComm::Serial => {}
     }
+}
+
+/// Reduce a slice of scalars using the requested reproducibility mode.
+#[inline]
+pub fn allreduce_sum_scalar_slice_with_mode(comm: &UniverseComm, data: &mut [S], mode: ReproMode) {
+    match mode {
+        ReproMode::Fast => allreduce_sum_scalar_slice_fast(comm, data),
+        ReproMode::Deterministic | ReproMode::DeterministicAccurate => {
+            reduce_scalar_slice_deterministic(comm, data, mode);
+        }
+    }
+}
+
+/// Reduce a slice of scalars and return the summed values in a new buffer using the
+/// requested reproducibility mode.
+#[inline]
+pub fn allreduce_sum_scalar_slice_owned_with_mode(
+    comm: &UniverseComm,
+    data: &[S],
+    mode: ReproMode,
+) -> Vec<S> {
+    let mut out = Vec::from(data);
+    allreduce_sum_scalar_slice_with_mode(comm, &mut out, mode);
+    out
+}
+
+/// Reduce a slice of scalars and return the summed values in a new buffer.
+#[inline]
+pub fn allreduce_sum_scalar_slice_owned(comm: &UniverseComm, data: &[S]) -> Vec<S> {
+    let mode = global_reduction_mode();
+    allreduce_sum_scalar_slice_owned_with_mode(comm, data, mode)
+}
+
+fn reduce_scalar_slice_deterministic(comm: &UniverseComm, data: &mut [S], mode: ReproMode) {
+    if data.is_empty() || comm.size() <= 1 {
+        return;
+    }
+
+    #[cfg(not(feature = "complex"))]
+    {
+        reduce_packets_in_place::<1, _, _>(
+            comm,
+            data,
+            mode,
+            |value| [value.real()],
+            |parts| S::from_real(parts[0]),
+        );
+    }
+
+    #[cfg(feature = "complex")]
+    {
+        reduce_packets_in_place::<2, _, _>(
+            comm,
+            data,
+            mode,
+            |value| pack_scalar(value),
+            |parts| S::from_parts(parts[0], parts[1]),
+        );
+    }
+}
+
+fn reduce_packets_in_place<const WIDTH: usize, F, G>(
+    comm: &UniverseComm,
+    data: &mut [S],
+    mode: ReproMode,
+    mut pack: F,
+    mut unpack: G,
+) where
+    F: FnMut(S) -> [f64; WIDTH],
+    G: FnMut([f64; WIDTH]) -> S,
+{
+    debug_assert!(WIDTH >= 1);
+
+    let mut scratch: SmallVec<[f64; 16]> = SmallVec::with_capacity(data.len() * WIDTH);
+    scratch.resize(data.len() * WIDTH, 0.0);
+
+    for (idx, &value) in data.iter().enumerate() {
+        let parts = pack(value);
+        scratch[idx * WIDTH..(idx + 1) * WIDTH].copy_from_slice(&parts);
+    }
+
+    reduce_buffer_in_packets(comm, scratch.as_mut_slice(), mode);
+
+    for (idx, slot) in data.iter_mut().enumerate() {
+        let mut parts = [0.0f64; WIDTH];
+        parts.copy_from_slice(&scratch[idx * WIDTH..(idx + 1) * WIDTH]);
+        *slot = unpack(parts);
+    }
+}
+
+fn reduce_buffer_in_packets(comm: &UniverseComm, buf: &mut [f64], mode: ReproMode) {
+    if buf.is_empty() {
+        return;
+    }
+
+    let mut offset = 0;
+    while offset < buf.len() {
+        let remaining = buf.len() - offset;
+        let width = remaining.min(4);
+        match width {
+            4 => {
+                let mut packet = Packet::<4> { v: [0.0; 4] };
+                packet.v.copy_from_slice(&buf[offset..offset + 4]);
+                let reduced = comm.allreduce_det(&packet, mode);
+                buf[offset..offset + 4].copy_from_slice(&reduced.v);
+            }
+            3 => {
+                let mut packet = Packet::<3> { v: [0.0; 3] };
+                packet.v.copy_from_slice(&buf[offset..offset + 3]);
+                let reduced = comm.allreduce_det(&packet, mode);
+                buf[offset..offset + 3].copy_from_slice(&reduced.v);
+            }
+            2 => {
+                let mut packet = Packet::<2> { v: [0.0; 2] };
+                packet.v.copy_from_slice(&buf[offset..offset + 2]);
+                let reduced = comm.allreduce_det(&packet, mode);
+                buf[offset..offset + 2].copy_from_slice(&reduced.v);
+            }
+            _ => {
+                let mut packet = Packet::<1> { v: [0.0; 1] };
+                packet.v[0] = buf[offset];
+                let reduced = comm.allreduce_det(&packet, mode);
+                buf[offset] = reduced.v[0];
+            }
+        }
+        offset += width;
+    }
+}
+
+/// Reduce a slice of scalars in place using the current global reduction mode.
+#[inline]
+pub fn allreduce_sum_scalar_slice_in_place(comm: &UniverseComm, data: &mut [S]) {
+    let mode = global_reduction_mode();
+    allreduce_sum_scalar_slice_with_mode(comm, data, mode);
 }
 
 #[cfg(test)]
@@ -144,5 +663,198 @@ mod tests {
         let dot_fast = global_dot_conj(&comm, &[z], &[S::one()]);
         let dot_repro = global_dot_conj_repro(&comm, &[z], &[S::one()]);
         assert_eq!(dot_fast, dot_repro);
+    }
+
+    #[test]
+    fn global_nrm2_single_rank() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let vec = [S::from_real(3.0), S::from_real(4.0)];
+        let norm = global_nrm2(&comm, &vec);
+        assert!((norm - 5.0).abs() < 1e-12);
+    }
+
+    #[test]
+    fn global_nrm2_repro_matches_fast_single_rank() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let vec = [S::from_parts(1.0, 0.5), S::from_parts(-2.0, -0.25)];
+        let fast = global_nrm2(&comm, &vec);
+        let repro = global_nrm2_repro(&comm, &vec);
+        assert!((fast - repro).abs() < 1e-15);
+    }
+
+    #[test]
+    fn global_nrm2_accurate_matches_fast_single_rank() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let vec = [S::from_parts(0.75, -0.5), S::from_parts(-1.25, 0.25)];
+        let fast = global_nrm2(&comm, &vec);
+        let accurate = global_nrm2_accurate(&comm, &vec);
+        assert!((fast - accurate).abs() < 1e-15);
+    }
+
+    #[test]
+    fn slice_reduction_respects_mode() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let mut data_fast = [S::from_real(1.0), S::from_real(-2.0), S::from_real(3.5)];
+        let mut data_det = data_fast;
+
+        allreduce_sum_scalar_slice_with_mode(&comm, &mut data_fast, ReproMode::Fast);
+        allreduce_sum_scalar_slice_with_mode(&comm, &mut data_det, ReproMode::Deterministic);
+
+        assert_eq!(data_fast, data_det);
+    }
+
+    #[test]
+    fn global_mode_controls_slice_reduction() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let _guard = set_global_reduction_mode_scoped(ReproMode::DeterministicAccurate);
+        let mut data = [S::from_real(0.5), S::from_real(-1.5)];
+        allreduce_sum_scalar_slice_in_place(&comm, &mut data);
+        assert_eq!(data, [S::from_real(0.5), S::from_real(-1.5)]);
+    }
+
+    #[test]
+    #[should_panic(expected = "global_dot_conj length mismatch")]
+    fn global_dot_conj_rejects_mismatched_lengths() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let x = [S::from_real(1.0)];
+        let y = [S::from_real(1.0), S::from_real(2.0)];
+        let _ = global_dot_conj(&comm, &x, &y);
+    }
+
+    #[test]
+    fn global_dot_conj_accurate_matches_fast_single_rank() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let x = [S::from_parts(0.5, -0.25), S::from_parts(1.5, 0.75)];
+        let y = [S::from_parts(1.0, 0.5), S::from_parts(-0.5, -0.5)];
+        let fast = global_dot_conj(&comm, &x, &y);
+        let accurate = global_dot_conj_accurate(&comm, &x, &y);
+        assert_eq!(fast, accurate);
+    }
+
+    #[test]
+    fn scoped_reduction_mode_guard_restores_state() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let prev = global_reduction_mode();
+        set_global_reduction_mode(ReproMode::Fast);
+        {
+            let _guard = set_global_reduction_mode_scoped(ReproMode::Deterministic);
+            assert_eq!(global_reduction_mode(), ReproMode::Deterministic);
+
+            let mut values = [S::from_real(1.0)];
+            allreduce_sum_scalar_slice_in_place(&comm, &mut values);
+            assert_eq!(values, [S::from_real(1.0)]);
+        }
+        assert_eq!(global_reduction_mode(), ReproMode::Fast);
+        set_global_reduction_mode(prev);
+    }
+
+    #[test]
+    fn owned_slice_reduction_single_rank_matches_input() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let input = [
+            S::from_parts(1.0, 0.25),
+            S::from_parts(-2.0, 0.5),
+            S::from_parts(0.75, -0.125),
+        ];
+        let summed = allreduce_sum_scalar_slice_owned(&comm, &input);
+        assert_eq!(summed, input);
+
+        let summed_det =
+            allreduce_sum_scalar_slice_owned_with_mode(&comm, &input, ReproMode::Deterministic);
+        assert_eq!(summed_det, input);
+    }
+
+    #[test]
+    fn owned_slice_reduction_respects_global_mode() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let prev = global_reduction_mode();
+        set_global_reduction_mode(ReproMode::DeterministicAccurate);
+        let input = [S::from_real(1.25), S::from_real(-0.75)];
+        let summed = allreduce_sum_scalar_slice_owned(&comm, &input);
+        assert_eq!(summed, input);
+        set_global_reduction_mode(prev);
+    }
+
+    #[test]
+    fn global_dot_conj_many_single_rank() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let x0 = [S::from_real(1.0), S::from_real(2.0)];
+        let y0 = [S::from_real(0.5), S::from_real(-1.0)];
+        let x1 = [S::from_parts(0.75, 0.25)];
+        let y1 = [S::from_parts(1.25, -0.5)];
+
+        let results = global_dot_conj_many(&comm, &[(&x0, &y0), (&x1, &y1)]);
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0], dot_conj(&x0, &y0));
+        assert_eq!(results[1], dot_conj(&x1, &y1));
+
+        let repro = global_dot_conj_many_repro(&comm, &[(&x0, &y0), (&x1, &y1)]);
+        assert_eq!(repro, results);
+    }
+
+    #[test]
+    fn global_dot_conj_many_into_single_rank() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let x0 = [S::from_parts(0.25, 0.5), S::from_parts(1.0, -0.25)];
+        let y0 = [S::from_parts(2.0, -1.5), S::from_parts(-0.5, 0.25)];
+        let x1 = [S::from_parts(-1.5, 0.75), S::from_parts(0.0, -0.5)];
+        let y1 = [S::from_parts(0.75, 0.5), S::from_parts(1.25, -0.75)];
+
+        let mut out = [S::zero(), S::zero()];
+        global_dot_conj_many_into(&comm, &[(&x0, &y0), (&x1, &y1)], &mut out);
+
+        assert_eq!(out[0], dot_conj(&x0, &y0));
+        assert_eq!(out[1], dot_conj(&x1, &y1));
+
+        let mut repro = out;
+        global_dot_conj_many_into_repro(&comm, &[(&x0, &y0), (&x1, &y1)], &mut repro);
+        assert_eq!(out, repro);
+
+        let mut accurate = out;
+        global_dot_conj_many_into_accurate(&comm, &[(&x0, &y0), (&x1, &y1)], &mut accurate);
+        assert_eq!(out, accurate);
+    }
+
+    #[test]
+    fn global_nrm2_many_single_rank() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let v0 = [S::from_real(3.0), S::from_real(4.0)];
+        let v1 = [S::from_parts(1.0, 0.5), S::from_parts(-2.0, -0.25)];
+
+        let norms = global_nrm2_many(&comm, &[&v0, &v1]);
+        assert_eq!(norms.len(), 2);
+        assert!((norms[0] - 5.0).abs() < 1e-12);
+
+        let expected1 = global_nrm2(&comm, &v1);
+        assert!((norms[1] - expected1).abs() < 1e-15);
+
+        let repro = global_nrm2_many_repro(&comm, &[&v0, &v1]);
+        assert_eq!(norms, repro);
+
+        let accurate = global_nrm2_many_accurate(&comm, &[&v0, &v1]);
+        assert_eq!(norms, accurate);
+    }
+
+    #[test]
+    fn global_nrm2_many_into_single_rank() {
+        let comm = UniverseComm::NoComm(NoComm);
+        let v0 = [S::from_parts(0.5, -0.25), S::from_parts(1.5, 0.75)];
+        let v1 = [S::from_parts(1.0, 0.5), S::from_parts(-0.5, -0.5)];
+
+        let mut out = [0.0, 0.0];
+        global_nrm2_many_into(&comm, &[&v0, &v1], &mut out);
+
+        let expected0 = global_nrm2(&comm, &v0);
+        let expected1 = global_nrm2(&comm, &v1);
+        assert!((out[0] - expected0).abs() < 1e-15);
+        assert!((out[1] - expected1).abs() < 1e-15);
+
+        let mut repro = out;
+        global_nrm2_many_into_repro(&comm, &[&v0, &v1], &mut repro);
+        assert_eq!(repro, out);
+
+        let mut accurate = out;
+        global_nrm2_many_into_accurate(&comm, &[&v0, &v1], &mut accurate);
+        assert_eq!(accurate, out);
     }
 }

--- a/src/reduction.rs
+++ b/src/reduction.rs
@@ -1,5 +1,8 @@
 use crate::parallel::Comm;
 
+#[cfg(feature = "mpi")]
+use crate::parallel::MpiComm;
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ReproMode {
     Fast,
@@ -226,67 +229,99 @@ impl<const N: usize> PacketAccum<N> for DDP<N> {
     }
 }
 
-pub trait CommDeterministic {
+pub trait CommDeterministic: Comm {
     fn allreduce_det<const N: usize>(&self, local: &Packet<N>, mode: ReproMode) -> Packet<N>;
 }
 
-use crate::parallel::UniverseComm;
+fn allreduce_packet_det<const N: usize, C>(
+    comm: &C,
+    local: &Packet<N>,
+    mode: ReproMode,
+) -> Packet<N>
+where
+    C: Comm,
+{
+    if matches!(mode, ReproMode::Fast) {
+        let mut tmp = local.clone();
+        comm.allreduce_sum_slice(&mut tmp.v);
+        return tmp;
+    }
+
+    let size = comm.size();
+    let rank = comm.rank();
+    if size == 1 {
+        return local.clone();
+    }
+
+    if rank == 0 {
+        match mode {
+            ReproMode::DeterministicAccurate => {
+                let mut acc = DDP::<N>::new();
+                acc.add(local);
+                for src in 1..size {
+                    let mut buf = Packet::<N>::default();
+                    {
+                        let mut recv = comm.irecv_from(&mut buf.v, src as i32);
+                        comm.wait_all(std::slice::from_mut(&mut recv));
+                    }
+                    acc.add(&buf);
+                }
+                let total = acc.finish();
+                for dest in 1..size {
+                    let mut send = comm.isend_to(&total.v, dest as i32);
+                    comm.wait_all(std::slice::from_mut(&mut send));
+                }
+                total
+            }
+            _ => {
+                let mut acc = KahanP::<N>::new();
+                acc.add(local);
+                for src in 1..size {
+                    let mut buf = Packet::<N>::default();
+                    {
+                        let mut recv = comm.irecv_from(&mut buf.v, src as i32);
+                        comm.wait_all(std::slice::from_mut(&mut recv));
+                    }
+                    acc.add(&buf);
+                }
+                let total = acc.finish();
+                for dest in 1..size {
+                    let mut send = comm.isend_to(&total.v, dest as i32);
+                    comm.wait_all(std::slice::from_mut(&mut send));
+                }
+                total
+            }
+        }
+    } else {
+        let mut send = comm.isend_to(&local.v, 0);
+        comm.wait_all(std::slice::from_mut(&mut send));
+        let mut buf = Packet::<N>::default();
+        {
+            let mut recv = comm.irecv_from(&mut buf.v, 0);
+            comm.wait_all(std::slice::from_mut(&mut recv));
+        }
+        buf
+    }
+}
+
+use crate::parallel::{NoComm, UniverseComm};
 
 impl CommDeterministic for UniverseComm {
     fn allreduce_det<const N: usize>(&self, local: &Packet<N>, mode: ReproMode) -> Packet<N> {
-        if matches!(mode, ReproMode::Fast) {
-            let mut tmp = local.clone();
-            self.allreduce_sum_slice(&mut tmp.v);
-            return tmp;
-        }
-        let size = self.size();
-        let rank = self.rank();
-        if size == 1 {
-            return local.clone();
-        }
-        if rank == 0 {
-            match mode {
-                ReproMode::DeterministicAccurate => {
-                    let mut acc = DDP::<N>::new();
-                    acc.add(local);
-                    for src in 1..size {
-                        let mut buf = Packet::<N>::default();
-                        let mut r = self.irecv_from(&mut buf.v, src as i32);
-                        self.wait_all(std::slice::from_mut(&mut r));
-                        acc.add(&buf);
-                    }
-                    let total = acc.finish();
-                    for dest in 1..size {
-                        let mut s = self.isend_to(&total.v, dest as i32);
-                        self.wait_all(std::slice::from_mut(&mut s));
-                    }
-                    total
-                }
-                _ => {
-                    let mut acc = KahanP::<N>::new();
-                    acc.add(local);
-                    for src in 1..size {
-                        let mut buf = Packet::<N>::default();
-                        let mut r = self.irecv_from(&mut buf.v, src as i32);
-                        self.wait_all(std::slice::from_mut(&mut r));
-                        acc.add(&buf);
-                    }
-                    let total = acc.finish();
-                    for dest in 1..size {
-                        let mut s = self.isend_to(&total.v, dest as i32);
-                        self.wait_all(std::slice::from_mut(&mut s));
-                    }
-                    total
-                }
-            }
-        } else {
-            let mut s = self.isend_to(&local.v, 0);
-            self.wait_all(std::slice::from_mut(&mut s));
-            let mut buf = Packet::<N>::default();
-            let mut r = self.irecv_from(&mut buf.v, 0);
-            self.wait_all(std::slice::from_mut(&mut r));
-            buf
-        }
+        allreduce_packet_det(self, local, mode)
+    }
+}
+
+impl CommDeterministic for NoComm {
+    fn allreduce_det<const N: usize>(&self, local: &Packet<N>, _mode: ReproMode) -> Packet<N> {
+        local.clone()
+    }
+}
+
+#[cfg(feature = "mpi")]
+impl CommDeterministic for MpiComm {
+    fn allreduce_det<const N: usize>(&self, local: &Packet<N>, mode: ReproMode) -> Packet<N> {
+        allreduce_packet_det(self, local, mode)
     }
 }
 
@@ -297,14 +332,9 @@ pub struct DotEngine {
 
 impl DotEngine {
     pub fn dot<C: Comm + CommDeterministic>(&self, u: &[f64], v: &[f64], comm: &C) -> f64 {
-        let local = if self.opts.mode == ReproMode::Fast {
-            u.iter().zip(v).map(|(a, b)| a * b).sum()
-        } else if self.opts.single_thread_local {
-            dot_local_slice(u, v, self.opts.mode)
-        } else {
-            dot_local_deterministic_parallel(u, v, self.opts.chunk_len, self.opts.mode)
+        let packet = Packet::<1> {
+            v: [self.dot_local(u, v)],
         };
-        let packet = Packet::<1> { v: [local] };
         let g = comm.allreduce_det(&packet, self.opts.mode);
         g.v[0]
     }
@@ -313,5 +343,137 @@ impl DotEngine {
         let packet = Packet::<2> { v: [a, b] };
         let g = comm.allreduce_det(&packet, self.opts.mode);
         (g.v[0], g.v[1])
+    }
+
+    fn dot_local(&self, u: &[f64], v: &[f64]) -> f64 {
+        if self.opts.mode == ReproMode::Fast {
+            u.iter().zip(v).map(|(a, b)| a * b).sum()
+        } else if self.opts.single_thread_local {
+            dot_local_slice(u, v, self.opts.mode)
+        } else {
+            dot_local_deterministic_parallel(u, v, self.opts.chunk_len, self.opts.mode)
+        }
+    }
+
+    pub fn dot_many_into<C: Comm + CommDeterministic>(
+        &self,
+        pairs: &[(&[f64], &[f64])],
+        out: &mut [f64],
+        comm: &C,
+    ) {
+        if pairs.len() != out.len() {
+            panic!(
+                "dot_many_into length mismatch: {} pairs for {} slots",
+                pairs.len(),
+                out.len()
+            );
+        }
+        if pairs.is_empty() {
+            return;
+        }
+
+        for ((u, v), slot) in pairs.iter().zip(out.iter_mut()) {
+            if u.len() != v.len() {
+                panic!(
+                    "dot_many_into vector length mismatch: {} vs {}",
+                    u.len(),
+                    v.len()
+                );
+            }
+            *slot = self.dot_local(u, v);
+        }
+
+        let width = self.opts.packet_width.max(1).min(4);
+        let mode = self.opts.mode;
+        let mut idx = 0;
+        while idx < out.len() {
+            let chunk_len = (out.len() - idx).min(width);
+            match chunk_len {
+                1 => {
+                    let packet = Packet::<1> { v: [out[idx]] };
+                    let reduced = comm.allreduce_det(&packet, mode);
+                    out[idx] = reduced.v[0];
+                }
+                2 => {
+                    let packet = Packet::<2> {
+                        v: [out[idx], out[idx + 1]],
+                    };
+                    let reduced = comm.allreduce_det(&packet, mode);
+                    out[idx..idx + 2].copy_from_slice(&reduced.v);
+                }
+                3 => {
+                    let packet = Packet::<3> {
+                        v: [out[idx], out[idx + 1], out[idx + 2]],
+                    };
+                    let reduced = comm.allreduce_det(&packet, mode);
+                    out[idx..idx + 3].copy_from_slice(&reduced.v);
+                }
+                _ => {
+                    let packet = Packet::<4> {
+                        v: [out[idx], out[idx + 1], out[idx + 2], out[idx + 3]],
+                    };
+                    let reduced = comm.allreduce_det(&packet, mode);
+                    out[idx..idx + 4].copy_from_slice(&reduced.v);
+                }
+            }
+            idx += chunk_len;
+        }
+    }
+
+    pub fn dot_many<C: Comm + CommDeterministic>(
+        &self,
+        pairs: &[(&[f64], &[f64])],
+        comm: &C,
+    ) -> Vec<f64> {
+        let mut out = vec![0.0; pairs.len()];
+        self.dot_many_into(pairs, &mut out, comm);
+        out
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parallel::NoComm;
+
+    #[test]
+    fn dot_engine_many_matches_individual_dots() {
+        let mut opts = ReductionOptions::default();
+        opts.packet_width = 4;
+        let engine = DotEngine { opts };
+        let a = vec![1.0, -2.0, 3.5, 0.75];
+        let b = vec![0.5, 1.5, -2.0, 4.0];
+        let c = vec![1.25, -0.5, 3.0, -1.0];
+        let pairs = [(&a[..], &b[..]), (&a[..], &c[..])];
+        let mut out = vec![0.0; pairs.len()];
+        engine.dot_many_into(&pairs, &mut out, &NoComm);
+
+        let single_ab = engine.dot(&a, &b, &NoComm);
+        let single_ac = engine.dot(&a, &c, &NoComm);
+        assert!((out[0] - single_ab).abs() < 1e-12);
+        assert!((out[1] - single_ac).abs() < 1e-12);
+    }
+
+    #[test]
+    fn dot_engine_many_batches_more_than_packet_width() {
+        let mut opts = ReductionOptions::default();
+        opts.packet_width = 3;
+        let engine = DotEngine { opts };
+
+        let inputs: Vec<Vec<f64>> = (0..5)
+            .map(|i| vec![i as f64 + 1.0, (i as f64 - 0.5) * 0.75])
+            .collect();
+        let mut pairs = Vec::new();
+        for idx in 0..inputs.len() {
+            let next = (idx + 1) % inputs.len();
+            pairs.push((&inputs[idx][..], &inputs[next][..]));
+        }
+        let mut out = vec![0.0; pairs.len()];
+        engine.dot_many_into(pairs.as_slice(), &mut out, &NoComm);
+
+        for (idx, (u, v)) in pairs.iter().enumerate() {
+            let expected = engine.dot(u, v, &NoComm);
+            assert!((out[idx] - expected).abs() < 1e-12);
+        }
     }
 }

--- a/src/solver/bicgstab.rs
+++ b/src/solver/bicgstab.rs
@@ -18,7 +18,7 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::{Comm, UniverseComm};
+use crate::parallel::{UniverseComm, global_dot_conj, global_dot_conj_many_into, global_nrm2};
 use crate::preconditioner::{PcSide, Preconditioner, Preconditioner as PreconditionerF64};
 use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, SolveStats};
@@ -28,13 +28,12 @@ use crate::utils::profiling::StageGuard;
 #[cfg(feature = "logging")]
 use log::trace;
 
-fn dot<C: Comm>(x: &[S], y: &[S], comm: &C) -> S {
-    comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, y))
+fn dot(x: &[S], y: &[S], comm: &UniverseComm) -> S {
+    global_dot_conj(comm, x, y)
 }
 
-fn norm2<C: Comm>(x: &[S], comm: &C) -> R {
-    let global = comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, x));
-    global.real().sqrt()
+fn norm2(x: &[S], comm: &UniverseComm) -> R {
+    global_nrm2(comm, x)
 }
 
 struct BiCgWorkspace<'a> {
@@ -384,7 +383,11 @@ impl BiCgStabSolver {
                 }
             }
 
-            let omega_den = dot(t, t, comm);
+            let mut omega_reds = [S::zero(), S::zero()];
+            let dot_pairs = [(&t[..], &t[..]), (&t[..], &s[..])];
+            global_dot_conj_many_into(comm, &dot_pairs, &mut omega_reds);
+
+            let omega_den = omega_reds[0];
             if omega_den.abs() <= eps_omega || !omega_den.is_finite() {
                 #[cfg(feature = "logging")]
                 trace!("BiCGStab breakdown: omega_den ~ 0 at iter {k}");
@@ -393,7 +396,7 @@ impl BiCgStabSolver {
                 stats.reason = ConvergedReason::DivergedDtol;
                 return Ok(stats);
             }
-            let omega = dot(t, s, comm) / omega_den;
+            let omega = omega_reds[1] / omega_den;
             if omega.abs() <= eps_omega || !omega.is_finite() {
                 #[cfg(feature = "logging")]
                 trace!("BiCGStab breakdown: omega ~ 0 at iter {k}");

--- a/src/solver/cg.rs
+++ b/src/solver/cg.rs
@@ -13,10 +13,12 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::{Comm, UniverseComm};
+use crate::parallel::{UniverseComm, global_dot_conj, global_dot_conj_many_into, global_nrm2};
 use crate::preconditioner::{PcSide, Preconditioner, Preconditioner as PreconditionerF64};
 use crate::solver::LinearSolver;
+use crate::solver::common::dot_result_to_real;
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
+use smallvec::SmallVec;
 use std::any::Any;
 
 #[cfg(feature = "logging")]
@@ -24,27 +26,13 @@ use crate::utils::profiling::StageGuard;
 #[cfg(feature = "logging")]
 use log::trace;
 
-fn dot<C: Comm>(u: &[S], v: &[S], comm: &C) -> R {
-    let global = comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(u, v));
-    #[cfg(feature = "complex")]
-    {
-        debug_assert!(
-            global.imag().abs() <= 1e-12 * global.real().abs().max(1.0) + 1e-30,
-            "CG detected non-real inner product: {} + {}i",
-            global.real(),
-            global.imag()
-        );
-        global.real()
-    }
-    #[cfg(not(feature = "complex"))]
-    {
-        global.real()
-    }
+fn norm2(x: &[S], comm: &UniverseComm) -> R {
+    global_nrm2(comm, x)
 }
 
-fn norm2<C: Comm>(x: &[S], comm: &C) -> R {
-    let global = comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, x));
-    global.real().abs().sqrt()
+fn dot(u: &[S], v: &[S], comm: &UniverseComm) -> R {
+    let global = global_dot_conj(comm, u, v);
+    dot_result_to_real(global)
 }
 
 struct CgWorkspace<'a> {
@@ -163,20 +151,19 @@ impl CgSolver {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn solve_with_comm<A, C>(
+    pub fn solve_with_comm<A>(
         &mut self,
         a: &A,
         pc: Option<&dyn KPreconditioner<Scalar = S>>,
         b: &[S],
         x: &mut [S],
         pc_side: PcSide,
-        comm: &C,
+        comm: &UniverseComm,
         monitors: Option<&[Box<dyn Fn(usize, R) + Send + Sync>]>,
         work: Option<&mut Workspace>,
     ) -> Result<SolveStats<R>, KError>
     where
         A: KLinOp<Scalar = S> + ?Sized,
-        C: Comm,
     {
         #[cfg(feature = "logging")]
         let _guard = StageGuard::new("CG");
@@ -226,14 +213,45 @@ impl CgSolver {
             z.copy_from_slice(r);
         }
 
-        let mut rho = dot(r, z, comm);
+        let want_unpre = matches!(self.norm_type, CgNormType::Unpreconditioned);
+        let want_natural = matches!(self.norm_type, CgNormType::Natural);
+
+        let (mut rho, rsq, znorm) = {
+            let mut dot_pairs: SmallVec<[(&[S], &[S]); 3]> = SmallVec::new();
+            dot_pairs.push((&r[..], &z[..]));
+            if want_unpre {
+                dot_pairs.push((&r[..], &r[..]));
+            }
+            if want_natural {
+                dot_pairs.push((&z[..], &z[..]));
+            }
+
+            let mut dot_results: SmallVec<[S; 3]> = SmallVec::new();
+            dot_results.resize(dot_pairs.len(), S::zero());
+            global_dot_conj_many_into(comm, dot_pairs.as_slice(), dot_results.as_mut_slice());
+
+            let mut result_idx = 0;
+            let rho = dot_result_to_real(dot_results[result_idx]);
+            result_idx += 1;
+            let rsq = if want_unpre {
+                let value = dot_results[result_idx];
+                result_idx += 1;
+                Some(dot_result_to_real(value))
+            } else {
+                None
+            };
+            let znorm = if want_natural {
+                let value = dot_results[result_idx];
+                Some(dot_result_to_real(value))
+            } else {
+                None
+            };
+            (rho, rsq, znorm)
+        };
         let mut rho_prev = rho;
         if rho <= 0.0 || !rho.is_finite() {
             return Err(KError::IndefinitePreconditioner);
         }
-
-        let rsq = matches!(self.norm_type, CgNormType::Unpreconditioned).then(|| dot(r, r, comm));
-        let znorm = matches!(self.norm_type, CgNormType::Natural).then(|| dot(z, z, comm));
         let mut xnorm = if self.trust_region.is_some() {
             norm2(x, comm)
         } else {
@@ -321,14 +339,45 @@ impl CgSolver {
                 z.copy_from_slice(r);
             }
 
-            let rho_new = dot(r, z, comm);
-            if rho_new <= 0.0 || !rho_new.is_finite() {
-                return Err(KError::IndefinitePreconditioner);
-            }
+            let (rho_new, rsq_new, znorm_new) = {
+                let want_unpre = matches!(self.norm_type, CgNormType::Unpreconditioned);
+                let want_natural = matches!(self.norm_type, CgNormType::Natural);
 
-            let rsq_new =
-                matches!(self.norm_type, CgNormType::Unpreconditioned).then(|| dot(r, r, comm));
-            let znorm_new = matches!(self.norm_type, CgNormType::Natural).then(|| dot(z, z, comm));
+                let mut dot_pairs: SmallVec<[(&[S], &[S]); 3]> = SmallVec::new();
+                dot_pairs.push((&r[..], &z[..]));
+                if want_unpre {
+                    dot_pairs.push((&r[..], &r[..]));
+                }
+                if want_natural {
+                    dot_pairs.push((&z[..], &z[..]));
+                }
+
+                let mut dot_results: SmallVec<[S; 3]> = SmallVec::new();
+                dot_results.resize(dot_pairs.len(), S::zero());
+                global_dot_conj_many_into(comm, dot_pairs.as_slice(), dot_results.as_mut_slice());
+
+                let mut result_idx = 0;
+                let rho_new = dot_result_to_real(dot_results[result_idx]);
+                result_idx += 1;
+                if rho_new <= 0.0 || !rho_new.is_finite() {
+                    return Err(KError::IndefinitePreconditioner);
+                }
+
+                let rsq_new = if want_unpre {
+                    let value = dot_results[result_idx];
+                    result_idx += 1;
+                    Some(dot_result_to_real(value))
+                } else {
+                    None
+                };
+                let znorm_new = if want_natural {
+                    let value = dot_results[result_idx];
+                    Some(dot_result_to_real(value))
+                } else {
+                    None
+                };
+                (rho_new, rsq_new, znorm_new)
+            };
 
             let res_reported = match self.norm_type {
                 CgNormType::Preconditioned => rho_new.abs().sqrt(),

--- a/src/solver/cgnr.rs
+++ b/src/solver/cgnr.rs
@@ -7,10 +7,10 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::{Comm, UniverseComm};
+use crate::parallel::{UniverseComm, global_dot_conj, global_dot_conj_many_into};
 use crate::preconditioner::{PcSide, Preconditioner, Preconditioner as PreconditionerF64};
 use crate::solver::LinearSolver;
-use crate::solver::common::{recompute_true_residual_norm_s, take_or_resize};
+use crate::solver::common::{dot_result_to_real, recompute_true_residual_norm_s, take_or_resize};
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 use std::any::Any;
 
@@ -33,13 +33,15 @@ impl CgnrSolver {
     }
 }
 
-fn dot<C: Comm>(x: &[S], y: &[S], comm: &C) -> S {
-    comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, y))
+fn dot(x: &[S], y: &[S], comm: &UniverseComm) -> S {
+    global_dot_conj(comm, x, y)
 }
 
-fn norm2<C: Comm>(x: &[S], comm: &C) -> R {
-    let global = comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, x));
-    global.real().sqrt()
+#[inline]
+fn norm_from_dot(result: S) -> R {
+    let real = dot_result_to_real(result);
+    let clamped = if real >= R::zero() { real } else { R::zero() };
+    clamped.sqrt()
 }
 
 struct CgnrWorkspace<'a> {
@@ -156,9 +158,12 @@ impl CgnrSolver {
         }
         p.copy_from_slice(zhat);
 
-        let mut rz = dot(z, zhat, comm);
-        let mut rnow = norm2(r, comm);
-        let bnorm = norm2(b, comm).max(1e-32);
+        let dot_pairs = [(&z[..], &zhat[..]), (&r[..], &r[..]), (b, b)];
+        let mut dot_results = [S::zero(); 3];
+        global_dot_conj_many_into(comm, &dot_pairs, &mut dot_results);
+        let mut rz = dot_results[0];
+        let mut rnow = norm_from_dot(dot_results[1]);
+        let bnorm = norm_from_dot(dot_results[2]).max(1e-32);
 
         for m in monitors {
             m(0, rnow);
@@ -176,7 +181,7 @@ impl CgnrSolver {
             iters = k;
 
             a.matvec_s(p, ap, scratch);
-            let denom = dot(ap, ap, comm).real();
+            let denom = dot_result_to_real(dot(ap, ap, comm));
             if denom <= 0.0 || !denom.is_finite() {
                 let true_res = recompute_true_residual_norm_s(a, b, x, comm, tmp_true, scratch);
                 return Ok(SolveStats::new(
@@ -200,8 +205,11 @@ impl CgnrSolver {
                 zhat.copy_from_slice(z);
             }
 
-            let rz_new = dot(z, zhat, comm);
-            rnow = norm2(r, comm);
+            let dot_pairs = [(&z[..], &zhat[..]), (&r[..], &r[..])];
+            let mut dot_results = [S::zero(); 2];
+            global_dot_conj_many_into(comm, &dot_pairs, &mut dot_results);
+            let rz_new = dot_results[0];
+            rnow = norm_from_dot(dot_results[1]);
 
             for m in monitors {
                 m(k, rnow);

--- a/src/solver/cgs.rs
+++ b/src/solver/cgs.rs
@@ -17,10 +17,10 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::{Comm, UniverseComm};
+use crate::parallel::{UniverseComm, global_dot_conj_many_into};
 use crate::preconditioner::{PcSide, Preconditioner, Preconditioner as PreconditionerF64};
 use crate::solver::LinearSolver;
-use crate::solver::common::{recompute_true_residual_norm_s, take_or_resize};
+use crate::solver::common::{dot_result_to_real, recompute_true_residual_norm_s, take_or_resize};
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 
 #[cfg(feature = "logging")]
@@ -35,13 +35,11 @@ const BRK_REL: R = 1e-12;
 /// Absolute floor to guard subnormals.
 const BRK_ABS: R = 1e-300;
 
-fn dot<C: Comm>(x: &[S], y: &[S], comm: &C) -> S {
-    comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, y))
-}
-
-fn norm2<C: Comm>(x: &[S], comm: &C) -> R {
-    let global = comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, x));
-    global.real().sqrt()
+#[inline]
+fn norm_from_dot(result: S) -> R {
+    let real = dot_result_to_real(result);
+    let clamped = if real >= R::zero() { real } else { R::zero() };
+    clamped.sqrt()
 }
 
 struct CgsWorkspace<'a> {
@@ -157,9 +155,16 @@ impl CgsSolver {
         }
         r_tld.copy_from_slice(r);
 
-        let rtld_norm = norm2(&r_tld, comm);
-
-        let mut rnorm = norm2(r, comm);
+        let dot_pairs = [
+            (&r_tld[..], &r[..]),
+            (&r[..], &r[..]),
+            (&r_tld[..], &r_tld[..]),
+        ];
+        let mut dot_results = [S::zero(); 3];
+        global_dot_conj_many_into(comm, &dot_pairs, &mut dot_results);
+        let mut rho = dot_results[0];
+        let mut rnorm = norm_from_dot(dot_results[1]);
+        let rtld_norm = norm_from_dot(dot_results[2]);
         let res0_reported = rnorm;
 
         for m in monitors {
@@ -171,8 +176,7 @@ impl CgsSolver {
             return Ok(SolveStats::new(0, rnorm, s0.reason));
         }
 
-        let mut rho = dot(&r_tld, r, comm);
-        let mut r_norm = norm2(r, comm);
+        let mut r_norm = rnorm;
         let mut rho_abs = rho.abs();
         let mut rho_thr = BRK_ABS.max(BRK_REL * rtld_norm * r_norm);
         if rho_abs <= rho_thr {
@@ -188,9 +192,12 @@ impl CgsSolver {
 
             a.matvec_s(p, &mut *v, &mut *scratch);
 
-            let sigma = dot(&r_tld, v, comm);
+            let dot_pairs = [(&r_tld[..], &v[..]), (&v[..], &v[..])];
+            let mut dot_results = [S::zero(); 2];
+            global_dot_conj_many_into(comm, &dot_pairs, &mut dot_results);
+            let sigma = dot_results[0];
             let sigma_abs = sigma.abs();
-            let v_norm = norm2(v, comm);
+            let v_norm = norm_from_dot(dot_results[1]);
             let sigma_thr = BRK_ABS.max(BRK_REL * rtld_norm * v_norm);
             if sigma_abs <= sigma_thr {
                 return Err(KError::IndefiniteMatrix);
@@ -212,7 +219,10 @@ impl CgsSolver {
                 r[i] -= alpha * w[i];
             }
 
-            rnorm = norm2(r, comm);
+            let dot_pairs = [(&r[..], &r[..]), (&r_tld[..], &r[..])];
+            let mut dot_results = [S::zero(); 2];
+            global_dot_conj_many_into(comm, &dot_pairs, &mut dot_results);
+            rnorm = norm_from_dot(dot_results[0]);
             for m in monitors {
                 m(k, rnorm);
             }
@@ -223,8 +233,9 @@ impl CgsSolver {
             }
 
             let rho_old = rho;
-            rho = dot(&r_tld, r, comm);
-            r_norm = norm2(r, comm);
+            let rho_new = dot_results[1];
+            rho = rho_new;
+            r_norm = rnorm;
             rho_abs = rho.abs();
             rho_thr = BRK_ABS.max(BRK_REL * rtld_norm * r_norm);
             if rho_abs <= rho_thr {

--- a/src/solver/common/mod.rs
+++ b/src/solver/common/mod.rs
@@ -6,13 +6,35 @@ use crate::algebra::bridge::BridgeScratch;
 use crate::algebra::prelude::*;
 use crate::matrix::op::LinOp;
 use crate::ops::klinop::KLinOp;
-use crate::parallel::{Comm, UniverseComm};
-use crate::utils::reduction::{AllreduceHandle, AsyncComm, ReductOptions};
+use crate::parallel::{Comm, UniverseComm, global_nrm2, global_reduction_mode};
+use crate::reduction::{CommDeterministic, Packet, ReproMode, dot_local_slice};
+#[cfg(feature = "complex")]
+use crate::reduction::{DDP, KahanP};
+use crate::utils::reduction::{AllreduceHandle, AsyncComm, ReductMode, ReductOptions};
 
 pub use buffer::take_or_resize;
 
-fn reduce_real<C: Comm>(comm: &C, value: R) -> R {
-    comm.allreduce_sum_scalar(S::from_real(value)).real()
+/// Convert a conjugated dot-product result into its real scalar component.
+///
+/// In complex builds we sanity-check that the imaginary component is within a
+/// small tolerance of zero so solvers can surface unexpected non-Hermitian
+/// reductions during debug runs.
+#[inline]
+pub fn dot_result_to_real(global: S) -> R {
+    #[cfg(feature = "complex")]
+    {
+        debug_assert!(
+            global.imag().abs() <= 1e-12 * global.real().abs().max(1.0) + 1e-30,
+            "non-real inner product detected: {} + {}i",
+            global.real(),
+            global.imag()
+        );
+        global.real()
+    }
+    #[cfg(not(feature = "complex"))]
+    {
+        global.real()
+    }
 }
 
 /// Recompute the true residual norm ||r||_2 where r = b - A x.
@@ -20,7 +42,7 @@ fn reduce_real<C: Comm>(comm: &C, value: R) -> R {
 /// This uses the provided `comm` for the dot-product reduction so it works in
 /// both serial and distributed settings.
 #[inline]
-pub fn recompute_true_residual_norm<C: Comm>(
+pub fn recompute_true_residual_norm<C: Comm + CommDeterministic>(
     a: &dyn LinOp<S = f64>,
     b: &[f64],
     x: &[f64],
@@ -33,25 +55,225 @@ pub fn recompute_true_residual_norm<C: Comm>(
         tmp[i] = b[i] - tmp[i];
         local += tmp[i] * tmp[i];
     }
-    if comm.size() == 1 {
-        local.sqrt()
+    let mode = global_reduction_mode();
+    let summed = if comm.size() == 1 {
+        local
     } else {
-        comm.allreduce_sum_scalar(S::from_real(local)).real().sqrt()
+        match mode {
+            ReproMode::Fast => comm.allreduce_sum_scalar(S::from_real(local)).real(),
+            _ => {
+                let packet = Packet::<1> { v: [local] };
+                comm.allreduce_det(&packet, mode).v[0]
+            }
+        }
+    };
+
+    let clamped = if summed >= 0.0 { summed } else { 0.0 };
+    clamped.sqrt()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parallel::{NoComm, UniverseComm, set_global_reduction_mode_scoped};
+    use std::any::Any;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    #[derive(Clone, Copy)]
+    struct IdentityOp;
+
+    impl LinOp for IdentityOp {
+        type S = f64;
+
+        fn dims(&self) -> (usize, usize) {
+            (2, 2)
+        }
+
+        fn matvec(&self, x: &[Self::S], y: &mut [Self::S]) {
+            y.copy_from_slice(x);
+        }
+
+        fn as_any(&self) -> &dyn Any {
+            self
+        }
+    }
+
+    struct MockComm {
+        fast_calls: AtomicUsize,
+        det_calls: AtomicUsize,
+        fast_value: f64,
+        det_value: f64,
+    }
+
+    impl MockComm {
+        fn new(fast_value: f64, det_value: f64) -> Self {
+            Self {
+                fast_calls: AtomicUsize::new(0),
+                det_calls: AtomicUsize::new(0),
+                fast_value,
+                det_value,
+            }
+        }
+
+        fn reset(&self) {
+            self.fast_calls.store(0, Ordering::Relaxed);
+            self.det_calls.store(0, Ordering::Relaxed);
+        }
+    }
+
+    impl Comm for MockComm {
+        type Vec = Vec<f64>;
+        type Request<'a> = ();
+
+        fn rank(&self) -> usize {
+            0
+        }
+
+        fn size(&self) -> usize {
+            2
+        }
+
+        fn barrier(&self) {}
+
+        #[cfg(feature = "mpi")]
+        fn scatter<T: Clone + mpi::datatype::Equivalence>(
+            &self,
+            _global: &[T],
+            _out: &mut [T],
+            _root: usize,
+        ) {
+            unimplemented!("scatter is not used in tests");
+        }
+
+        #[cfg(not(feature = "mpi"))]
+        fn scatter<T: Clone>(&self, _global: &[T], _out: &mut [T], _root: usize) {
+            unimplemented!("scatter is not used in tests");
+        }
+
+        #[cfg(feature = "mpi")]
+        fn gather<T: Clone + mpi::datatype::Equivalence>(
+            &self,
+            _local: &[T],
+            _out: &mut Vec<T>,
+            _root: usize,
+        ) {
+            unimplemented!("gather is not used in tests");
+        }
+
+        #[cfg(not(feature = "mpi"))]
+        fn gather<T: Clone>(&self, _local: &[T], _out: &mut Vec<T>, _root: usize) {
+            unimplemented!("gather is not used in tests");
+        }
+
+        fn all_reduce_f64(&self, _local: f64) -> f64 {
+            self.fast_value
+        }
+
+        fn allreduce_sum(&self, _x: f64) -> f64 {
+            self.fast_value
+        }
+
+        fn allreduce_sum2(&self, _a: f64, _b: f64) -> (f64, f64) {
+            (self.fast_value, self.fast_value)
+        }
+
+        fn allreduce_sum_slice(&self, _v: &mut [f64]) {
+            unimplemented!("slice reductions are not used in tests");
+        }
+
+        fn allreduce_sum_scalar(&self, _z: S) -> S {
+            self.fast_calls.fetch_add(1, Ordering::Relaxed);
+            S::from_real(self.fast_value)
+        }
+
+        fn split(&self, _color: i32, _key: i32) -> UniverseComm {
+            UniverseComm::NoComm(NoComm)
+        }
+
+        fn irecv_from<'a>(&'a self, _buf: &'a mut [f64], _src: i32) -> Self::Request<'a> {
+            unimplemented!("irecv is not used in tests");
+        }
+
+        fn isend_to<'a>(&'a self, _buf: &'a [f64], _dest: i32) -> Self::Request<'a> {
+            unimplemented!("isend is not used in tests");
+        }
+
+        fn irecv_from_u64<'a>(&'a self, _buf: &'a mut [u64], _src: i32) -> Self::Request<'a> {
+            unimplemented!("irecv_u64 is not used in tests");
+        }
+
+        fn isend_to_u64<'a>(&'a self, _buf: &'a [u64], _dest: i32) -> Self::Request<'a> {
+            unimplemented!("isend_u64 is not used in tests");
+        }
+
+        fn wait_all<'a>(&self, _reqs: &mut [Self::Request<'a>]) {}
+    }
+
+    impl CommDeterministic for MockComm {
+        fn allreduce_det<const N: usize>(&self, _local: &Packet<N>, mode: ReproMode) -> Packet<N> {
+            self.det_calls.fetch_add(1, Ordering::Relaxed);
+            let value = match mode {
+                ReproMode::Fast => self.fast_value,
+                _ => self.det_value,
+            };
+            let mut out = Packet::<N>::default();
+            for slot in out.v.iter_mut() {
+                *slot = value;
+            }
+            out
+        }
+    }
+
+    #[test]
+    fn recompute_true_residual_norm_respects_global_mode() {
+        let op = IdentityOp;
+        let b = [2.0, -1.0];
+        let x = [1.0, 0.0];
+        let comm = MockComm::new(2.0, 4.0);
+        let mut tmp = vec![0.0; 2];
+
+        {
+            let _guard = set_global_reduction_mode_scoped(ReproMode::Fast);
+            tmp.fill(0.0);
+            let norm = recompute_true_residual_norm(&op, &b, &x, &comm, &mut tmp);
+            assert!((norm - 2.0_f64.sqrt()).abs() < 1e-12);
+        }
+        assert_eq!(comm.fast_calls.load(Ordering::Relaxed), 1);
+        assert_eq!(comm.det_calls.load(Ordering::Relaxed), 0);
+
+        comm.reset();
+        {
+            let _guard = set_global_reduction_mode_scoped(ReproMode::Deterministic);
+            tmp.fill(0.0);
+            let norm = recompute_true_residual_norm(&op, &b, &x, &comm, &mut tmp);
+            assert!((norm - 2.0).abs() < 1e-12);
+        }
+        assert_eq!(comm.fast_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(comm.det_calls.load(Ordering::Relaxed), 1);
+
+        comm.reset();
+        {
+            let _guard = set_global_reduction_mode_scoped(ReproMode::DeterministicAccurate);
+            tmp.fill(0.0);
+            let norm = recompute_true_residual_norm(&op, &b, &x, &comm, &mut tmp);
+            assert!((norm - 2.0).abs() < 1e-12);
+        }
+        assert_eq!(comm.fast_calls.load(Ordering::Relaxed), 0);
+        assert_eq!(comm.det_calls.load(Ordering::Relaxed), 1);
     }
 }
 
 #[inline]
-pub fn recompute_true_residual_norm_s<A, C>(
+pub fn recompute_true_residual_norm_s<A>(
     a: &A,
     b: &[S],
     x: &[S],
-    comm: &C,
+    comm: &UniverseComm,
     tmp: &mut [S],
     scratch: &mut BridgeScratch,
 ) -> R
 where
     A: KLinOp<Scalar = S> + ?Sized,
-    C: Comm,
 {
     debug_assert_eq!(b.len(), x.len());
     debug_assert_eq!(tmp.len(), x.len());
@@ -60,8 +282,7 @@ where
     for i in 0..tmp.len() {
         tmp[i] = b[i] - tmp[i];
     }
-    let local = crate::algebra::blas::dot_conj(tmp, tmp);
-    comm.allreduce_sum_scalar(local).real().sqrt()
+    global_nrm2(comm, tmp)
 }
 
 /// Compute the residual norm used for iteration monitors (the "reported" norm):
@@ -102,6 +323,15 @@ pub struct AsyncDot2 {
     pub local: (f64, f64),
 }
 
+#[inline]
+fn reduct_to_repro(mode: ReductMode) -> ReproMode {
+    match mode {
+        ReductMode::Fast => ReproMode::Fast,
+        ReductMode::Deterministic => ReproMode::Deterministic,
+        ReductMode::DeterministicAccurate => ReproMode::DeterministicAccurate,
+    }
+}
+
 /// Launch a fused pair of dot products asynchronously.
 pub fn dot2_async<C: AsyncComm + ?Sized>(
     comm: &C,
@@ -113,12 +343,9 @@ pub fn dot2_async<C: AsyncComm + ?Sized>(
 ) -> AsyncDot2 {
     debug_assert_eq!(x1.len(), y1.len());
     debug_assert_eq!(x2.len(), y2.len());
-    let mut a = 0.0;
-    let mut b = 0.0;
-    for ((&xi, &yi), (&xj, &yj)) in x1.iter().zip(y1).zip(x2.iter().zip(y2)) {
-        a += xi * yi;
-        b += xj * yj;
-    }
+    let mode = reduct_to_repro(opt.mode);
+    let a = dot_local_slice(x1, y1, mode);
+    let b = dot_local_slice(x2, y2, mode);
     let (handle, local) = comm
         .allreduce2_async(a, b, opt)
         .expect("async reduction launch");
@@ -134,10 +361,8 @@ pub fn dot1_async<C: AsyncComm + ?Sized>(
     opt: &ReductOptions,
 ) -> Result<(AllreduceHandle<(f64, f64)>, (f64, f64)), crate::error::KError> {
     debug_assert_eq!(x.len(), y.len());
-    let mut sum = 0.0;
-    for i in 0..x.len() {
-        sum += x[i] * y[i];
-    }
+    let mode = reduct_to_repro(opt.mode);
+    let sum = dot_local_slice(x, y, mode);
     comm.allreduce2_async(sum, 0.0, opt)
 }
 
@@ -160,8 +385,9 @@ pub fn dot1_async_s<C: AsyncComm + ?Sized>(
 
     #[cfg(feature = "complex")]
     {
-        let sum = dot_conj(x, y).real();
-        comm.allreduce2_async(sum, 0.0, opt)
+        let mode = reduct_to_repro(opt.mode);
+        let Packet { v: [re, im] } = dot_conj_components(x, y, mode);
+        comm.allreduce2_async(re, im, opt)
     }
 }
 
@@ -179,13 +405,10 @@ pub fn dotn_async<C: AsyncComm + ?Sized>(
     opt: &ReductOptions,
 ) -> AsyncDotN {
     let mut loc = vec![0.0; pairs.len()];
+    let mode = reduct_to_repro(opt.mode);
     for (k, (x, y)) in pairs.iter().enumerate() {
         debug_assert_eq!(x.len(), y.len());
-        let mut sum = 0.0;
-        for i in 0..x.len() {
-            sum += x[i] * y[i];
-        }
-        loc[k] = sum;
+        loc[k] = dot_local_slice(x, y, mode);
     }
     let (handle, local) = comm
         .allreduce_n_async(loc.clone(), opt)
@@ -199,10 +422,8 @@ pub fn nrm2_async<C: AsyncComm + ?Sized>(
     x: &[f64],
     opt: &ReductOptions,
 ) -> (AllreduceHandle<(f64, f64)>, f64) {
-    let mut sumsq = 0.0;
-    for &xi in x {
-        sumsq += xi * xi;
-    }
+    let mode = reduct_to_repro(opt.mode);
+    let sumsq = dot_local_slice(x, x, mode);
     let (handle, local) = comm
         .allreduce2_async(sumsq, 0.0, opt)
         .expect("async reduction launch");
@@ -223,10 +444,48 @@ pub fn nrm2_async_s<C: AsyncComm + ?Sized>(
 
     #[cfg(feature = "complex")]
     {
-        let sumsq = dot_conj(x, x).real();
+        let mode = reduct_to_repro(opt.mode);
+        let Packet { v: [re, im] } = dot_conj_components(x, x, mode);
         let (handle, local) = comm
-            .allreduce2_async(sumsq, 0.0, opt)
+            .allreduce2_async(re, im, opt)
             .expect("async reduction launch");
         (handle, local.0)
+    }
+}
+
+#[cfg(feature = "complex")]
+fn dot_conj_components(x: &[S], y: &[S], mode: ReproMode) -> Packet<2> {
+    debug_assert_eq!(x.len(), y.len());
+    match mode {
+        ReproMode::Fast => {
+            let mut re = 0.0;
+            let mut im = 0.0;
+            for (&xi, &yi) in x.iter().zip(y) {
+                let prod = xi.conj() * yi;
+                re += prod.real();
+                im += prod.imag();
+            }
+            Packet { v: [re, im] }
+        }
+        ReproMode::Deterministic => {
+            let mut acc = KahanP::<2>::new();
+            for (&xi, &yi) in x.iter().zip(y) {
+                let prod = xi.conj() * yi;
+                acc.add(&Packet {
+                    v: [prod.real(), prod.imag()],
+                });
+            }
+            acc.finish()
+        }
+        ReproMode::DeterministicAccurate => {
+            let mut acc = DDP::<2>::new();
+            for (&xi, &yi) in x.iter().zip(y) {
+                let prod = xi.conj() * yi;
+                acc.add(&Packet {
+                    v: [prod.real(), prod.imag()],
+                });
+            }
+            acc.finish()
+        }
     }
 }

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -1,7 +1,6 @@
 //! Flexible GMRES (FGMRES) over the scalar-generic [`KLinOp`] interface with optional
 //! mutable preconditioning support.
 
-use crate::algebra::blas::{dot_conj, nrm2};
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
 use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
@@ -11,11 +10,14 @@ use crate::matrix::op::LinOp;
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc_mut};
-use crate::parallel::UniverseComm;
+use crate::parallel::{
+    UniverseComm, global_dot_conj_many_into, global_nrm2, global_nrm2_many_into,
+};
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::solver::common::recompute_true_residual_norm_s;
 use crate::utils::convergence::{ConvergedReason, SolveStats};
+use smallvec::SmallVec;
 use std::any::Any;
 
 /// Orthogonalization flavor
@@ -69,15 +71,6 @@ impl FgmresSolver {
             reorth: ReorthPolicy::IfNeeded,
             reorth_tol: 0.7,
         }
-    }
-
-    #[inline]
-    fn dot(x: &[S], y: &[S]) -> S {
-        dot_conj(x, y)
-    }
-    #[inline]
-    fn nrm2(x: &[S]) -> R {
-        nrm2(x)
     }
 
     fn ensure_workspace(&self, w: &mut Workspace, n: usize, m: usize) {
@@ -146,8 +139,10 @@ impl FgmresSolver {
             ws.tmp1[i] = b[i] - ws.tmp1[i];
         }
 
-        let mut beta0 = Self::nrm2(&ws.tmp1[..n]);
-        let bnorm = Self::nrm2(b).max(1e-32);
+        let mut norms = [R::zero(); 2];
+        global_nrm2_many_into(comm, &[&ws.tmp1[..n], b], &mut norms);
+        let mut beta0 = norms[0];
+        let bnorm = norms[1].max(1e-32);
         let thr = self.atol.max(self.rtol * bnorm);
 
         ws.h_mem.fill(S::zero());
@@ -223,26 +218,53 @@ impl FgmresSolver {
                         ws.tmp1[..n].copy_from_slice(&ws.z_mem[base..base + n]);
                         a.matvec_s(&ws.tmp1[..n], &mut ws.tmp2[..n], &mut ws.bridge);
 
-                        let mut hvals = vec![S::zero(); j + 1];
+                        let mut hvals: SmallVec<[S; 32]> = SmallVec::with_capacity(j + 1);
+                        hvals.resize(j + 1, S::zero());
                         {
-                            let tmp2 = &mut ws.tmp2[..n];
+                            let tmp2_slice: &[S] = &ws.tmp2[..n];
+                            let mut pairs: SmallVec<[(&[S], &[S]); 32]> =
+                                SmallVec::with_capacity(j + 1);
                             for i in 0..=j {
                                 let vi = &ws.v_mem[i * n..(i + 1) * n];
-                                let hij = Self::dot(vi, tmp2);
-                                hvals[i] = hij;
+                                pairs.push((vi, tmp2_slice));
+                            }
+                            global_dot_conj_many_into(comm, pairs.as_slice(), hvals.as_mut_slice());
+                        }
+                        {
+                            let tmp2 = &mut ws.tmp2[..n];
+                            for (i, hij) in hvals.iter().copied().enumerate() {
+                                let vi = &ws.v_mem[i * n..(i + 1) * n];
                                 for (w_i, &vi_val) in tmp2.iter_mut().zip(vi) {
                                     *w_i -= hij * vi_val;
                                 }
                             }
-                            if matches!(self.orthog, Orthog::Modified) {
+                        }
+                        if matches!(self.orthog, Orthog::Modified) {
+                            let mut corr: SmallVec<[S; 32]> = SmallVec::with_capacity(j + 1);
+                            corr.resize(j + 1, S::zero());
+                            {
+                                let tmp2_slice: &[S] = &ws.tmp2[..n];
+                                let mut pairs: SmallVec<[(&[S], &[S]); 32]> =
+                                    SmallVec::with_capacity(j + 1);
                                 for i in 0..=j {
                                     let vi = &ws.v_mem[i * n..(i + 1) * n];
-                                    let corr = Self::dot(vi, tmp2);
-                                    if corr.abs() > 1e-12 {
+                                    pairs.push((vi, tmp2_slice));
+                                }
+                                global_dot_conj_many_into(
+                                    comm,
+                                    pairs.as_slice(),
+                                    corr.as_mut_slice(),
+                                );
+                            }
+                            {
+                                let tmp2 = &mut ws.tmp2[..n];
+                                for (i, corr_val) in corr.into_iter().enumerate() {
+                                    if corr_val.abs() > 1e-12 {
+                                        let vi = &ws.v_mem[i * n..(i + 1) * n];
                                         for (w_i, &vi_val) in tmp2.iter_mut().zip(vi) {
-                                            *w_i -= corr * vi_val;
+                                            *w_i -= corr_val * vi_val;
                                         }
-                                        hvals[i] += corr;
+                                        hvals[i] += corr_val;
                                     }
                                 }
                             }
@@ -251,7 +273,7 @@ impl FgmresSolver {
                             *ws.h_at_mut(i, j) = hvals[i];
                         }
 
-                        let hij1 = nrm2(&ws.tmp2[..n]);
+                        let hij1 = global_nrm2(comm, &ws.tmp2[..n]);
                         *ws.h_at_mut(j + 1, j) = S::from_real(hij1);
 
                         if hij1 > 0.0 {
@@ -363,7 +385,7 @@ impl FgmresSolver {
             for i in 0..n {
                 ws.tmp1[i] = b[i] - ws.tmp1[i];
             }
-            beta0 = Self::nrm2(&ws.tmp1[..n]);
+            beta0 = global_nrm2(comm, &ws.tmp1[..n]);
 
             ws.h_mem.fill(S::zero());
             ws.cs.fill(0.0);

--- a/src/solver/gmres.rs
+++ b/src/solver/gmres.rs
@@ -15,7 +15,6 @@
 //! in column-major form. The legacy `Workspace.z` (Vec<Vec<_>>) is not used by
 //! GMRES/FGMRES.
 
-use crate::algebra::blas::{dot_conj, nrm2};
 use crate::algebra::bridge::BridgeScratch;
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
@@ -25,10 +24,13 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::{UniverseComm, global_dot_conj};
+use crate::parallel::{
+    UniverseComm, global_dot_conj_many_into, global_nrm2, global_nrm2_many_into,
+};
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
+use smallvec::SmallVec;
 use std::any::Any;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -170,7 +172,7 @@ impl GmresSolver {
         for i in 0..tmp.len() {
             tmp[i] = b[i] - tmp[i];
         }
-        global_dot_conj(comm, tmp, tmp).real().sqrt()
+        global_nrm2(comm, tmp)
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -223,7 +225,7 @@ impl GmresSolver {
         ws.g.fill(S::zero());
 
         let mut res: R;
-        let beta: R = match pc_side {
+        let (beta, mut bnorm) = match pc_side {
             PcSide::Left => {
                 if let Some(pc) = pc {
                     let tmp2 = &mut ws.tmp2[..n];
@@ -231,7 +233,9 @@ impl GmresSolver {
                 } else {
                     ws.tmp2[..n].copy_from_slice(&ws.tmp1[..n]);
                 }
-                let beta = nrm2(&ws.tmp2[..n]);
+                let mut norms = [R::zero(); 2];
+                global_nrm2_many_into(comm, &[&ws.tmp2[..n], b], &mut norms);
+                let beta = norms[0];
                 if beta > 0.0 {
                     let inv = S::from_real(1.0 / beta);
                     for val in &mut ws.tmp2[..n] {
@@ -241,10 +245,12 @@ impl GmresSolver {
                 } else {
                     ws.v_col(0).fill(S::zero());
                 }
-                beta
+                (beta, norms[1])
             }
             PcSide::Right => {
-                let beta = nrm2(&ws.tmp1[..n]);
+                let mut norms = [R::zero(); 2];
+                global_nrm2_many_into(comm, &[&ws.tmp1[..n], b], &mut norms);
+                let beta = norms[0];
                 if beta > 0.0 {
                     let inv = S::from_real(1.0 / beta);
                     for (dst, &src) in ws.tmp2[..n].iter_mut().zip(&ws.tmp1[..n]) {
@@ -254,13 +260,13 @@ impl GmresSolver {
                 } else {
                     ws.v_col(0).fill(S::zero());
                 }
-                beta
+                (beta, norms[1])
             }
             PcSide::Symmetric => unreachable!(),
         };
 
         ws.g[0] = S::from_real(beta);
-        let bnorm = nrm2(b).max(1e-32);
+        bnorm = bnorm.max(1e-32);
         let thr = self.conv.atol.max(self.conv.rtol * bnorm);
 
         let mut total_iters = 0usize;
@@ -309,13 +315,26 @@ impl GmresSolver {
                             } else {
                                 ws.tmp2[..n].copy_from_slice(&ws.tmp1[..n]);
                             }
-                            let mut hvals = vec![S::zero(); k + 1];
+                            let mut hvals: SmallVec<[S; 32]> = SmallVec::with_capacity(k + 1);
+                            hvals.resize(k + 1, S::zero());
                             {
-                                let tmp2 = &mut ws.tmp2[..n];
+                                let tmp2_slice: &[S] = &ws.tmp2[..n];
+                                let mut pairs: SmallVec<[(&[S], &[S]); 32]> =
+                                    SmallVec::with_capacity(k + 1);
                                 for i in 0..=k {
                                     let vi = &ws.v_mem[i * n..(i + 1) * n];
-                                    let hij = dot_conj(vi, tmp2);
-                                    hvals[i] = hij;
+                                    pairs.push((vi, tmp2_slice));
+                                }
+                                global_dot_conj_many_into(
+                                    comm,
+                                    pairs.as_slice(),
+                                    hvals.as_mut_slice(),
+                                );
+                            }
+                            {
+                                let tmp2 = &mut ws.tmp2[..n];
+                                for (i, hij) in hvals.iter().copied().enumerate() {
+                                    let vi = &ws.v_mem[i * n..(i + 1) * n];
                                     for (w, &vi_j) in tmp2.iter_mut().zip(vi) {
                                         *w -= hij * vi_j;
                                     }
@@ -324,7 +343,7 @@ impl GmresSolver {
                             for i in 0..=k {
                                 *ws.h_at_mut(i, k) = hvals[i];
                             }
-                            let hnext = nrm2(&ws.tmp2[..n]);
+                            let hnext = global_nrm2(comm, &ws.tmp2[..n]);
                             *ws.h_at_mut(k + 1, k) = S::from_real(hnext);
                             if hnext > 0.0 {
                                 let inv = S::from_real(1.0 / hnext);
@@ -349,13 +368,26 @@ impl GmresSolver {
                                 zk.copy_from_slice(tmp2);
                             }
                             a.matvec_s(&ws.tmp2[..n], &mut ws.tmp1, &mut ws.bridge);
-                            let mut hvals = vec![S::zero(); k + 1];
+                            let mut hvals: SmallVec<[S; 32]> = SmallVec::with_capacity(k + 1);
+                            hvals.resize(k + 1, S::zero());
                             {
-                                let tmp1 = &mut ws.tmp1[..n];
+                                let tmp1_slice: &[S] = &ws.tmp1[..n];
+                                let mut pairs: SmallVec<[(&[S], &[S]); 32]> =
+                                    SmallVec::with_capacity(k + 1);
                                 for i in 0..=k {
                                     let vi = &ws.v_mem[i * n..(i + 1) * n];
-                                    let hij = dot_conj(vi, tmp1);
-                                    hvals[i] = hij;
+                                    pairs.push((vi, tmp1_slice));
+                                }
+                                global_dot_conj_many_into(
+                                    comm,
+                                    pairs.as_slice(),
+                                    hvals.as_mut_slice(),
+                                );
+                            }
+                            {
+                                let tmp1 = &mut ws.tmp1[..n];
+                                for (i, hij) in hvals.iter().copied().enumerate() {
+                                    let vi = &ws.v_mem[i * n..(i + 1) * n];
                                     for (w, &vi_j) in tmp1.iter_mut().zip(vi) {
                                         *w -= hij * vi_j;
                                     }
@@ -364,7 +396,7 @@ impl GmresSolver {
                             for i in 0..=k {
                                 *ws.h_at_mut(i, k) = hvals[i];
                             }
-                            let hnext = nrm2(&ws.tmp1[..n]);
+                            let hnext = global_nrm2(comm, &ws.tmp1[..n]);
                             *ws.h_at_mut(k + 1, k) = S::from_real(hnext);
                             if hnext > 0.0 {
                                 let inv = S::from_real(1.0 / hnext);
@@ -486,9 +518,9 @@ impl GmresSolver {
                     } else {
                         ws.tmp2[..n].copy_from_slice(&ws.tmp1[..n]);
                     }
-                    nrm2(&ws.tmp2[..n])
+                    global_nrm2(comm, &ws.tmp2[..n])
                 }
-                PcSide::Right => nrm2(&ws.tmp1[..n]),
+                PcSide::Right => global_nrm2(comm, &ws.tmp1[..n]),
                 PcSide::Symmetric => unreachable!(),
             };
 
@@ -512,7 +544,7 @@ impl GmresSolver {
                     } else {
                         ws.tmp2[..n].copy_from_slice(&ws.tmp1[..n]);
                     }
-                    let beta = nrm2(&ws.tmp2[..n]);
+                    let beta = global_nrm2(comm, &ws.tmp2[..n]);
                     if beta > 0.0 {
                         let inv = S::from_real(1.0 / beta);
                         for val in &mut ws.tmp2[..n] {
@@ -525,7 +557,7 @@ impl GmresSolver {
                     beta
                 }
                 PcSide::Right => {
-                    let beta = nrm2(&ws.tmp1[..n]);
+                    let beta = global_nrm2(comm, &ws.tmp1[..n]);
                     if beta > 0.0 {
                         let inv = S::from_real(1.0 / beta);
                         for (dst, &src) in ws.tmp2[..n].iter_mut().zip(&ws.tmp1[..n]) {

--- a/src/solver/idrs.rs
+++ b/src/solver/idrs.rs
@@ -1,4 +1,3 @@
-use crate::algebra::blas::dot_conj;
 use crate::algebra::bridge::BridgeScratch;
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
@@ -7,7 +6,10 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::{Comm, UniverseComm};
+use crate::parallel::{
+    UniverseComm, allreduce_sum_scalar_with_mode, global_dot_conj, global_dot_conj_many_into,
+    global_nrm2, global_reduction_mode,
+};
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::utils::convergence::{ConvergedReason, SolveStats, SolverCounters};
@@ -16,48 +18,16 @@ use rand::rngs::StdRng;
 use rand_distr::{Distribution, StandardNormal};
 use std::cmp::min;
 
-#[cfg(feature = "complex")]
-use num_complex::Complex64;
-
-fn reduce_real<C: Comm>(comm: &C, value: R) -> R {
-    if comm.size() == 1 {
-        value
-    } else {
-        comm.allreduce_sum(value)
-    }
+fn reduce_real(comm: &UniverseComm, value: R) -> R {
+    allreduce_sum_scalar_with_mode(comm, S::from_real(value), global_reduction_mode()).real()
 }
 
-fn reduce_scalar<C: Comm>(comm: &C, value: S) -> S {
-    #[cfg(feature = "complex")]
-    {
-        if comm.size() == 1 {
-            value
-        } else {
-            let (real, imag) = comm.allreduce_sum2(value.re, value.im);
-            Complex64::new(real, imag)
-        }
-    }
-    #[cfg(not(feature = "complex"))]
-    {
-        if comm.size() == 1 {
-            value
-        } else {
-            comm.allreduce_sum(value)
-        }
-    }
+fn dot_reduce(comm: &UniverseComm, a: &[S], b: &[S]) -> S {
+    global_dot_conj(comm, a, b)
 }
 
-fn dot_reduce<C: Comm>(comm: &C, a: &[S], b: &[S]) -> S {
-    let local = dot_conj(a, b);
-    reduce_scalar(comm, local)
-}
-
-fn norm2<C: Comm>(x: &[S], comm: &C) -> R {
-    let local = x.iter().fold(0.0, |acc, &val| {
-        let mag = val.abs();
-        acc + mag * mag
-    });
-    reduce_real(comm, local).sqrt()
+fn norm2(x: &[S], comm: &UniverseComm) -> R {
+    global_nrm2(comm, x)
 }
 
 #[derive(Clone, Debug)]
@@ -582,9 +552,11 @@ impl IdrsSolver {
     }
 
     fn omega_value(&self, comm: &UniverseComm, stats: &mut IdrsStats, t: &[S], v: &[S]) -> S {
-        let tv = dot_reduce(comm, t, v);
-        let tt = dot_reduce(comm, t, t);
-        stats.dots += 2;
+        let mut reductions = [S::zero(); 2];
+        global_dot_conj_many_into(comm, &[(t, v), (t, t)], &mut reductions);
+        stats.dots += reductions.len();
+        let tv = reductions[0];
+        let tt = reductions[1];
         let tt_real = tt.real();
         let mut omega = if tt_real.abs() <= f64::EPSILON {
             S::zero()
@@ -716,9 +688,15 @@ impl IdrsSolver {
                 &mut self.ws.scratch,
                 &mut stats,
             )?;
-            let vr = dot_reduce(comm, &self.ws.v[..n], &self.ws.r[..n]);
-            let vv = dot_reduce(comm, &self.ws.v[..n], &self.ws.v[..n]);
-            stats.dots += 2;
+            let mut reductions = [S::zero(); 2];
+            let dot_pairs = [
+                (&self.ws.v[..n], &self.ws.r[..n]),
+                (&self.ws.v[..n], &self.ws.v[..n]),
+            ];
+            global_dot_conj_many_into(comm, &dot_pairs, &mut reductions);
+            stats.dots += reductions.len();
+            let vr = reductions[0];
+            let vv = reductions[1];
             if vv.abs() <= f64::EPSILON {
                 return Err(KError::BreakdownOrIndefinite);
             }

--- a/src/solver/minres.rs
+++ b/src/solver/minres.rs
@@ -10,21 +10,12 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::{Comm, UniverseComm};
+use crate::parallel::{Comm, UniverseComm, global_dot_conj_many_into, global_nrm2_many_into};
 use crate::preconditioner::{self, PcSide, Preconditioner as PreconditionerF64};
 use crate::solver::LinearSolver;
-use crate::solver::common::recompute_true_residual_norm_s;
+use crate::solver::common::{dot_result_to_real, recompute_true_residual_norm_s};
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 use std::any::Any;
-
-fn dot<C: Comm>(x: &[S], y: &[S], comm: &C) -> S {
-    comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, y))
-}
-
-fn norm2<C: Comm>(x: &[S], comm: &C) -> R {
-    let global = comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, x));
-    global.real().sqrt()
-}
 
 struct MinresWorkspace<'a> {
     v_prev: &'a mut [S],
@@ -159,13 +150,16 @@ impl MinresSolver {
             tmp2.copy_from_slice(tmp1);
         }
 
-        let mut res = norm2(tmp2, comm);
+        let mut batched_norms = [0.0; 2];
+        let tmp2_view: &[S] = &tmp2[..n];
+        global_nrm2_many_into(comm, &[tmp2_view, b], &mut batched_norms);
+        let mut res = batched_norms[0];
         let res0 = res;
         for m in monitors {
             m(0, res);
         }
 
-        let bnorm = norm2(b, comm).max(1e-32);
+        let bnorm = batched_norms[1].max(1e-32);
         let thr = self.conv.atol.max(self.conv.rtol * bnorm);
         if res <= thr {
             let reason = if res <= self.conv.atol {
@@ -192,6 +186,8 @@ impl MinresSolver {
         let mut final_reason = ConvergedReason::Continued;
         let mut iters = 0usize;
 
+        let mut dot_results = [S::zero(); 3];
+
         for k in 1..=self.conv.max_iters {
             iters = k;
 
@@ -202,16 +198,62 @@ impl MinresSolver {
                 tmp2.copy_from_slice(tmp1);
             }
 
-            let alpha = dot(v_k, tmp2, comm).real();
+            let (alpha, prev_projection, tmp2_norm_sq) = {
+                let v_k_view: &[S] = &v_k[..n];
+                let v_prev_view: &[S] = &v_prev[..n];
+                let tmp2_view: &[S] = &tmp2[..n];
+
+                let mut pairs: [(&[S], &[S]); 3] = [(&[], &[]); 3];
+                let mut used = 0usize;
+                pairs[used] = (v_k_view, tmp2_view);
+                used += 1;
+                if k > 1 {
+                    pairs[used] = (v_prev_view, tmp2_view);
+                    used += 1;
+                }
+                pairs[used] = (tmp2_view, tmp2_view);
+                used += 1;
+
+                global_dot_conj_many_into(comm, &pairs[..used], &mut dot_results[..used]);
+
+                let alpha = dot_result_to_real(dot_results[0]);
+                let prev_proj = if k > 1 {
+                    dot_result_to_real(dot_results[1])
+                } else {
+                    0.0
+                };
+                let tmp2_norm_sq = dot_result_to_real(dot_results[used - 1]);
+                (alpha, prev_proj, tmp2_norm_sq)
+            };
+
             let alpha_s = S::from_real(alpha);
             let beta_s = S::from_real(beta);
             for i in 0..n {
                 v_next[i] = tmp2[i] - alpha_s * v_k[i] - beta_s * v_prev[i];
             }
-            let beta_next = norm2(v_next, comm);
+
+            let mut beta_next_sq = tmp2_norm_sq - alpha * alpha;
+            if k > 1 {
+                beta_next_sq =
+                    tmp2_norm_sq + beta * beta - alpha * alpha - 2.0 * beta * prev_projection;
+            }
+            if beta_next_sq < 0.0 {
+                beta_next_sq = 0.0;
+            }
+            if comm.size() <= 1 {
+                let mut local_sq = 0.0;
+                for &val in &v_next[..n] {
+                    let mag = val.abs();
+                    local_sq += mag * mag;
+                }
+                beta_next_sq = local_sq;
+            }
+            let mut beta_next = beta_next_sq.sqrt();
+            if beta_next <= 1e-30 {
+                beta_next = 0.0;
+            }
             if beta_next == 0.0 {
                 final_reason = ConvergedReason::ConvergedAtol;
-                beta = beta_next;
                 break;
             }
             if beta_next != 0.0 {

--- a/src/solver/pca_gmres.rs
+++ b/src/solver/pca_gmres.rs
@@ -1,7 +1,6 @@
 //! PCA-GMRES (baseline) over &dyn LinOp<f64> with left/right/no preconditioning,
 //! using disjoint slabs for V and Z, with semantics enforced by `pc_mode`.
 
-use crate::algebra::blas::{dot_conj, nrm2};
 use crate::algebra::bridge::BridgeScratch;
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
@@ -13,11 +12,14 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::UniverseComm;
+use crate::parallel::{
+    UniverseComm, global_dot_conj_many_into, global_nrm2, global_nrm2_many_into,
+};
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::solver::common::givens::{apply_new_givens_and_update_g, apply_prev_givens_to_col};
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
+use smallvec::SmallVec;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum PcaPcMode {
@@ -152,29 +154,54 @@ impl PcaGmresSolver {
         k: usize,
         w: &mut [S],
         hcols: &mut [Vec<S>],
+        comm: &UniverseComm,
     ) -> R {
         let hcol = &mut hcols[k];
         // First pass
-        for i in 0..=k {
-            let hij: S = dot_conj(&v_basis[i], w);
-            hcol[i] = hij;
-            for (wi, &vi) in w.iter_mut().zip(&v_basis[i]) {
-                *wi -= hij * vi;
+        let mut first_pass: SmallVec<[S; 32]> = SmallVec::with_capacity(k + 1);
+        first_pass.resize(k + 1, S::zero());
+        {
+            let mut pairs: SmallVec<[(&[S], &[S]); 32]> = SmallVec::with_capacity(k + 1);
+            let w_view: &[S] = &w[..];
+            for i in 0..=k {
+                pairs.push((&v_basis[i], w_view));
+            }
+            global_dot_conj_many_into(comm, pairs.as_slice(), first_pass.as_mut_slice());
+        }
+        {
+            let w_mut = &mut w[..];
+            for (i, hij) in first_pass.iter().copied().enumerate() {
+                hcol[i] = hij;
+                for (wi, &vi) in w_mut.iter_mut().zip(&v_basis[i]) {
+                    *wi -= hij * vi;
+                }
             }
         }
         if self.modified_gs {
             // Re-orthogonalize for robustness
-            for i in 0..=k {
-                let corr: S = dot_conj(&v_basis[i], w);
-                if corr.abs() > 1e-12 {
-                    hcol[i] += corr;
-                    for (wi, &vi) in w.iter_mut().zip(&v_basis[i]) {
-                        *wi -= corr * vi;
+            let mut corr: SmallVec<[S; 32]> = SmallVec::with_capacity(k + 1);
+            corr.resize(k + 1, S::zero());
+            {
+                let mut pairs: SmallVec<[(&[S], &[S]); 32]> = SmallVec::with_capacity(k + 1);
+                let w_view: &[S] = &w[..];
+                for i in 0..=k {
+                    pairs.push((&v_basis[i], w_view));
+                }
+                global_dot_conj_many_into(comm, pairs.as_slice(), corr.as_mut_slice());
+            }
+            {
+                let w_mut = &mut w[..];
+                for (i, corr_val) in corr.into_iter().enumerate() {
+                    if corr_val.abs() > 1e-12 {
+                        hcol[i] += corr_val;
+                        for (wi, &vi) in w_mut.iter_mut().zip(&v_basis[i]) {
+                            *wi -= corr_val * vi;
+                        }
                     }
                 }
             }
         }
-        let hnorm = nrm2(w);
+        let hnorm = global_nrm2(comm, w);
         if hcol.len() > k + 1 {
             hcol[k + 1] = S::from_real(hnorm);
             for val in hcol.iter_mut().skip(k + 2) {
@@ -285,9 +312,11 @@ impl PcaGmresSolver {
             ws.tmp1[i] = b[i] - ws.tmp1[i];
         }
 
-        let beta0: R = match mode {
+        let (beta0, mut bnorm) = match mode {
             PcaPcMode::None => {
-                let beta = nrm2(&ws.tmp1);
+                let mut norms = [R::zero(); 2];
+                global_nrm2_many_into(comm, &[&ws.tmp1, b], &mut norms);
+                let beta = norms[0];
                 let v0 = &mut ws.q_s[0][..];
                 if beta > 0.0 {
                     let denom = S::from_real(beta);
@@ -297,11 +326,13 @@ impl PcaGmresSolver {
                 } else {
                     v0.fill(S::zero());
                 }
-                beta
+                (beta, norms[1])
             }
             PcaPcMode::Left => {
                 Self::apply_pc(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2, &mut ws.bridge)?;
-                let beta = nrm2(&ws.tmp2);
+                let mut norms = [R::zero(); 2];
+                global_nrm2_many_into(comm, &[&ws.tmp2, b], &mut norms);
+                let beta = norms[0];
                 let v0 = &mut ws.q_s[0][..];
                 if beta > 0.0 {
                     let denom = S::from_real(beta);
@@ -311,10 +342,12 @@ impl PcaGmresSolver {
                 } else {
                     v0.fill(S::zero());
                 }
-                beta
+                (beta, norms[1])
             }
             PcaPcMode::Right => {
-                let beta = nrm2(&ws.tmp1);
+                let mut norms = [R::zero(); 2];
+                global_nrm2_many_into(comm, &[&ws.tmp1, b], &mut norms);
+                let beta = norms[0];
                 let v0 = &mut ws.q_s[0][..];
                 if beta > 0.0 {
                     let denom = S::from_real(beta);
@@ -324,7 +357,7 @@ impl PcaGmresSolver {
                 } else {
                     v0.fill(S::zero());
                 }
-                beta
+                (beta, norms[1])
             }
         };
 
@@ -334,7 +367,7 @@ impl PcaGmresSolver {
         ws.g.fill(S::zero());
         ws.g[0] = S::from_real(beta0);
 
-        let bnorm = nrm2(b).max(1e-32);
+        bnorm = bnorm.max(1e-32);
         let thr = self.conv.atol.max(self.conv.rtol * bnorm);
 
         let mut total_iters = 0usize;
@@ -354,8 +387,6 @@ impl PcaGmresSolver {
             };
             return Ok(stats);
         }
-
-        let _ = comm;
 
         'outer: while total_iters < self.conv.max_iters {
             let max_k = self.restart.min(self.conv.max_iters - total_iters);
@@ -378,7 +409,7 @@ impl PcaGmresSolver {
                     }
                 }
 
-                let hnorm = self.project_and_normalize(&ws.q_s, k, &mut ws.tmp1, &mut ws.h_s);
+                let hnorm = self.project_and_normalize(&ws.q_s, k, &mut ws.tmp1, &mut ws.h_s, comm);
 
                 let vnext = &mut ws.q_s[k + 1][..];
                 if hnorm > 0.0 {
@@ -455,7 +486,7 @@ impl PcaGmresSolver {
             }
             let beta0_new: R = match mode {
                 PcaPcMode::None => {
-                    let beta = nrm2(&ws.tmp1);
+                    let beta = global_nrm2(comm, &ws.tmp1);
                     let v0 = &mut ws.q_s[0][..];
                     if beta > 0.0 {
                         let denom = S::from_real(beta);
@@ -469,7 +500,7 @@ impl PcaGmresSolver {
                 }
                 PcaPcMode::Left => {
                     Self::apply_pc(pc, PcSide::Left, &ws.tmp1, &mut ws.tmp2, &mut ws.bridge)?;
-                    let beta = nrm2(&ws.tmp2);
+                    let beta = global_nrm2(comm, &ws.tmp2);
                     let v0 = &mut ws.q_s[0][..];
                     if beta > 0.0 {
                         let denom = S::from_real(beta);
@@ -482,7 +513,7 @@ impl PcaGmresSolver {
                     beta
                 }
                 PcaPcMode::Right => {
-                    let beta = nrm2(&ws.tmp1);
+                    let beta = global_nrm2(comm, &ws.tmp1);
                     let v0 = &mut ws.q_s[0][..];
                     if beta > 0.0 {
                         let denom = S::from_real(beta);
@@ -520,7 +551,7 @@ impl PcaGmresSolver {
         for i in 0..n {
             ws.tmp1[i] = b[i] - ws.tmp1[i];
         }
-        let true_res: R = nrm2(&ws.tmp1);
+        let true_res: R = global_nrm2(comm, &ws.tmp1);
         let (_r, mut s) = self.conv.check(true_res, bnorm, total_iters);
         s.iterations = total_iters;
         s.final_residual = true_res;
@@ -596,6 +627,7 @@ mod tests {
     use super::*;
     use crate::algebra::blas::{dot_conj, nrm2};
     use crate::context::ksp_context::Workspace;
+    use crate::parallel::NoComm;
 
     #[test]
     fn arnoldi_project_and_normalize_orthonormalizes_vector() {
@@ -611,7 +643,8 @@ mod tests {
         let mut w = vec![S::zero(); n];
         w[1] = S::one();
 
-        let hnorm = solver.project_and_normalize(&ws.q_s, 0, &mut w, &mut ws.h_s);
+        let comm = UniverseComm::NoComm(NoComm);
+        let hnorm = solver.project_and_normalize(&ws.q_s, 0, &mut w, &mut ws.h_s, &comm);
 
         assert!((hnorm - 1.0).abs() < 1e-12);
         assert!((nrm2(&w) - 1.0).abs() < 1e-12);

--- a/src/solver/pcg.rs
+++ b/src/solver/pcg.rs
@@ -8,11 +8,14 @@ use crate::matrix::op_bridge::matvec_s;
 use crate::parallel::{Comm, UniverseComm};
 use crate::preconditioner::bridge::apply_pc_s;
 use crate::preconditioner::{PcSide, Preconditioner};
+#[cfg(feature = "complex")]
+use crate::reduction::Packet;
 use crate::reduction::{CommDeterministic, DotEngine, ReductionOptions, ReproMode};
 use crate::solver::LinearSolver;
 use crate::solver::common::{dot1_async_s, nrm2_async_s};
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats, SolverCounters};
 use crate::utils::reduction::{AllreduceHandle, AllreduceOps, ReductMode, ReductOptions};
+use smallvec::SmallVec;
 use std::any::Any;
 
 #[derive(Debug, Clone, Copy)]
@@ -168,9 +171,8 @@ impl PcgSolver {
         let mut opt = self.async_reduction.clone();
         opt.mode = match self.reduction.mode {
             ReproMode::Fast => ReductMode::Fast,
-            ReproMode::Deterministic | ReproMode::DeterministicAccurate => {
-                ReductMode::Deterministic
-            }
+            ReproMode::Deterministic => ReductMode::Deterministic,
+            ReproMode::DeterministicAccurate => ReductMode::DeterministicAccurate,
         };
         opt
     }
@@ -223,8 +225,60 @@ impl PcgSolver {
 
         #[cfg(feature = "complex")]
         {
-            let global = comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(u, v));
-            global.real()
+            let local = crate::algebra::blas::dot_conj(u, v);
+            if matches!(self.reduction.mode, ReproMode::Fast) {
+                return comm.allreduce_sum_scalar(local).real();
+            }
+
+            let packet = Packet::<2> {
+                v: [local.real(), local.imag()],
+            };
+            let reduced = comm.allreduce_det(&packet, self.reduction.mode);
+            reduced.v[0]
+        }
+    }
+
+    #[inline]
+    fn dot_scalar_many<C: Comm + CommDeterministic>(
+        &self,
+        pairs: &[(&[S], &[S])],
+        comm: &C,
+        out: &mut [R],
+    ) {
+        assert_eq!(pairs.len(), out.len());
+        if pairs.is_empty() {
+            return;
+        }
+
+        #[cfg(not(feature = "complex"))]
+        {
+            let engine = DotEngine {
+                opts: self.reduction,
+            };
+            let mut real_pairs: SmallVec<[(&[f64], &[f64]); 8]> =
+                SmallVec::with_capacity(pairs.len());
+            for &(u, v) in pairs {
+                let ur: &[f64] = unsafe { &*(u as *const [S] as *const [f64]) };
+                let vr: &[f64] = unsafe { &*(v as *const [S] as *const [f64]) };
+                real_pairs.push((ur, vr));
+            }
+            engine.dot_many_into(real_pairs.as_slice(), out, comm);
+        }
+
+        #[cfg(feature = "complex")]
+        {
+            for ((u, v), slot) in pairs.iter().zip(out.iter_mut()) {
+                let local = crate::algebra::blas::dot_conj(u, v);
+                if matches!(self.reduction.mode, ReproMode::Fast) {
+                    *slot = comm.allreduce_sum_scalar(local).real();
+                } else {
+                    let packet = Packet::<2> {
+                        v: [local.real(), local.imag()],
+                    };
+                    let reduced = comm.allreduce_det(&packet, self.reduction.mode);
+                    *slot = reduced.v[0];
+                }
+            }
         }
     }
 
@@ -232,6 +286,22 @@ impl PcgSolver {
     fn nrm2_scalar<C: Comm + CommDeterministic>(&self, u: &[S], comm: &C) -> R {
         let val = self.dot_scalar(u, u, comm);
         val.abs().sqrt()
+    }
+
+    #[inline]
+    fn ensure_norm<C: Comm + CommDeterministic>(
+        &self,
+        vec: &[S],
+        comm: &C,
+        cache: &mut Option<R>,
+    ) -> R {
+        if let Some(val) = *cache {
+            val
+        } else {
+            let val = self.nrm2_scalar(vec, comm);
+            *cache = Some(val);
+            val
+        }
     }
 
     #[allow(clippy::too_many_arguments)]
@@ -272,17 +342,55 @@ impl PcgSolver {
             z.copy_from_slice(r);
         }
 
-        let mut rho = self.dot_scalar(r, z, comm);
+        let need_r_norm_res = matches!(
+            self.norm_type,
+            CgNormType::Unpreconditioned | CgNormType::None
+        );
+        let need_z_norm_res = matches!(self.norm_type, CgNormType::Natural);
+        let need_r_norm_monitor = self.true_residual_monitor.is_some();
+
+        let mut initial_pairs: SmallVec<[(&[S], &[S]); 3]> = SmallVec::new();
+        initial_pairs.push((&r[..], &z[..]));
+        if need_r_norm_res || need_r_norm_monitor {
+            initial_pairs.push((&r[..], &r[..]));
+        }
+        if need_z_norm_res {
+            initial_pairs.push((&z[..], &z[..]));
+        }
+        let mut reductions: SmallVec<[R; 3]> = SmallVec::new();
+        reductions.resize(initial_pairs.len(), R::zero());
+        self.dot_scalar_many(initial_pairs.as_slice(), comm, reductions.as_mut_slice());
+
+        let mut idx = 0;
+        let mut rho = reductions[idx];
+        idx += 1;
         if rho <= 0.0 || !rho.is_finite() {
             return Err(KError::IndefinitePreconditioner);
         }
+
+        let mut cached_r_norm = if need_r_norm_res || need_r_norm_monitor {
+            let value = reductions[idx];
+            idx += 1;
+            Some(if value < 0.0 { 0.0 } else { value }.sqrt())
+        } else {
+            None
+        };
+        let cached_z_norm = if need_z_norm_res {
+            let value = reductions[idx];
+            Some(if value < 0.0 { 0.0 } else { value }.sqrt())
+        } else {
+            None
+        };
         let mut rho_prev = rho;
+
+        drop(initial_pairs);
+        drop(reductions);
 
         let mut res = match self.norm_type {
             CgNormType::Preconditioned => rho.abs().sqrt(),
-            CgNormType::Unpreconditioned => self.nrm2_scalar(r, comm),
-            CgNormType::Natural => self.nrm2_scalar(z, comm),
-            CgNormType::None => self.nrm2_scalar(r, comm),
+            CgNormType::Unpreconditioned => cached_r_norm.unwrap(),
+            CgNormType::Natural => cached_z_norm.unwrap(),
+            CgNormType::None => cached_r_norm.unwrap(),
         };
         let res0 = res;
 
@@ -290,14 +398,15 @@ impl PcgSolver {
             m(0, res);
         }
         if let Some(m) = &self.true_residual_monitor {
-            m(0, self.nrm2_scalar(r, comm));
+            let value = self.ensure_norm(r, comm, &mut cached_r_norm);
+            m(0, value);
         }
 
         p.copy_from_slice(z);
 
         let (reason0, mut stats0) = self.conv.check(res, res0, 0);
         if !matches!(reason0, ConvergedReason::Continued) {
-            stats0.final_residual = self.nrm2_scalar(r, comm);
+            stats0.final_residual = self.ensure_norm(r, comm, &mut cached_r_norm);
             return Ok(stats0);
         }
 
@@ -329,7 +438,28 @@ impl PcgSolver {
                 z.copy_from_slice(r);
             }
 
-            let mut rho_new = self.dot_scalar(r, z, comm);
+            let need_r_norm_res = matches!(
+                self.norm_type,
+                CgNormType::Unpreconditioned | CgNormType::None
+            );
+            let need_z_norm_res = matches!(self.norm_type, CgNormType::Natural);
+            let need_r_norm_monitor = self.true_residual_monitor.is_some();
+
+            let mut dot_pairs: SmallVec<[(&[S], &[S]); 3]> = SmallVec::new();
+            dot_pairs.push((&r[..], &z[..]));
+            if need_r_norm_res || need_r_norm_monitor {
+                dot_pairs.push((&r[..], &r[..]));
+            }
+            if need_z_norm_res {
+                dot_pairs.push((&z[..], &z[..]));
+            }
+            let mut dot_results: SmallVec<[R; 3]> = SmallVec::new();
+            dot_results.resize(dot_pairs.len(), R::zero());
+            self.dot_scalar_many(dot_pairs.as_slice(), comm, dot_results.as_mut_slice());
+
+            let mut idx = 0;
+            let mut rho_new = dot_results[idx];
+            idx += 1;
             if !rho_new.is_finite() || rho_new < 0.0 {
                 return Err(KError::IndefinitePreconditioner);
             }
@@ -337,39 +467,65 @@ impl PcgSolver {
                 rho_new = 0.0;
             }
 
-            res = match self.norm_type {
-                CgNormType::Preconditioned => rho_new.abs().sqrt(),
-                CgNormType::Unpreconditioned => self.nrm2_scalar(r, comm),
-                CgNormType::Natural => self.nrm2_scalar(z, comm),
-                CgNormType::None => res,
+            let mut r_norm = if need_r_norm_res || need_r_norm_monitor {
+                let value = dot_results[idx];
+                idx += 1;
+                Some(if value < 0.0 { 0.0 } else { value }.sqrt())
+            } else {
+                None
             };
+            let mut z_norm = if need_z_norm_res {
+                let value = dot_results[idx];
+                Some(if value < 0.0 { 0.0 } else { value }.sqrt())
+            } else {
+                None
+            };
+
+            drop(dot_pairs);
+            drop(dot_results);
+
+            match self.norm_type {
+                CgNormType::Preconditioned => {
+                    res = rho_new.abs().sqrt();
+                }
+                CgNormType::Unpreconditioned => {
+                    res = r_norm.unwrap();
+                }
+                CgNormType::Natural => {
+                    res = z_norm.unwrap();
+                }
+                CgNormType::None => {}
+            }
 
             for m in monitors {
                 m(k, res);
             }
             if let Some(m) = &self.true_residual_monitor {
-                m(k, self.nrm2_scalar(r, comm));
+                let value = self.ensure_norm(r, comm, &mut r_norm);
+                m(k, value);
             }
 
             let res_check = match self.norm_type {
                 CgNormType::Preconditioned => rho_new.abs().sqrt(),
-                CgNormType::Unpreconditioned => self.nrm2_scalar(r, comm),
-                CgNormType::Natural => self.nrm2_scalar(z, comm),
-                CgNormType::None => self.nrm2_scalar(r, comm),
+                CgNormType::Unpreconditioned => self.ensure_norm(r, comm, &mut r_norm),
+                CgNormType::Natural => self.ensure_norm(z, comm, &mut z_norm),
+                CgNormType::None => self.ensure_norm(r, comm, &mut r_norm),
             };
             let (reason, mut stats) = self.conv.check(res_check, res0, k);
             if !matches!(reason, ConvergedReason::Continued) {
-                stats.final_residual = self.nrm2_scalar(r, comm);
+                stats.final_residual = self.ensure_norm(r, comm, &mut r_norm);
                 return Ok(stats);
             }
 
             rho_prev = rho;
             rho = rho_new;
+            cached_r_norm = r_norm;
         }
 
+        let final_res = self.ensure_norm(r, comm, &mut cached_r_norm);
         Ok(SolveStats::new(
             self.conv.max_iters,
-            self.nrm2_scalar(r, comm),
+            final_res,
             ConvergedReason::DivergedMaxIts,
         ))
     }

--- a/src/solver/qmr.rs
+++ b/src/solver/qmr.rs
@@ -11,10 +11,12 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::{Comm, UniverseComm};
+use crate::parallel::{
+    UniverseComm, global_dot_conj, global_dot_conj_many_into, global_nrm2, global_nrm2_many_into,
+};
 use crate::preconditioner::{PcSide, Preconditioner, Preconditioner as PreconditionerF64};
 use crate::solver::LinearSolver;
-use crate::solver::common::{recompute_true_residual_norm_s, take_or_resize};
+use crate::solver::common::{dot_result_to_real, recompute_true_residual_norm_s, take_or_resize};
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 use std::any::Any;
 
@@ -108,8 +110,11 @@ impl QmrSolver {
         }
         r_tld.copy_from_slice(r);
 
-        let mut res = norm2(r, comm);
-        let bnorm = norm2(b, comm).max(1e-32);
+        let mut norms = [0.0; 2];
+        let r_view: &[S] = &r[..];
+        global_nrm2_many_into(comm, &[r_view, b], &mut norms);
+        let mut res = norms[0];
+        let bnorm = norms[1].max(1e-32);
 
         for m in monitors {
             m(0, res);
@@ -164,11 +169,15 @@ impl QmrSolver {
             }
             a.matvec_s(s, t, scratch);
 
-            let tt = dot(t, t, comm).real();
+            let mut reductions = [S::zero(); 2];
+            let t_view: &[S] = &t[..];
+            let s_view: &[S] = &s[..];
+            global_dot_conj_many_into(comm, &[(t_view, t_view), (t_view, s_view)], &mut reductions);
+            let tt = dot_result_to_real(reductions[0]);
             if tt <= eps || !tt.is_finite() {
                 return Err(KError::IndefiniteMatrix);
             }
-            let ts = dot(t, s, comm);
+            let ts = reductions[1];
             let omega = ts / S::from_real(tt);
 
             for i in 0..ncols {
@@ -311,13 +320,12 @@ impl LinearSolver for QmrSolver {
     }
 }
 
-fn dot<C: Comm>(x: &[S], y: &[S], comm: &C) -> S {
-    comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, y))
+fn dot(x: &[S], y: &[S], comm: &UniverseComm) -> S {
+    global_dot_conj(comm, x, y)
 }
 
-fn norm2<C: Comm>(x: &[S], comm: &C) -> R {
-    let global = comm.allreduce_sum_scalar(crate::algebra::blas::dot_conj(x, x));
-    global.real().sqrt()
+fn norm2(x: &[S], comm: &UniverseComm) -> R {
+    global_nrm2(comm, x)
 }
 
 struct QmrWorkspace<'a> {

--- a/src/solver/tfqmr.rs
+++ b/src/solver/tfqmr.rs
@@ -2,7 +2,6 @@
 //!
 //! Accepts [`PcSide::Left`] or [`PcSide::Right`]; residuals are reported as the true `||r||`.
 
-use crate::algebra::blas::{dot_conj, nrm2};
 use crate::algebra::bridge::BridgeScratch;
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
@@ -12,10 +11,10 @@ use crate::matrix::op::{LinOp, LinOpF64};
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc};
-use crate::parallel::UniverseComm;
+use crate::parallel::{UniverseComm, global_dot_conj, global_dot_conj_many_into, global_nrm2};
 use crate::preconditioner::{PcSide, Preconditioner, Preconditioner as PreconditionerF64};
 use crate::solver::LinearSolver;
-use crate::solver::common::take_or_resize;
+use crate::solver::common::{dot_result_to_real, take_or_resize};
 use crate::utils::convergence::{ConvergedReason, Convergence, SolveStats};
 use std::any::Any;
 
@@ -46,7 +45,7 @@ impl TfqmrSolver {
         b: &[S],
         x: &mut [S],
         mut pc_side: PcSide,
-        _comm: &UniverseComm,
+        comm: &UniverseComm,
         monitors: Option<&[Box<dyn Fn(usize, R) + Send + Sync>]>,
         work: Option<&mut Workspace>,
     ) -> Result<SolveStats<R>, KError>
@@ -103,8 +102,15 @@ impl TfqmrSolver {
 
         r_tld.copy_from_slice(r);
 
-        let mut rho: S = dot_conj(r_tld, r);
-        let res0: R = nrm2(r);
+        let mut reductions = [S::zero(); 2];
+        let initial_pairs = [(&r_tld[..], &r[..]), (&r[..], &r[..])];
+        global_dot_conj_many_into(comm, &initial_pairs, &mut reductions);
+        let mut rho: S = reductions[0];
+        let mut res_sq: R = dot_result_to_real(reductions[1]);
+        if res_sq < 0.0 {
+            res_sq = 0.0;
+        }
+        let res0: R = res_sq.sqrt();
         let mut stats = SolveStats::new(0, res0, ConvergedReason::Continued);
         for m in monitors {
             m(0, res0);
@@ -138,7 +144,7 @@ impl TfqmrSolver {
                 pc.apply_s(pc_side, tmp_pc, v, scratch)?;
             }
 
-            let sigma: S = dot_conj(r_tld, v);
+            let sigma: S = global_dot_conj(comm, r_tld, v);
             if !sigma.is_finite() || sigma.abs() < self.breakdown_eps {
                 stats.iterations = k;
                 stats.final_residual = true_res;
@@ -156,7 +162,8 @@ impl TfqmrSolver {
             for i in 0..n {
                 u[i] = r[i] - alpha * v[i];
             }
-            let mut tau_local: R = (nrm2(u) * dpold).sqrt();
+            let u_norm = global_nrm2(comm, u);
+            let mut tau_local: R = (u_norm * dpold).sqrt();
 
             for mstep in 0..2 {
                 if mstep == 0 {
@@ -178,7 +185,12 @@ impl TfqmrSolver {
                 }
 
                 let src: &[S] = if mstep == 0 { &u[..] } else { &qv[..] };
-                let psi: R = nrm2(src) / tau_local.max(1e-300);
+                let src_norm = if mstep == 0 {
+                    u_norm
+                } else {
+                    global_nrm2(comm, src)
+                };
+                let psi: R = src_norm / tau_local.max(1e-300);
                 let c: R = 1.0 / (1.0 + psi * psi).sqrt();
                 let eta: S = S::from_real(c * c) * alpha;
                 let cf: S = if k == 1 && mstep == 0 {
@@ -217,7 +229,7 @@ impl TfqmrSolver {
                         tmp_pc.copy_from_slice(&au[..]);
                         pc.apply_s(pc_side, tmp_pc, au, scratch)?;
                     }
-                    true_res = nrm2(au);
+                    true_res = global_nrm2(comm, au);
                     stats.final_residual = true_res;
                 } else {
                     stats.final_residual = dpest;
@@ -238,7 +250,9 @@ impl TfqmrSolver {
                 }
             }
 
-            let rho_new: S = dot_conj(r_tld, r);
+            let update_pairs = [(&r_tld[..], &r[..]), (&r[..], &r[..])];
+            global_dot_conj_many_into(comm, &update_pairs, &mut reductions);
+            let rho_new: S = reductions[0];
             if !rho_new.is_finite() || rho_new.abs() < self.breakdown_eps {
                 stats.iterations = k;
                 stats.reason = ConvergedReason::DivergedDtol;
@@ -253,7 +267,11 @@ impl TfqmrSolver {
                 yv[i] = r[i] + beta * (qv[i] + beta * yv[i]);
             }
 
-            dpold = nrm2(r);
+            let mut rr = dot_result_to_real(reductions[1]);
+            if rr < 0.0 {
+                rr = 0.0;
+            }
+            dpold = rr.sqrt();
 
             if self.resid_recalc_every == 1 {
                 a.matvec_s(x, au, scratch);
@@ -264,7 +282,7 @@ impl TfqmrSolver {
                     tmp_pc.copy_from_slice(&au[..]);
                     pc.apply_s(pc_side, tmp_pc, au, scratch)?;
                 }
-                true_res = nrm2(au);
+                true_res = global_nrm2(comm, au);
                 stats.final_residual = true_res;
                 let (reason, s2) = self.conv.check(true_res, res0, 2 * k);
                 stats = s2;

--- a/src/utils/reduction.rs
+++ b/src/utils/reduction.rs
@@ -3,6 +3,7 @@ use std::sync::mpsc::Receiver;
 
 use crate::error::KError;
 use crate::parallel::Comm;
+use crate::reduction::{CommDeterministic, Packet, ReproMode};
 #[cfg(feature = "mpi")]
 use mpi::raw::AsRaw;
 use once_cell::sync::Lazy;
@@ -80,8 +81,19 @@ pub mod test_hooks {
 pub enum ReductMode {
     /// Fast, implementation-defined reduction path.
     Fast,
-    /// Deterministic tree reductions (future extension).
+    /// Deterministic tree reductions.
     Deterministic,
+    /// Deterministic reductions with extended-precision accumulation.
+    DeterministicAccurate,
+}
+
+#[inline]
+fn repro_mode_from_reduct(mode: ReductMode) -> ReproMode {
+    match mode {
+        ReductMode::Fast => ReproMode::Fast,
+        ReductMode::Deterministic => ReproMode::Deterministic,
+        ReductMode::DeterministicAccurate => ReproMode::DeterministicAccurate,
+    }
 }
 
 /// Options that control asynchronous reductions.
@@ -210,6 +222,52 @@ fn finalize_handle_vec(handle: &mut AllreduceHandle<Vec<f64>>, result: Vec<f64>)
 fn convert_pair(buf: &[f64]) -> (f64, f64) {
     debug_assert_eq!(buf.len(), 2);
     (buf[0], buf[1])
+}
+
+fn deterministic_reduce_vec<C>(comm: &C, data: &[f64], mode: ReproMode) -> Vec<f64>
+where
+    C: Comm + CommDeterministic,
+{
+    if data.is_empty() {
+        return Vec::new();
+    }
+
+    let mut out = Vec::with_capacity(data.len());
+    let mut offset = 0;
+    while offset < data.len() {
+        let remaining = data.len() - offset;
+        let width = remaining.min(4);
+        match width {
+            4 => {
+                let mut chunk = [0.0f64; 4];
+                chunk.copy_from_slice(&data[offset..offset + 4]);
+                let packet = Packet::<4> { v: chunk };
+                let reduced = comm.allreduce_det(&packet, mode);
+                out.extend_from_slice(&reduced.v);
+            }
+            3 => {
+                let mut chunk = [0.0f64; 3];
+                chunk.copy_from_slice(&data[offset..offset + 3]);
+                let packet = Packet::<3> { v: chunk };
+                let reduced = comm.allreduce_det(&packet, mode);
+                out.extend_from_slice(&reduced.v);
+            }
+            2 => {
+                let mut chunk = [0.0f64; 2];
+                chunk.copy_from_slice(&data[offset..offset + 2]);
+                let packet = Packet::<2> { v: chunk };
+                let reduced = comm.allreduce_det(&packet, mode);
+                out.extend_from_slice(&reduced.v);
+            }
+            _ => {
+                let packet = Packet::<1> { v: [data[offset]] };
+                let reduced = comm.allreduce_det(&packet, mode);
+                out.push(reduced.v[0]);
+            }
+        }
+        offset += width;
+    }
+    out
 }
 
 #[cfg(feature = "mpi")]
@@ -352,8 +410,12 @@ impl AllreduceOps for crate::parallel::mpi_comm::MpiComm {
         b: f64,
         opt: &ReductOptions,
     ) -> Result<(AllreduceHandle<(f64, f64)>, (f64, f64)), KError> {
-        if matches!(opt.mode, ReductMode::Deterministic) {
-            return Err(KError::Unsupported("deterministic reductions"));
+        if let ReductMode::Deterministic | ReductMode::DeterministicAccurate = opt.mode {
+            record_reduction(2);
+            let packet = Packet::<2> { v: [a, b] };
+            let reduced = self.allreduce_det(&packet, repro_mode_from_reduct(opt.mode));
+            let result = (reduced.v[0], reduced.v[1]);
+            return Ok((AllreduceHandle::new_ready(result), (a, b)));
         }
         record_reduction(2);
         let mut buf = vec![a, b];
@@ -387,8 +449,10 @@ impl AllreduceOps for crate::parallel::mpi_comm::MpiComm {
         data: Vec<f64>,
         opt: &ReductOptions,
     ) -> Result<(AllreduceHandle<Vec<f64>>, Vec<f64>), KError> {
-        if matches!(opt.mode, ReductMode::Deterministic) {
-            return Err(KError::Unsupported("deterministic reductions"));
+        if let ReductMode::Deterministic | ReductMode::DeterministicAccurate = opt.mode {
+            record_reduction(data.len());
+            let reduced = deterministic_reduce_vec(self, &data, repro_mode_from_reduct(opt.mode));
+            return Ok((AllreduceHandle::new_ready(reduced), data));
         }
         record_reduction(data.len());
         let mut buf = data.clone();

--- a/tests/parallel_reductions.rs
+++ b/tests/parallel_reductions.rs
@@ -1,0 +1,513 @@
+#![cfg(feature = "mpi")]
+
+use kryst::algebra::blas::dot_conj;
+use kryst::algebra::prelude::*;
+use kryst::parallel::{
+    MpiComm, UniverseComm, allreduce_sum_scalar_mpi_sys, allreduce_sum_scalar_slice_in_place,
+    allreduce_sum_scalar_slice_owned, global_dot_conj, global_dot_conj_accurate,
+    global_dot_conj_many, global_dot_conj_many_accurate, global_dot_conj_many_into,
+    global_dot_conj_many_into_accurate, global_dot_conj_many_into_repro,
+    global_dot_conj_many_repro, global_dot_conj_repro, global_nrm2, global_nrm2_accurate,
+    global_nrm2_many, global_nrm2_many_accurate, global_nrm2_many_into,
+    global_nrm2_many_into_accurate, global_nrm2_many_into_repro, global_nrm2_many_repro,
+    global_nrm2_repro,
+};
+use kryst::utils::reduction::{AllreduceOps, ReductMode, ReductOptions};
+use std::sync::Arc;
+
+fn make_world() -> UniverseComm {
+    UniverseComm::Mpi(Arc::new(MpiComm::new()))
+}
+
+fn local_scalar(rank: usize) -> S {
+    let re = rank as f64 + 1.0;
+    let im = 0.5 * rank as f64;
+    S::from_parts(re, im)
+}
+
+fn local_vectors(rank: usize) -> ([S; 2], [S; 2]) {
+    let x0 = S::from_parts(rank as f64 + 0.25, 0.5 * rank as f64);
+    let x1 = S::from_parts(-0.75 + 0.1 * rank as f64, -0.25 * rank as f64);
+    let y0 = S::from_parts(1.25, -0.75);
+    let y1 = S::from_parts(-0.5, 0.5);
+    ([x0, x1], [y0, y1])
+}
+
+fn local_slice(rank: usize) -> Vec<S> {
+    vec![
+        S::from_parts(rank as f64 + 1.0, 0.25 * rank as f64),
+        S::from_parts(rank as f64 + 2.0, -0.4 * rank as f64),
+        S::from_parts(0.5 * rank as f64, 0.1 * (rank + 1) as f64),
+    ]
+}
+
+#[test]
+fn allreduce_scalar_matches_closed_form() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let size = comm.size();
+
+    let local = local_scalar(rank);
+    let reduced = comm.allreduce_sum_scalar(local);
+
+    let mut expected_re = 0.0;
+    let mut expected_im = 0.0;
+    for r in 0..size {
+        let value = local_scalar(r);
+        expected_re += value.real();
+        expected_im += value.imag();
+    }
+
+    assert!((reduced.real() - expected_re).abs() < 1e-12 * size as f64);
+    assert!((reduced.imag() - expected_im).abs() < 1e-12 * size as f64);
+}
+
+#[test]
+fn mpi_sys_scalar_matches_safe_path() {
+    let comm = make_world();
+
+    if comm.size() <= 1 {
+        // No collective exchange occurs in serial mode, so both helpers are identity maps.
+        return;
+    }
+
+    let rank = comm.rank();
+    let local = local_scalar(rank);
+
+    let safe = comm.allreduce_sum_scalar(local);
+    let raw = allreduce_sum_scalar_mpi_sys(&comm, local);
+
+    assert!((safe.real() - raw.real()).abs() < 1e-12 * comm.size() as f64);
+    #[cfg(feature = "complex")]
+    assert!((safe.imag() - raw.imag()).abs() < 1e-12 * comm.size() as f64);
+}
+
+#[test]
+fn allreduce_scalar_accurate_matches_safe_path() {
+    let comm = make_world();
+    let rank = comm.rank();
+
+    let local = local_scalar(rank);
+    let fast = comm.allreduce_sum_scalar(local);
+    let accurate = comm.allreduce_sum_scalar_accurate(local);
+
+    assert_eq!(fast, accurate);
+}
+
+#[test]
+fn global_dot_conj_matches_manual_sum() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let size = comm.size();
+
+    let (x_local, y_local) = local_vectors(rank);
+    let dot = global_dot_conj(&comm, &x_local, &y_local);
+
+    let mut expected = S::zero();
+    for r in 0..size {
+        let (x, y) = local_vectors(r);
+        expected = expected + dot_conj(&x, &y);
+    }
+
+    assert!((dot.real() - expected.real()).abs() < 1e-12 * size as f64);
+    assert!((dot.imag() - expected.imag()).abs() < 1e-12 * size as f64);
+}
+
+#[test]
+fn global_dot_conj_accurate_matches_manual_sum() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let size = comm.size();
+
+    let (x_local, y_local) = local_vectors(rank);
+    let dot = global_dot_conj_accurate(&comm, &x_local, &y_local);
+
+    let mut expected = S::zero();
+    for r in 0..size {
+        let (x, y) = local_vectors(r);
+        expected = expected + dot_conj(&x, &y);
+    }
+
+    assert!((dot.real() - expected.real()).abs() < 1e-12 * size as f64);
+    assert!((dot.imag() - expected.imag()).abs() < 1e-12 * size as f64);
+}
+
+#[test]
+fn global_dot_conj_repro_matches_fast() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let (x_local, y_local) = local_vectors(rank);
+
+    let fast = global_dot_conj(&comm, &x_local, &y_local);
+    let repro = global_dot_conj_repro(&comm, &x_local, &y_local);
+
+    assert_eq!(fast, repro);
+}
+
+#[test]
+fn global_dot_conj_many_matches_individual_calls() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let size = comm.size();
+
+    let (x_local, y_local) = local_vectors(rank);
+    let slice = local_slice(rank);
+    let pairs = vec![(&x_local[..], &y_local[..]), (&slice[..1], &slice[..1])];
+
+    let bundled = global_dot_conj_many(&comm, &pairs);
+    let repro = global_dot_conj_many_repro(&comm, &pairs);
+
+    assert_eq!(bundled.len(), pairs.len());
+    assert_eq!(bundled, repro);
+
+    let mut expected = Vec::with_capacity(2);
+    let mut accum0 = S::zero();
+    let mut accum1 = S::zero();
+    for r in 0..size {
+        let (vx, vy) = local_vectors(r);
+        accum0 = accum0 + dot_conj(&vx, &vy);
+
+        let sl = local_slice(r);
+        accum1 = accum1 + dot_conj(&sl[..1], &sl[..1]);
+    }
+    expected.push(accum0);
+    expected.push(accum1);
+
+    for (g, e) in bundled.iter().zip(expected.iter()) {
+        assert!((g.real() - e.real()).abs() < 1e-12 * size as f64);
+        assert!((g.imag() - e.imag()).abs() < 1e-12 * size as f64);
+    }
+}
+
+#[test]
+fn global_dot_conj_many_accurate_matches_individual_calls() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let size = comm.size();
+
+    let (x_local, y_local) = local_vectors(rank);
+    let slice = local_slice(rank);
+    let pairs = vec![(&x_local[..], &y_local[..]), (&slice[..2], &slice[..2])];
+
+    let bundled = global_dot_conj_many_accurate(&comm, &pairs);
+    assert_eq!(bundled.len(), pairs.len());
+
+    let mut expected = Vec::with_capacity(pairs.len());
+    let mut accum0 = S::zero();
+    let mut accum1 = S::zero();
+    for r in 0..size {
+        let (vx, vy) = local_vectors(r);
+        accum0 = accum0 + dot_conj(&vx, &vy);
+
+        let sl = local_slice(r);
+        accum1 = accum1 + dot_conj(&sl[..2], &sl[..2]);
+    }
+    expected.push(accum0);
+    expected.push(accum1);
+
+    for (g, e) in bundled.iter().zip(expected.iter()) {
+        assert!((g.real() - e.real()).abs() < 1e-12 * size as f64);
+        assert!((g.imag() - e.imag()).abs() < 1e-12 * size as f64);
+    }
+}
+
+#[test]
+fn global_dot_conj_many_into_matches_owned_helpers() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let size = comm.size();
+
+    let (x_local, y_local) = local_vectors(rank);
+    let slice = local_slice(rank);
+    let pairs = vec![(&x_local[..], &y_local[..]), (&slice[..2], &slice[..2])];
+
+    let mut into = vec![S::zero(); pairs.len()];
+    global_dot_conj_many_into(&comm, &pairs, &mut into);
+
+    let owned = global_dot_conj_many(&comm, &pairs);
+    assert_eq!(into, owned);
+
+    let mut accurate = vec![S::zero(); pairs.len()];
+    global_dot_conj_many_into_accurate(&comm, &pairs, &mut accurate);
+    assert_eq!(into, accurate);
+
+    let mut repro = vec![S::zero(); pairs.len()];
+    global_dot_conj_many_into_repro(&comm, &pairs, &mut repro);
+    assert_eq!(into, repro);
+
+    let mut manual = vec![S::zero(); pairs.len()];
+    for r in 0..size {
+        let (vx, vy) = local_vectors(r);
+        manual[0] = manual[0] + dot_conj(&vx, &vy);
+
+        let sl = local_slice(r);
+        manual[1] = manual[1] + dot_conj(&sl[..2], &sl[..2]);
+    }
+
+    for (result, expected) in into.iter().zip(manual.iter()) {
+        assert!((result.real() - expected.real()).abs() < 1e-12 * size as f64);
+        assert!((result.imag() - expected.imag()).abs() < 1e-12 * size as f64);
+    }
+}
+
+#[test]
+fn global_nrm2_many_matches_individual_calls() {
+    let comm = make_world();
+    let rank = comm.rank();
+
+    let (x_local, _) = local_vectors(rank);
+    let slice = local_slice(rank);
+    let local_refs = vec![&x_local[..], &slice[..2]];
+
+    let bundled = global_nrm2_many(&comm, &local_refs);
+    assert_eq!(bundled.len(), local_refs.len());
+
+    let single0 = global_nrm2(&comm, &x_local);
+    let single1 = global_nrm2(&comm, &slice[..2]);
+
+    assert!((bundled[0] - single0).abs() < 1e-13);
+    assert!((bundled[1] - single1).abs() < 1e-13);
+
+    let repro = global_nrm2_many_repro(&comm, &local_refs);
+    assert_eq!(bundled, repro);
+
+    let accurate = global_nrm2_many_accurate(&comm, &local_refs);
+    assert_eq!(bundled, accurate);
+}
+
+#[test]
+fn global_nrm2_many_into_matches_owned_helpers() {
+    let comm = make_world();
+    let rank = comm.rank();
+
+    let (x_local, _) = local_vectors(rank);
+    let slice = local_slice(rank);
+    let local_refs = vec![&x_local[..], &slice[..2]];
+
+    let mut into = vec![0.0; local_refs.len()];
+    global_nrm2_many_into(&comm, &local_refs, &mut into);
+
+    let owned = global_nrm2_many(&comm, &local_refs);
+    assert_eq!(into, owned);
+
+    let mut repro = vec![0.0; local_refs.len()];
+    global_nrm2_many_into_repro(&comm, &local_refs, &mut repro);
+    assert_eq!(into, repro);
+
+    let mut accurate = vec![0.0; local_refs.len()];
+    global_nrm2_many_into_accurate(&comm, &local_refs, &mut accurate);
+    assert_eq!(into, accurate);
+}
+
+#[test]
+fn global_nrm2_matches_manual_norm() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let size = comm.size();
+
+    let values = local_slice(rank);
+    let norm = global_nrm2(&comm, &values);
+
+    let mut total_sq = 0.0;
+    for r in 0..size {
+        for value in local_slice(r) {
+            let mag = value.abs();
+            total_sq += mag * mag;
+        }
+    }
+    let expected = total_sq.max(0.0).sqrt();
+
+    assert!((norm - expected).abs() < 1e-12 * (size as f64).sqrt());
+}
+
+#[test]
+fn global_nrm2_repro_matches_fast() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let values = local_slice(rank);
+
+    let fast = global_nrm2(&comm, &values);
+    let repro = global_nrm2_repro(&comm, &values);
+
+    assert_eq!(fast, repro);
+}
+
+#[test]
+fn global_nrm2_accurate_matches_fast() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let values = local_slice(rank);
+
+    let fast = global_nrm2(&comm, &values);
+    let accurate = global_nrm2_accurate(&comm, &values);
+
+    assert_eq!(fast, accurate);
+}
+
+#[test]
+fn allreduce_scalar_slice_in_place_matches_component_sums() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let size = comm.size();
+
+    let mut local = local_slice(rank);
+    allreduce_sum_scalar_slice_in_place(&comm, &mut local);
+
+    let mut expected = vec![S::zero(); local.len()];
+    for r in 0..size {
+        for (slot, value) in expected.iter_mut().zip(local_slice(r)) {
+            *slot = *slot + value;
+        }
+    }
+
+    for (result, target) in local.iter().zip(expected.iter()) {
+        assert!((result.real() - target.real()).abs() < 1e-12 * size as f64);
+        assert!((result.imag() - target.imag()).abs() < 1e-12 * size as f64);
+    }
+}
+
+#[test]
+fn owned_slice_reduction_matches_component_sums() {
+    let comm = make_world();
+    let rank = comm.rank();
+    let size = comm.size();
+
+    let local = local_slice(rank);
+    let reduced = allreduce_sum_scalar_slice_owned(&comm, &local);
+
+    let mut expected = vec![S::zero(); local.len()];
+    for r in 0..size {
+        for (slot, value) in expected.iter_mut().zip(local_slice(r)) {
+            *slot = *slot + value;
+        }
+    }
+
+    assert_eq!(reduced.len(), expected.len());
+    for (result, target) in reduced.iter().zip(expected.iter()) {
+        assert!((result.real() - target.real()).abs() < 1e-12 * size as f64);
+        assert!((result.imag() - target.imag()).abs() < 1e-12 * size as f64);
+    }
+}
+
+#[test]
+fn mpi_async_pair_supports_deterministic_mode() {
+    let comm = make_world();
+    let opt = ReductOptions {
+        mode: ReductMode::Deterministic,
+        ..Default::default()
+    };
+
+    let rank = comm.rank();
+    let a = rank as f64 + 0.5;
+    let b = -0.75 * rank as f64;
+    let mut handle = comm
+        .allreduce2_async(a, b, &opt)
+        .expect("deterministic async pair reduction should succeed")
+        .0;
+    let maybe = <UniverseComm as AllreduceOps>::test_pair(&mut handle)
+        .expect("deterministic pair handle should be ready");
+
+    let mut expected_a = 0.0;
+    let mut expected_b = 0.0;
+    for r in 0..comm.size() {
+        expected_a += r as f64 + 0.5;
+        expected_b += -0.75 * r as f64;
+    }
+
+    assert!((maybe.0 - expected_a).abs() < 1e-12 * comm.size() as f64);
+    assert!((maybe.1 - expected_b).abs() < 1e-12 * comm.size() as f64);
+}
+
+#[test]
+fn mpi_async_vec_supports_deterministic_mode() {
+    let comm = make_world();
+    let opt = ReductOptions {
+        mode: ReductMode::Deterministic,
+        ..Default::default()
+    };
+
+    let rank = comm.rank();
+    let local = local_slice(rank);
+    let expected_local: Vec<f64> = local.iter().map(|z| z.real()).collect();
+    let (mut handle, original) = comm
+        .allreduce_n_async(local.clone().into_iter().map(|z| z.real()).collect(), &opt)
+        .expect("deterministic async vector reduction should succeed");
+
+    assert_eq!(original, expected_local);
+
+    // Expect the handle to be ready immediately.
+    let reduced = <UniverseComm as AllreduceOps>::test_vec(&mut handle)
+        .expect("deterministic vector handle should be ready");
+
+    let mut expected = vec![0.0f64; reduced.len()];
+    for r in 0..comm.size() {
+        for (idx, value) in local_slice(r).iter().enumerate() {
+            expected[idx] += value.real();
+        }
+    }
+
+    for (got, want) in reduced.iter().zip(expected.iter()) {
+        assert!((*got - *want).abs() < 1e-12 * comm.size() as f64);
+    }
+}
+
+#[test]
+fn mpi_async_pair_supports_deterministic_accurate_mode() {
+    let comm = make_world();
+    let opt = ReductOptions {
+        mode: ReductMode::DeterministicAccurate,
+        ..Default::default()
+    };
+
+    let rank = comm.rank();
+    let a = rank as f64 + 0.5;
+    let b = -0.75 * rank as f64;
+    let mut handle = comm
+        .allreduce2_async(a, b, &opt)
+        .expect("accurate async pair reduction should succeed")
+        .0;
+    let maybe = <UniverseComm as AllreduceOps>::test_pair(&mut handle)
+        .expect("accurate pair handle should be ready");
+
+    let mut expected_a = 0.0;
+    let mut expected_b = 0.0;
+    for r in 0..comm.size() {
+        expected_a += r as f64 + 0.5;
+        expected_b += -0.75 * r as f64;
+    }
+
+    assert!((maybe.0 - expected_a).abs() < 1e-12 * comm.size() as f64);
+    assert!((maybe.1 - expected_b).abs() < 1e-12 * comm.size() as f64);
+}
+
+#[test]
+fn mpi_async_vec_supports_deterministic_accurate_mode() {
+    let comm = make_world();
+    let opt = ReductOptions {
+        mode: ReductMode::DeterministicAccurate,
+        ..Default::default()
+    };
+
+    let rank = comm.rank();
+    let local = local_slice(rank);
+    let expected_local: Vec<f64> = local.iter().map(|z| z.real()).collect();
+    let (mut handle, original) = comm
+        .allreduce_n_async(local.clone().into_iter().map(|z| z.real()).collect(), &opt)
+        .expect("accurate async vector reduction should succeed");
+
+    assert_eq!(original, expected_local);
+
+    let reduced = <UniverseComm as AllreduceOps>::test_vec(&mut handle)
+        .expect("accurate vector handle should be ready");
+
+    let mut expected = vec![0.0f64; reduced.len()];
+    for r in 0..comm.size() {
+        for (idx, value) in local_slice(r).iter().enumerate() {
+            expected[idx] += value.real();
+        }
+    }
+
+    for (observed, target) in reduced.iter().zip(expected.iter()) {
+        assert!((observed - target).abs() < 1e-12 * comm.size() as f64);
+    }
+}


### PR DESCRIPTION
## Summary
- extend the shared dot engine with a batched reduction API and unit coverage for packet width chunking
- refactor classic PCG to reuse the new batched dot helper, caching required norms for monitors and convergence checks

## Testing
- cargo test --lib reduction::tests::dot_engine_many_matches_individual_dots
- cargo test --lib reduction::tests::dot_engine_many_batches_more_than_packet_width
- cargo test --test pcg_basic
- cargo test --test pcg_norm_types
- cargo test --test pcg_true_residual_monitor

------
https://chatgpt.com/codex/tasks/task_e_68e1afb5378883298c37f6430d57899d