### PR TITLE
Fix CSR column ordering in fieldsplit benchmark example

### DIFF
--- a/examples/fieldsplit_block_system_benchmark.rs
+++ b/examples/fieldsplit_block_system_benchmark.rs
@@ -37,14 +37,14 @@ fn coupled_block_system(nu: usize, np: usize) -> CsrMatrix<S> {
 
     for i in 0..n {
         if i < nu {
+            if i > 0 {
+                col_idx.push(i - 1);
+                values.push(S::from_real(-1.0));
+            }
             col_idx.push(i);
             values.push(S::from_real(4.0));
             if i + 1 < nu {
                 col_idx.push(i + 1);
-                values.push(S::from_real(-1.0));
-            }
-            if i > 0 {
-                col_idx.push(i - 1);
                 values.push(S::from_real(-1.0));
             }
             if np > 0 {
@@ -53,10 +53,10 @@ fn coupled_block_system(nu: usize, np: usize) -> CsrMatrix<S> {
             }
         } else {
             let p = i - nu;
-            col_idx.push(i);
-            values.push(S::from_real(2.0));
             col_idx.push(p % nu);
             values.push(S::from_real(0.15));
+            col_idx.push(i);
+            values.push(S::from_real(2.0));
         }
         row_ptr.push(col_idx.len());
     }


### PR DESCRIPTION
### Motivation

- The example assembly emitted unsorted column indices per CSR row, violating the debug invariant in `CsrMatrix::from_csr` and causing a panic (`row 1 has unsorted column indices`).
- The goal is to preserve the same stencil/coupling values while ensuring each CSR row's `col_idx` slice is sorted ascending.

### Description

- Reordered per-row assembly in `examples/fieldsplit_block_system_benchmark.rs::coupled_block_system` so velocity rows emit `i-1` (if present), then `i`, then `i+1`, then the pressure coupling column and pressure rows emit the velocity-coupling column (`p % nu`) before the diagonal `i`, guaranteeing ascending column indices.
- Kept all numerical values and sparsity pattern unchanged; only the order of `col_idx` / `values` pushes was altered to satisfy CSR invariants.

### Testing

- Ran `cargo run --example fieldsplit_block_system_benchmark --features backend-faer` and the example built and ran to completion, printing benchmark timings with no CSR sorted-index panic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69cbfa48c0c08329a2beec8a555f27c6)