### PR TITLE
Rename BiCGStab LowSync variant to FewerChecks

### DIFF
--- a/benches/solver_reduction_scaling.rs
+++ b/benches/solver_reduction_scaling.rs
@@ -209,12 +209,12 @@ fn main() {
         let bicg_classic_ms = bicg_classic_start.elapsed().as_secs_f64() * 1e3;
 
         xb.fill(0.0);
-        let mut bicg_lowsync = BiCgStabSolver::new(1e-8, 600);
-        bicg_lowsync.set_variant(BiCgStabVariant::LowSync);
+        let mut bicg_fewerchecks = BiCgStabSolver::new(1e-8, 600);
+        bicg_fewerchecks.set_variant(BiCgStabVariant::FewerChecks);
         let mut ws = Workspace::default();
         let t0 = Instant::now();
-        let bicg_lowsync_start = Instant::now();
-        let s_bicg_lowsync = bicg_lowsync
+        let bicg_fewerchecks_start = Instant::now();
+        let s_bicg_fewerchecks = bicg_fewerchecks
             .solve_f64(
                 &a3,
                 None,
@@ -225,15 +225,18 @@ fn main() {
                 None,
                 Some(&mut ws),
             )
-            .expect("bicgstab lowsync");
+            .expect("bicgstab fewerchecks");
         report(
-            "bicgstab-lowsync",
-            s_bicg_lowsync.iterations,
-            s_bicg_lowsync.counters.num_global_reductions,
+            "bicgstab-fewer-checks",
+            s_bicg_fewerchecks.iterations,
+            s_bicg_fewerchecks.counters.num_global_reductions,
             t0.elapsed().as_secs_f64() * 1e3,
-            s_bicg_lowsync.reduction_model.as_ref().map(|m| m.variant),
+            s_bicg_fewerchecks
+                .reduction_model
+                .as_ref()
+                .map(|m| m.variant),
         );
-        let bicg_lowsync_ms = bicg_lowsync_start.elapsed().as_secs_f64() * 1e3;
+        let bicg_fewerchecks_ms = bicg_fewerchecks_start.elapsed().as_secs_f64() * 1e3;
 
         let mut xq = vec![0.0; a3.nrows()];
         let mut qmr = QmrSolver::new(1e-8, 600);
@@ -283,20 +286,20 @@ fn main() {
         );
 
         println!(
-            "      deltas: bicg-lowsync vs classic => reductions={} runtime_ms={:.3}",
+            "      deltas: bicg-fewerchecks vs classic => reductions={} runtime_ms={:.3}",
             s_bicg_classic.counters.num_global_reductions as isize
-                - s_bicg_lowsync.counters.num_global_reductions as isize,
-            bicg_classic_ms - bicg_lowsync_ms
+                - s_bicg_fewerchecks.counters.num_global_reductions as isize,
+            bicg_classic_ms - bicg_fewerchecks_ms
         );
 
         assert!(
-            s_bicg_lowsync.counters.overlap_global_reductions > 0,
-            "benchmark gate failed: bicgstab lowsync should record overlap reductions"
+            s_bicg_fewerchecks.counters.overlap_global_reductions > 0,
+            "benchmark gate failed: bicgstab fewerchecks should record overlap reductions"
         );
         assert!(
-            s_bicg_lowsync.counters.num_global_reductions
+            s_bicg_fewerchecks.counters.num_global_reductions
                 <= s_bicg_classic.counters.num_global_reductions,
-            "benchmark gate failed: lowsync did not reduce synchronization"
+            "benchmark gate failed: fewerchecks did not reduce synchronization"
         );
     }
 }

--- a/docs/howto/mpi_rayon_solver_tuning.md
+++ b/docs/howto/mpi_rayon_solver_tuning.md
@@ -38,7 +38,7 @@ Use reduced-sync variants only where the recurrences are mathematically valid fo
 - `CgVariant::Pipelined` (CG): SPD operator, left HPD preconditioner.
 - `PcgVariant::Pipelined { replace_every }` (PCG): same SPD/left-HPD assumptions.
 - `GmresVariant::Pipelined` and `FgmresVariant::Pipelined`: general nonsymmetric systems with Arnoldi-based fused reductions.
-- `BiCgStabVariant::LowSync`: nonsymmetric systems when lower synchronization is desired over strict classical recurrence behavior.
+- `BiCgStabVariant::FewerChecks`: nonsymmetric systems when lower synchronization is desired over strict classical recurrence behavior.
 
 Practical drift control for long runs:
 

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -154,7 +154,7 @@ pub struct KspOptions {
     pub chebyshev_omega: Option<f64>,
     /// Restart length for GCR family (falls back to ksp_restart).
     pub gcr_restart: Option<usize>,
-    /// BiCGStab algorithm variant: "classic" | "lowsync" | "reliable"
+    /// BiCGStab algorithm variant: "classic" | "fewerchecks" | "reliable"
     pub bicgstab_variant: Option<String>,
     /// Residual replacement interval for reliable BiCGStab.
     pub bicgstab_replace_every: Option<usize>,

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -74,7 +74,7 @@ pub static SPECS: &[Spec] = &[
         key: "ksp_bicgstab_variant",
         arity: Arity::One,
         kind: ValueKind::Str,
-        doc: "BiCGStab variant: classic|lowsync|reliable",
+        doc: "BiCGStab variant: classic|fewerchecks|reliable",
     },
     Spec {
         flag: "-ksp_bicgstab_replace_every",

--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -1373,7 +1373,8 @@ impl KspContext {
         if let Some(ref variant) = opts.bicgstab_variant {
             let parsed = match variant.as_str() {
                 "classic" => BiCgStabVariant::Classic,
-                "lowsync" | "low_sync" | "low-sync" => BiCgStabVariant::LowSync,
+                "fewerchecks" | "fewer_checks" | "fewer-checks" | "lowsync" | "low_sync"
+                | "low-sync" => BiCgStabVariant::FewerChecks,
                 "reliable" => BiCgStabVariant::Reliable {
                     residual_replace_every: self
                         .pending_bicgstab
@@ -1383,7 +1384,7 @@ impl KspContext {
                 },
                 other => {
                     return Err(KError::SolveError(format!(
-                        "Unrecognized ksp_bicgstab_variant: {other} (expected 'classic'|'lowsync'|'reliable')"
+                        "Unrecognized ksp_bicgstab_variant: {other} (expected 'classic'|'fewerchecks'|'reliable'; legacy aliases: 'lowsync'|'low_sync'|'low-sync')"
                     )));
                 }
             };
@@ -4928,7 +4929,7 @@ mod tests {
         for (solver, key, value) in [
             ("gmres", "gmres_variant", "pipelined"),
             ("fgmres", "fgmres_variant", "pipelined"),
-            ("bicgstab", "bicgstab_variant", "lowsync"),
+            ("bicgstab", "bicgstab_variant", "fewerchecks"),
         ] {
             let (x1, overlap1) = run_once(solver, key, value);
             let (x2, overlap2) = run_once(solver, key, value);
@@ -5151,7 +5152,7 @@ mod tests {
         ksp.atol = 1e-12;
         ksp.maxits = 500;
         let opts = KspOptions {
-            bicgstab_variant: Some("lowsync".into()),
+            bicgstab_variant: Some("fewerchecks".into()),
             ..Default::default()
         };
         ksp.set_from_options(&opts).expect("set opts");

--- a/src/solver/bicgstab.rs
+++ b/src/solver/bicgstab.rs
@@ -260,7 +260,7 @@ fn finalize_breakdown_salvage_exit<A: KLinOp<Scalar = S> + ?Sized>(
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum BiCgStabVariant {
     Classic,
-    LowSync,
+    FewerChecks,
     Reliable { residual_replace_every: usize },
 }
 
@@ -307,8 +307,8 @@ impl BiCgStabSolver {
                 per_iteration: 5.0,
                 tail: 1,
             },
-            BiCgStabVariant::LowSync => ReductionModel {
-                variant: "bicgstab-lowsync",
+            BiCgStabVariant::FewerChecks => ReductionModel {
+                variant: "bicgstab-fewer-checks",
                 startup: 2,
                 per_iteration: 4.0,
                 tail: 1,
@@ -470,7 +470,7 @@ impl BiCgStabSolver {
 
         let (check_s_norm, replace_every) = match self.variant {
             BiCgStabVariant::Classic => (true, None),
-            BiCgStabVariant::LowSync => (false, None),
+            BiCgStabVariant::FewerChecks => (false, None),
             BiCgStabVariant::Reliable {
                 residual_replace_every,
             } => (true, Some(residual_replace_every.max(1))),

--- a/src/solver/tests/breakdown_true_residual.rs
+++ b/src/solver/tests/breakdown_true_residual.rs
@@ -132,7 +132,10 @@ fn bicgstab_breakdown_reclassified_when_true_residual_meets_tol() {
 
     assert_eq!(stats.reason, ConvergedReason::ConvergedHappyBreakdown);
     assert_eq!(stats.acceptance_status, AcceptanceStatus::OkWithWarning);
-    assert_eq!(stats.breakdown_reason, Some(ConvergedReason::DivergedBreakdownBiCG));
+    assert_eq!(
+        stats.breakdown_reason,
+        Some(ConvergedReason::DivergedBreakdownBiCG)
+    );
     assert!(
         stats
             .residual_override_note
@@ -186,7 +189,7 @@ fn bicgstab_omega_breakdown_reclassified_when_true_residual_meets_tol() {
     let mut x = vec![1.0, 0.0];
     let mut solver = BiCgStabSolver::new(1e-12, 5);
     solver.atol = 1e-12;
-    solver.set_variant(crate::solver::bicgstab::BiCgStabVariant::LowSync);
+    solver.set_variant(crate::solver::bicgstab::BiCgStabVariant::FewerChecks);
     let comm = UniverseComm::NoComm(NoComm);
     let mut ws = Workspace::default();
 
@@ -205,7 +208,10 @@ fn bicgstab_omega_breakdown_reclassified_when_true_residual_meets_tol() {
 
     assert_eq!(stats.reason, ConvergedReason::ConvergedHappyBreakdown);
     assert_eq!(stats.acceptance_status, AcceptanceStatus::OkWithWarning);
-    assert_eq!(stats.breakdown_reason, Some(ConvergedReason::DivergedBreakdownBiCG));
+    assert_eq!(
+        stats.breakdown_reason,
+        Some(ConvergedReason::DivergedBreakdownBiCG)
+    );
     assert!(
         stats
             .residual_override_note
@@ -228,7 +234,7 @@ fn bicgstab_omega_breakdown_keeps_hard_breakdown_above_tol() {
     let mut x = vec![1.0, 0.0];
     let mut solver = BiCgStabSolver::new(1e-12, 5);
     solver.atol = 1e-12;
-    solver.set_variant(crate::solver::bicgstab::BiCgStabVariant::LowSync);
+    solver.set_variant(crate::solver::bicgstab::BiCgStabVariant::FewerChecks);
     let comm = UniverseComm::NoComm(NoComm);
     let mut ws = Workspace::default();
 

--- a/src/solver/tests/sync_counts.rs
+++ b/src/solver/tests/sync_counts.rs
@@ -117,7 +117,7 @@ fn gmres_classic_reduction_count_within_expected_bounds() -> Result<(), KError> 
 }
 
 #[test]
-fn bicgstab_lowsync_reduces_reported_syncs_vs_classic() -> Result<(), KError> {
+fn bicgstab_fewerchecks_reduces_reported_syncs_vs_classic() -> Result<(), KError> {
     let a = util::nonsym_convdiff_2d(8, 3.0);
     let b: Vec<R> = util::rhs_random(a.nrows(), 9);
     let comm = UniverseComm::NoComm(NoComm);
@@ -137,11 +137,11 @@ fn bicgstab_lowsync_reduces_reported_syncs_vs_classic() -> Result<(), KError> {
         Some(&mut ws),
     )?;
 
-    let mut lowsync = BiCgStabSolver::new(1e-8, 200);
-    lowsync.set_variant(BiCgStabVariant::LowSync);
+    let mut fewerchecks = BiCgStabSolver::new(1e-8, 200);
+    fewerchecks.set_variant(BiCgStabVariant::FewerChecks);
     let mut xl = vec![R::default(); a.nrows()];
     let mut ws = Workspace::default();
-    let stats_lowsync = lowsync.solve_f64(
+    let stats_fewerchecks = fewerchecks.solve_f64(
         &a,
         None,
         &b,
@@ -153,12 +153,12 @@ fn bicgstab_lowsync_reduces_reported_syncs_vs_classic() -> Result<(), KError> {
     )?;
 
     let b_norm2 = b.iter().map(|&v| v * v).sum::<f64>().sqrt();
-    assert!(stats_lowsync.final_residual <= 1e-6 * b_norm2 + 1e-8);
+    assert!(stats_fewerchecks.final_residual <= 1e-6 * b_norm2 + 1e-8);
     assert!(
-        stats_lowsync.counters.num_global_reductions
+        stats_fewerchecks.counters.num_global_reductions
             <= stats_classic.counters.num_global_reductions,
-        "expected lowsync reductions <= classic (lowsync={}, classic={})",
-        stats_lowsync.counters.num_global_reductions,
+        "expected fewerchecks reductions <= classic (fewerchecks={}, classic={})",
+        stats_fewerchecks.counters.num_global_reductions,
         stats_classic.counters.num_global_reductions
     );
     Ok(())

--- a/tests/bicgstab_variants.rs
+++ b/tests/bicgstab_variants.rs
@@ -160,7 +160,7 @@ impl LinOpF64 for NanOnceOp {
 }
 
 #[test]
-fn bicgstab_lowsync_keeps_convergence_and_reduces_syncs() {
+fn bicgstab_fewerchecks_keeps_convergence_and_reduces_syncs() {
     let n = 36;
     let a = nonsym_tridiag(n);
     let b = vec![1.0; n];
@@ -185,7 +185,7 @@ fn bicgstab_lowsync_keeps_convergence_and_reduces_syncs() {
 
     let mut x_low = vec![0.0; n];
     let mut low = BiCgStabSolver::new(1e-9, 300);
-    low.set_variant(BiCgStabVariant::LowSync);
+    low.set_variant(BiCgStabVariant::FewerChecks);
     let mut ws_low = kryst::context::ksp_context::Workspace::default();
     let stats_low = low
         .solve_f64(
@@ -208,9 +208,13 @@ fn bicgstab_lowsync_keeps_convergence_and_reduces_syncs() {
 
 #[test]
 fn bicgstab_variant_selectable_from_ksp_options() {
-    let opts =
-        KspOptions::from_args(&["-ksp_type", "bicgstab", "-ksp_bicgstab_variant", "lowsync"])
-            .unwrap();
+    let opts = KspOptions::from_args(&[
+        "-ksp_type",
+        "bicgstab",
+        "-ksp_bicgstab_variant",
+        "fewerchecks",
+    ])
+    .unwrap();
     let mut ksp = KspContext::new();
     ksp.set_from_options(&opts).unwrap();
 
@@ -223,7 +227,7 @@ fn bicgstab_variant_selectable_from_ksp_options() {
 
     assert_eq!(
         stats.reduction_model.as_ref().map(|m| m.variant),
-        Some("bicgstab-lowsync")
+        Some("bicgstab-fewer-checks")
     );
 }
 
@@ -358,7 +362,7 @@ fn bicgstab_handles_t_zero_and_s_zero_as_converged_for_left_and_right() {
             ],
         );
         let mut solver = BiCgStabSolver::new(1e-12, 10);
-        solver.set_variant(BiCgStabVariant::LowSync);
+        solver.set_variant(BiCgStabVariant::FewerChecks);
         let mut ws = kryst::context::ksp_context::Workspace::default();
         let mut x = vec![0.0, 0.0];
         let stats = solver
@@ -390,7 +394,7 @@ fn bicgstab_handles_t_zero_and_s_nonzero_as_breakdown_for_left_and_right() {
             ],
         );
         let mut solver = BiCgStabSolver::new(1e-12, 10);
-        solver.set_variant(BiCgStabVariant::LowSync);
+        solver.set_variant(BiCgStabVariant::FewerChecks);
         solver.atol = 0.0;
         solver.rtol = 0.0;
         let mut ws = kryst::context::ksp_context::Workspace::default();
@@ -489,7 +493,7 @@ fn bicgstab_omega_den_breakdown_salvage_branch_is_reachable() {
     let mut solver = BiCgStabSolver::new(0.0, 6);
     solver.atol = 0.0;
     solver.rtol = 0.0;
-    solver.set_variant(BiCgStabVariant::LowSync);
+    solver.set_variant(BiCgStabVariant::FewerChecks);
     let mut ws = kryst::context::ksp_context::Workspace::default();
     let mut x = vec![0.0, 0.0];
 


### PR DESCRIPTION
### Motivation
- The previous name `LowSync` implied a pipelined/low-sync algorithm but the code implements a behavior of performing fewer intermediate checks; renaming clarifies intent and avoids misleading API/docs. 

### Description
- Rename enum variant `BiCgStabVariant::LowSync` to `BiCgStabVariant::FewerChecks` and update all match arms to use the new symbol. 
- Update `BiCgStabSolver::reduction_model()` to report the variant string as `"bicgstab-fewer-checks"` with the appropriate `per_iteration` model. 
- Replace all references in tests, benchmarks, docs, and config/registry/options from `lowsync`/`low_sync`/`low-sync` to `fewerchecks`/`fewer_checks`/`fewer-checks` and adjust labels/messages accordingly. 
- Preserve backwards-compatible CLI parsing by accepting legacy aliases (`"lowsync"|"low_sync"|"low-sync"`) and mapping them to `BiCgStabVariant::FewerChecks`. 

### Testing
- Ran `cargo fmt` successfully. 
- Ran the variant tests with `cargo test --test bicgstab_variants bicgstab_fewerchecks_keeps_convergence_and_reduces_syncs` and `cargo test --test bicgstab_variants bicgstab_variant_selectable_from_ksp_options`, both of which passed. 
- Ran the sync-counts unit with `cargo test --lib sync_counts::bicgstab_fewerchecks_reduces_reported_syncs_vs_classic`, which also passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d80b6b98a8832997abe9a5acb4b305)