### PR TITLE
Add scalar/complex-facing BiCGSTAB solve entry points

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -3085,7 +3085,7 @@ impl KspContext {
                             .as_any_mut()
                             .downcast_mut::<BiCgStabSolver>()
                             .ok_or_else(|| KError::SolveError("BiCGStab solver missing".into()))?;
-                        s.solve(
+                        s.solve_k(
                             &op,
                             pc_k.as_deref(),
                             b,

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -9,4 +9,5 @@ pub use crate::matrix::LinOp;
 pub use crate::matrix::OpFormat;
 pub use crate::parallel::{Comm, UniverseComm};
 pub use crate::preconditioner::{PcSide, Preconditioner};
+pub use crate::solver::{KLinOp, KPreconditioner};
 pub use crate::utils::convergence::{ConvergedReason, SolveStats};

--- a/src/solver/bicgstab.rs
+++ b/src/solver/bicgstab.rs
@@ -323,7 +323,7 @@ impl BiCgStabSolver {
     }
 
     #[allow(clippy::too_many_arguments)]
-    pub fn solve<A>(
+    pub fn solve_k<A>(
         &mut self,
         a: &A,
         pc: Option<&dyn KPreconditioner<Scalar = S>>,
@@ -1049,6 +1049,7 @@ impl BiCgStabSolver {
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[cfg(not(feature = "complex"))]
     fn solve_csr(
         &mut self,
         a: &crate::matrix::sparse::CsrMatrix<f64>,
@@ -1060,10 +1061,11 @@ impl BiCgStabSolver {
         monitors: Option<&[Box<MonitorCallback<R>>]>,
         work: Option<&mut Workspace>,
     ) -> Result<SolveStats<R>, KError> {
-        self.solve(a, pc, b, x, pc_side, comm, monitors, work)
+        self.solve_k(a, pc, b, x, pc_side, comm, monitors, work)
     }
 
     #[allow(clippy::too_many_arguments)]
+    #[cfg(not(feature = "complex"))]
     fn solve_dist_csr(
         &mut self,
         a: &crate::matrix::DistCsrOp,
@@ -1075,10 +1077,15 @@ impl BiCgStabSolver {
         monitors: Option<&[Box<MonitorCallback<R>>]>,
         work: Option<&mut Workspace>,
     ) -> Result<SolveStats<R>, KError> {
-        self.solve(a, pc, b, x, pc_side, comm, monitors, work)
+        self.solve_k(a, pc, b, x, pc_side, comm, monitors, work)
     }
 
     #[allow(clippy::too_many_arguments)]
+    /// Solve using real (`f64`) operator/preconditioner interfaces.
+    ///
+    /// In `feature = "complex"` builds this bridge maps `f64 -> S` and projects
+    /// the final iterate back to `f64` (real part). For genuine complex solves,
+    /// prefer [`Self::solve_k`] or [`Self::solve_c64`].
     pub fn solve_f64<A>(
         &mut self,
         a: &A,
@@ -1114,7 +1121,7 @@ impl BiCgStabSolver {
                     .solve_csr(csr, pc_ref, b_s, x_s, pc_side, comm, monitors, work)
                     .map(|stats| stats.with_reduction_model(self.reduction_model()));
             }
-            self.solve(&op, pc_ref, b_s, x_s, pc_side, comm, monitors, work)
+            self.solve_k(&op, pc_ref, b_s, x_s, pc_side, comm, monitors, work)
                 .map(|stats| stats.with_reduction_model(self.reduction_model()))
         }
         #[cfg(feature = "complex")]
@@ -1122,7 +1129,7 @@ impl BiCgStabSolver {
             let b_s: Vec<S> = b.iter().copied().map(S::from_real).collect();
             let mut x_s: Vec<S> = x.iter().copied().map(S::from_real).collect();
             let result = self
-                .solve(&op, pc_ref, &b_s, &mut x_s, pc_side, comm, monitors, work)
+                .solve_k(&op, pc_ref, &b_s, &mut x_s, pc_side, comm, monitors, work)
                 .map(|stats| stats.with_reduction_model(self.reduction_model()));
             if result.is_ok() {
                 for (dst, src) in x.iter_mut().zip(x_s.iter()) {
@@ -1131,6 +1138,43 @@ impl BiCgStabSolver {
             }
             result
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    pub fn solve<A>(
+        &mut self,
+        a: &A,
+        pc: Option<&dyn KPreconditioner<Scalar = S>>,
+        b: &[S],
+        x: &mut [S],
+        pc_side: PcSide,
+        comm: &UniverseComm,
+        monitors: Option<&[Box<MonitorCallback<R>>]>,
+        work: Option<&mut Workspace>,
+    ) -> Result<SolveStats<R>, KError>
+    where
+        A: KLinOp<Scalar = S> + ?Sized,
+    {
+        self.solve_k(a, pc, b, x, pc_side, comm, monitors, work)
+    }
+
+    #[cfg(feature = "complex")]
+    #[allow(clippy::too_many_arguments)]
+    pub fn solve_c64<A>(
+        &mut self,
+        a: &A,
+        pc: Option<&dyn KPreconditioner<Scalar = S>>,
+        b: &[S],
+        x: &mut [S],
+        pc_side: PcSide,
+        comm: &UniverseComm,
+        monitors: Option<&[Box<MonitorCallback<R>>]>,
+        work: Option<&mut Workspace>,
+    ) -> Result<SolveStats<R>, KError>
+    where
+        A: KLinOp<Scalar = S> + ?Sized,
+    {
+        self.solve_k(a, pc, b, x, pc_side, comm, monitors, work)
     }
 }
 

--- a/src/solver/block/bicgstab.rs
+++ b/src/solver/block/bicgstab.rs
@@ -95,7 +95,7 @@ impl LinearSolver for BlockBicgstabSolver {
             let mut solver = BiCgStabSolver::new(self.options.rtol, self.options.max_iters);
             solver.atol = self.options.atol;
             solver.dtol = self.options.dtol;
-            let stats = solver.solve(
+            let stats = solver.solve_k(
                 &op,
                 pc_ref,
                 b_block.col(col),

--- a/src/solver/mod.rs
+++ b/src/solver/mod.rs
@@ -23,6 +23,8 @@ pub type MonitorCallback<R> = dyn Fn(usize, R, usize) -> MonitorAction + Send + 
 pub mod api;
 pub use api::Solver;
 pub mod adapters;
+pub use crate::ops::klinop::KLinOp;
+pub use crate::ops::kpc::KPreconditioner;
 pub use adapters::LegacyDirectAdapter;
 
 pub mod block;


### PR DESCRIPTION
### Motivation
- Provide a true complex-capable BiCGSTAB entry point that accepts and returns complex `S` vectors (rather than projecting to real parts via `solve_f64`) so genuine complex workloads are supported when `feature = "complex"`.
- Avoid routing complex solves through the `f64`-only bridge path and make solver/preconditioner wiring ergonomic for callers that already have `KLinOp`/`KPreconditioner` over `S`.

### Description
- Introduced a scalar-generic canonical entry point `BiCgStabSolver::solve_k` that accepts `A: KLinOp<Scalar = S>` / `pc: Option<&dyn KPreconditioner<Scalar = S>>` and operates on `&[S]` / `&mut [S]` directly.
- Added a `#[cfg(feature = "complex")]` helper `BiCgStabSolver::solve_c64` (and kept `solve` as a forwarding alias to `solve_k`) to make the complex-facing API explicit for complex builds.
- Kept and documented `solve_f64` as the real-operator bridge but changed its internal routing to call `solve_k` (where appropriate) so real-bridges remain but no longer hide the scalar-generic path; added clarifying doc comments.
- Guarded `solve_csr` / `solve_dist_csr` specializations with `#[cfg(not(feature = "complex"))]` so they only apply where appropriate and avoid type conflicts in complex builds.
- Updated call sites to use the scalar path: replaced BiCGSTAB invocations with `solve_k` in the block BiCGSTAB flow and in `KspContext` dispatch.
- Re-exported `KLinOp` and `KPreconditioner` from `solver` and added them to the crate `prelude` to simplify users invoking scalar-generic solvers directly.

### Testing
- Ran `cargo fmt` successfully to normalize formatting.
- Ran `cargo check -q` (no features) successfully after the changes.
- Ran `cargo check -q --features complex` successfully to validate the complex build path.
- During iteration, `cargo test` for solver kernel targets exposed compile-time mismatches that were fixed by the API wiring changes; subsequent type-check runs passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d83970cd8083298f1b1c9ff433b0a8)