### PR TITLE
Gate BiCgStab real-dispatch tests behind non-complex cfg

### DIFF
--- a/src/solver/bicgstab.rs
+++ b/src/solver/bicgstab.rs
@@ -1481,10 +1481,12 @@ mod tests {
         assert!(stats.counters.residual_replacements >= stats.iterations);
     }
 
+    #[cfg(not(feature = "complex"))]
     struct IdentityHintPc {
         format: OpFormat,
     }
 
+    #[cfg(not(feature = "complex"))]
     impl Preconditioner for IdentityHintPc {
         fn setup(&mut self, _a: &dyn LinOp<S = S>) -> Result<(), KError> {
             Ok(())
@@ -1500,6 +1502,7 @@ mod tests {
         }
     }
 
+    #[cfg(not(feature = "complex"))]
     fn csr_reference_system() -> (Arc<CsrMatrix<f64>>, Vec<f64>, Vec<f64>) {
         let row_ptr = vec![0, 2, 4];
         let col_idx = vec![0, 1, 0, 1];
@@ -1511,6 +1514,7 @@ mod tests {
         (csr, b, x_true)
     }
 
+    #[cfg(not(feature = "complex"))]
     #[test]
     fn bicgstab_dispatch_prefers_csr_materialized_when_pc_requires_csr() {
         let (csr, _, _) = csr_reference_system();
@@ -1533,6 +1537,7 @@ mod tests {
         );
     }
 
+    #[cfg(not(feature = "complex"))]
     #[test]
     fn bicgstab_csr_materialized_and_generic_routes_match_numerics() {
         let (csr, b, x_true) = csr_reference_system();


### PR DESCRIPTION
### Motivation
- Fix compile errors when building with `--features=complex` where unit tests reference `RealDispatchRoute` and `select_real_dispatch` that exist only for real scalars.

### Description
- Add `#[cfg(not(feature = "complex"))]` to the `IdentityHintPc` test helper, its `Preconditioner` impl, and the `csr_reference_system` helper in `src/solver/bicgstab.rs` so they are only compiled for non-complex builds.
- Add `#[cfg(not(feature = "complex"))]` guards to the two BiCGStab dispatch tests that call `BiCgStabSolver::select_real_dispatch` to avoid referencing real-only APIs in complex-feature builds.

### Testing
- Ran `cargo test --features=mpi,rayon,backend-faer,logging,complex` and the previous BiCgStab compilation errors are resolved.
- The test run produced `440 passed; 3 failed; 6 ignored` where the remaining 3 failures are unrelated runtime panics in ILU complex tests under `preconditioner::tests::ilu_csr_complex::*`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b4433ecc8329810e5d46e4beccad)