### PR TITLE
Fix complex ILU permutation metadata initialization for apply path

### DIFF
--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -1390,7 +1390,10 @@ impl Preconditioner for IluCsr {
             } else {
                 permute_csr_symmetric(csr, &perm)
             };
-            self.perm = perm;
+            self.perm = perm.clone();
+            self.pipeline_meta = PreconditioningMetadata::identity(csr.nrows());
+            self.pipeline_meta.left_perm = perm.clone();
+            self.pipeline_meta.right_perm = perm;
 
             match self.cfg.kind {
                 IluKind::Ilu0 | IluKind::Milu0 => {


### PR DESCRIPTION
### Motivation
- When setting up complex ILU, `self.perm` was updated but `pipeline_meta` remained the default identity of size 0 for fresh instances, which caused `Permutation::apply_vec` to index out of bounds during degraded-complex apply paths.

### Description
- Initialize `pipeline_meta` to `PreconditioningMetadata::identity(csr.nrows())` in the complex `IluCsr::setup` path. 
- Set `pipeline_meta.left_perm` and `pipeline_meta.right_perm` to the computed permutation and clone `perm` into `self.perm` so the apply path has valid permutation metadata.
- Change is localized to `src/preconditioner/ilu_csr/mod.rs` near the complex setup/reordering code.

### Testing
- Ran `cargo test --features=mpi,rayon,logging,backend-faer,complex` and the suite completed; the previously failing complex ILU CSR tests now pass. 
- Verified the specific regression tests now succeed: `preconditioner::tests::ilu_csr_complex::ilut_complex_uses_native_kernel_and_respects_numeric_update`, `preconditioner::tests::ilu_csr_complex::ilut_complex_native_beats_degraded_residual`, and `preconditioner::tests::ilu_csr_complex::iluk_complex_native_beats_degraded_residual`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9b6a4bd6483298e0f6f96fbd57c68)