### PR TITLE
Fix CSR column ordering in MPI Rayon stress test

### DIFF
--- a/tests/parallel_reductions.rs
+++ b/tests/parallel_reductions.rs
@@ -74,17 +74,20 @@ fn dist_matvec_mpi_rayon_stress() {
 
     let next = if rank + 1 < size { rank + 1 } else { 0 };
     let remote_col = next * local_n;
+    let mut row0 = [(row_start, S::from_real(2.0)), (remote_col, S::from_real(-0.25))];
+    row0.sort_by_key(|(col, _)| *col);
+    let mut row1 = [
+        (row_start + 1, S::from_real(3.0)),
+        (remote_col, S::from_real(0.5)),
+    ];
+    row1.sort_by_key(|(col, _)| *col);
+
     let local = CsrMatrix::<S>::from_csr(
         local_n,
         n_global,
         vec![0, 2, 4],
-        vec![row_start, remote_col, row_start + 1, remote_col],
-        vec![
-            S::from_real(2.0),
-            S::from_real(-0.25),
-            S::from_real(3.0),
-            S::from_real(0.5),
-        ],
+        vec![row0[0].0, row0[1].0, row1[0].0, row1[1].0],
+        vec![row0[0].1, row0[1].1, row1[0].1, row1[1].1],
     );
     let part: Vec<usize> = (0..=size).map(|r| r * local_n).collect();
     let op = DistCsrOp::from_local_rows(n_global, row_start, &local, &part, comm.clone()).unwrap();


### PR DESCRIPTION
### Motivation
- The `dist_matvec_mpi_rayon_stress` test could construct CSR rows with unsorted column indices when `remote_col < row_start`, causing `CsrMatrix::from_csr` to panic and poison the global MPI test guard, which led to many cascading `mpi_test_guard poisoned` failures.

### Description
- Sort each per-row `(column, value)` pair before building `col_idx` and `vals` so `CsrMatrix::from_csr` receives correctly ordered columns; implemented by constructing `row0` and `row1`, calling `sort_by_key`, and assembling the vectors from the sorted tuples in `tests/parallel_reductions.rs`.
- Change is localized to the `dist_matvec_mpi_rayon_stress` test and preserves the original numeric stencil values while ensuring CSR ordering invariants are satisfied.

### Testing
- Ran `cargo test --features=mpi,rayon,backend-faer,logging --test parallel_reductions -- --test-threads=1` and all tests in `parallel_reductions` passed (`21 passed`).
- Ran the full suite with `cargo test --features=mpi,rayon,backend-faer,logging`; the run progressed past `parallel_reductions` but encountered an unrelated MPI runtime failure in `tests/dist_csr.rs` (`MPI_Comm_dup` / `MPI_ERR_INTERN`) so the overall full-featured test run did not complete successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9baa928448329bfd3085b0432b21c)