### PR TITLE
Serialize MPI route selection integration tests

### DIFF
--- a/tests/mpi_route_selection.rs
+++ b/tests/mpi_route_selection.rs
@@ -2,7 +2,7 @@
 
 mod fixtures;
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex, MutexGuard, OnceLock};
 
 use kryst::config::options::{KspOptions, PcOptions};
 use kryst::context::ksp_context::{KspContext, SolverType};
@@ -10,6 +10,14 @@ use kryst::matrix::dist_csr::DistCsrOp;
 use kryst::matrix::sparse::CsrMatrix;
 use kryst::parallel::{Comm, MpiComm, UniverseComm};
 use kryst::utils::convergence::ConvergedReason;
+
+fn mpi_test_guard() -> MutexGuard<'static, ()> {
+    static MPI_TEST_MUTEX: OnceLock<Mutex<()>> = OnceLock::new();
+    MPI_TEST_MUTEX
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .expect("mpi test mutex poisoned")
+}
 
 fn local_rows_from_global(
     global: &CsrMatrix<f64>,
@@ -75,6 +83,7 @@ fn solve_with_pc(
 
 #[test]
 fn mpi_matrix_route_policy_solver_and_pc_combinations() {
+    let _guard = mpi_test_guard();
     let comm = UniverseComm::Mpi(Arc::new(MpiComm::new()));
     if comm.size() <= 1 {
         return;
@@ -142,6 +151,7 @@ fn mpi_matrix_route_policy_solver_and_pc_combinations() {
 
 #[test]
 fn mpi_stress_empty_rank_nnz_imbalance_and_disconnected_partitions() {
+    let _guard = mpi_test_guard();
     let comm = UniverseComm::Mpi(Arc::new(MpiComm::new()));
     if comm.size() <= 1 {
         return;
@@ -253,6 +263,7 @@ fn mpi_stress_empty_rank_nnz_imbalance_and_disconnected_partitions() {
 
 #[test]
 fn mpi_fault_injection_native_setup_failure_and_replay_tokens() {
+    let _guard = mpi_test_guard();
     let comm = UniverseComm::Mpi(Arc::new(MpiComm::new()));
     if comm.size() <= 1 {
         return;


### PR DESCRIPTION
### Motivation
- Prevent intermittent hangs when multiple MPI integration tests in the same test binary run concurrently and their MPI collectives overlap under Rust's parallel test runner.

### Description
- Added a process-local static guard `mpi_test_guard()` in `tests/mpi_route_selection.rs` that returns a `MutexGuard` from a `OnceLock<Mutex<()>>`.
- Imported `Mutex`, `MutexGuard`, and `OnceLock` and acquire the guard at the start of each MPI test in the file to serialize their execution.
- Modified `tests/mpi_route_selection.rs` to call `let _guard = mpi_test_guard();` at the top of `mpi_matrix_route_policy_solver_and_pc_combinations`, `mpi_stress_empty_rank_nnz_imbalance_and_disconnected_partitions`, and `mpi_fault_injection_native_setup_failure_and_replay_tokens`.

### Testing
- Ran `cargo test --features "backend-faer mpi" --test mpi_route_selection mpi_matrix_route_policy_solver_and_pc_combinations -- --nocapture` and it passed.
- Ran `cargo test --features "backend-faer mpi" --test mpi_route_selection -- --nocapture` and it passed (all tests in file OK).
- Ran `cargo test --features "backend-faer mpi" --test mpi_route_selection -- --test-threads=3` to exercise parallel test scheduling and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9bddd866c8329bdf993736c3f856c)