### PR TITLE
Fix nested KSP-as-PC option propagation and scoped overrides

### DIFF
--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -2097,6 +2097,18 @@ impl PcOptions {
         if self.pc_ksp_pc_type.is_some() {
             pc.pc_type = self.pc_ksp_pc_type.clone();
         }
+        if self.pc_ksp_monitor_policy.is_some() {
+            pc.pc_ksp_monitor_policy = self.pc_ksp_monitor_policy.clone();
+        }
+        if self.pc_ksp_inner_tol_policy.is_some() {
+            pc.pc_ksp_inner_tol_policy = self.pc_ksp_inner_tol_policy.clone();
+        }
+        if self.pc_ksp_propagate_converged_reason.is_some() {
+            pc.pc_ksp_propagate_converged_reason = self.pc_ksp_propagate_converged_reason;
+        }
+        if self.pc_ksp_allow_maxits.is_some() {
+            pc.pc_ksp_allow_maxits = self.pc_ksp_allow_maxits;
+        }
         pc
     }
 

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -768,10 +768,16 @@ impl PcConfig {
                 destroy: o.pc_shell_destroy.clone(),
                 context: o.pc_shell_context.clone(),
             },
-            Ksp => PcConfig::Ksp {
-                ksp_options: o.resolved_pc_ksp_ksp_options(),
-                pc_options: o.resolved_pc_ksp_pc_options(),
-            },
+            Ksp => {
+                let mut ksp_options = o.resolved_pc_ksp_ksp_options();
+                if let Some(scoped) = o.pc_ksp_ksp_options.clone() {
+                    ksp_options.overlay_from(scoped);
+                }
+                PcConfig::Ksp {
+                    ksp_options,
+                    pc_options: o.resolved_pc_ksp_pc_options(),
+                }
+            }
             Mg => PcConfig::Mg {
                 levels: o.pc_mg_levels.unwrap_or(2),
                 cycle_type: o.pc_mg_cycle_type.clone(),

--- a/src/preconditioner/ksp_pc/mod.rs
+++ b/src/preconditioner/ksp_pc/mod.rs
@@ -132,10 +132,7 @@ impl KspAsPc {
     }
 
     pub fn new(mut ksp_options: KspOptions, mut pc_options: PcOptions) -> Result<Self, KError> {
-        let mut resolved_ksp = pc_options.resolved_pc_ksp_ksp_options();
-        resolved_ksp.overlay_from(ksp_options.clone());
-        Self::stage_nested_solver_for_variable_local_pc(&mut resolved_ksp, &pc_options);
-        ksp_options = resolved_ksp;
+        Self::stage_nested_solver_for_variable_local_pc(&mut ksp_options, &pc_options);
         if ksp_options.ksp_type.is_none() {
             ksp_options.ksp_type = Some("richardson".to_string());
         }
@@ -163,10 +160,9 @@ impl KspAsPc {
         let drop_tol = self.pc_options.drop_tol.unwrap_or_default();
         let amat = materialize_ref(a, want, drop_tol).ok();
 
-        let mut ksp_opts = self.pc_options.resolved_pc_ksp_ksp_options();
-        ksp_opts.overlay_from(self.ksp_options.clone());
+        let mut ksp_opts = self.ksp_options.clone();
         Self::stage_nested_solver_for_variable_local_pc(&mut ksp_opts, &self.pc_options);
-        let pc_opts = self.pc_options.resolved_pc_ksp_pc_options();
+        let pc_opts = self.pc_options.clone();
         let monitor_rank0 = ksp_opts.ksp_monitor_rank0.unwrap_or(false);
         let allow_maxits_compat = self.pc_options.pc_ksp_inner_tol_policy.is_none()
             && self.pc_options.pc_ksp_allow_maxits.unwrap_or(true);


### PR DESCRIPTION
### Motivation
- Nested KSP-as-PC builds were losing important nested runtime knobs and scoped overrides because the nested KSP options were being re-resolved from the inner PC option bag instead of using the builder-provided nested options.
- This caused runtime behavior/diagnostics tests to fail that expect nested `pc_ksp_*` policies to be preserved and scoped nested `KspOptions` to take precedence.

### Description
- Make `KspAsPc::new` and `configure_nested_ksp` use the passed `KspOptions`/`PcOptions` directly for runtime configuration and cloning, instead of re-resolving nested KSP options from `pc_options` which dropped intended knobs (`src/preconditioner/ksp_pc/mod.rs`).
- Preserve nested KSP policy fields by copying `pc_ksp_monitor_policy`, `pc_ksp_inner_tol_policy`, `pc_ksp_propagate_converged_reason`, and `pc_ksp_allow_maxits` into `resolved_pc_ksp_pc_options` so inner PC runtime diagnostics and tolerance policy are available at runtime (`src/config/options.rs`).
- When constructing `PcConfig::Ksp`, start from `resolved_pc_ksp_ksp_options()` and then overlay explicit scoped `pc_ksp_ksp_options` so an explicit `pc_ksp_ksp_options` object wins over flat `pc_ksp_*` aliases for nested runtime behavior (`src/context/pc_context.rs`).

### Testing
- Ran the targeted tests with `cargo test --features=mpi,rayon,backend-faer,logging --test pc_runtime_new_types ksp_pc_uses_inner_pc_options -- --exact` and it passed.
- Ran the targeted nested-diagnostics test with `cargo test --features=mpi,rayon,backend-faer,logging --test pc_runtime_new_types ksp_pc_failure_reports_nested_diagnostics_consistently -- --exact` and it passed.
- Ran the scoped-overrides test with `cargo test --features=mpi,rayon,backend-faer,logging --test pc_runtime_new_types ksp_pc_scoped_options_override -- --exact` and it passed.
- Ran the whole `pc_runtime_new_types` test file with `cargo test --features=mpi,rayon,backend-faer,logging --test pc_runtime_new_types` and all tests in that file passed (6 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d9c098248883299a3975dc56365943)