### PR TITLE
Normalize FGMRES pc-side to Right and surface requested vs effective side

### DIFF
--- a/docs/petsc_mapping.md
+++ b/docs/petsc_mapping.md
@@ -90,7 +90,7 @@ features, options, and monitoring/convergence hooks.
 | `-ksp_gcr_restart` | [`KspOptions::gcr_restart`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.gcr_restart) | Supported | GCR/PipeGCR restart length. |
 | `-ksp_richardson_omega` | [`KspOptions::richardson_omega`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.richardson_omega) | Supported | Richardson step size. |
 | `-ksp_chebyshev_omega` | [`KspOptions::chebyshev_omega`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.chebyshev_omega) | Partial | Used for Chebyshev-as-KSP. |
-| `-ksp_pc_side` | [`KspOptions::pc_side`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.pc_side) | Supported | `left`/`right`/`symmetric`. |
+| `-ksp_pc_side` | [`KspOptions::pc_side`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.pc_side) | Supported | `left`/`right`/`symmetric` request values; FGMRES normalizes effective side to `right`. |
 | `-ksp_monitor_rank0` | [`KspOptions::ksp_monitor_rank0`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.ksp_monitor_rank0) | Supported | Rank-0 monitor policy. |
 | `-ksp_reduction` | [`KspOptions::reduction`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.reduction) | Supported | Reduction mode (`fast`/`deterministic`). |
 
@@ -143,7 +143,7 @@ features, options, and monitoring/convergence hooks.
 For nested KSP-as-PC, kryst applies side compatibility using the inner Krylov method:
 
 - **Inner GMRES**: `symmetric` is interpreted as `left`.
-- **Inner FGMRES**: `left` and `symmetric` both map to `right`.
+- **Inner FGMRES**: requests `left`/`symmetric`/`right`, but the effective side is always `right` (`left`/`symmetric` are normalized).
 - **Explicit inner side (`-pc_ksp_pc_side`)**: respected for non-symmetric outer requests, and reported as `compatible_override` when it differs from the outer effective side.
 - **Symmetric outer side + conflicting explicit inner side**: rejected with a nested failure (`SolveStats.reason = DivergedPcFailed`) and `nested_pc_failure.detail` includes `compatibility=mismatch`.
 
@@ -281,6 +281,7 @@ MG diagnostics expose the chosen coarse route and resolved fallback chain at the
 For PETSc-like nested workflows, these templates are the most robust defaults in kryst:
 
 - **Outer GMRES/FGMRES + inner KSP-as-PC (Jacobi)**
+  - For inner FGMRES, avoid interpreting this as distinct left-vs-right algorithm families: `left`/`symmetric` are compatibility aliases that normalize to effective `right`.
   - `-pc_type ksp -pc_ksp_ksp_type gmres -pc_ksp_pc_type jacobi`
   - Prefer explicit inner side (`-pc_ksp_pc_side left|right`) when outer side differs.
   - Inner restart precedence follows PETSc-style solver-specific keys: `pc_ksp_gmres_restart` / `pc_ksp_fgmres_restart` then `pc_ksp_restart`.

--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -129,6 +129,9 @@ mod complex_demo {
                 println!(
                     "                    true(explicit) = ||b - A x||₂ recomputed after solve."
                 );
+                println!(
+                    "FGMRES side policy: requested left/symmetric are normalized to effective right preconditioning."
+                );
                 let include_dof_col = matches!(
                     problem.backend,
                     CsrBackend::Serial | CsrBackend::Distributed
@@ -387,7 +390,9 @@ mod complex_demo {
                     }
                     "--restarts" => {
                         let Some(v) = args.next() else {
-                            return Err(KError::InvalidInput("missing value for --restarts".into()));
+                            return Err(KError::InvalidInput(
+                                "missing value for --restarts".into(),
+                            ));
                         };
                         cfg.restarts = parse_usize_csv("--restarts", &v)?;
                     }
@@ -548,14 +553,25 @@ mod complex_demo {
         }
 
         fn method_label(&self) -> String {
+            let effective_side = normalized_fgmres_side(self.pc_side);
+            let side_desc = if effective_side == self.pc_side {
+                format!("{}", pc_side_label(self.pc_side))
+            } else {
+                format!(
+                    "{}→{} (normalized)",
+                    pc_side_label(self.pc_side),
+                    pc_side_label(effective_side)
+                )
+            };
             format!(
-                "FGMRES+{} [m={}, v={}, orth={}, reorth={}, pc={}]",
+                "FGMRES+{} [m={}, v={}, orth={}, reorth={}, pc=requested {}, effective {}]",
                 self.pc.label(),
                 self.restart,
                 variant_label(self.variant),
                 orthog_label(self.orthog),
                 reorth_label(self.reorth),
-                pc_side_label(self.pc_side)
+                pc_side_label(self.pc_side),
+                side_desc,
             )
         }
     }
@@ -599,12 +615,20 @@ mod complex_demo {
         }
     }
 
+    fn normalized_fgmres_side(requested_side: PcSide) -> PcSide {
+        match requested_side {
+            PcSide::Right => PcSide::Right,
+            PcSide::Left | PcSide::Symmetric => PcSide::Right,
+        }
+    }
+
     fn run_once(
         problem: &Problem,
         spec: &RunSpec,
         bench_cfg: &BenchmarkConfig,
     ) -> Result<ResultRow, KError> {
         let b = &problem.rhs;
+        let effective_pc_side = normalized_fgmres_side(spec.pc_side);
         let mut jacobi_pc: Option<Jacobi> = None;
         let setup_start = Instant::now();
         if matches!(spec.pc, PcKind::Jacobi) {
@@ -625,7 +649,7 @@ mod complex_demo {
                     .map(|pc| pc as &mut dyn KPreconditioner<Scalar = S>),
                 b,
                 &mut x,
-                spec.pc_side,
+                effective_pc_side,
                 &problem.comm,
                 None,
                 Some(&mut workspace),
@@ -649,7 +673,7 @@ mod complex_demo {
                     .map(|pc| pc as &mut dyn KPreconditioner<Scalar = S>),
                 b,
                 &mut x,
-                spec.pc_side,
+                effective_pc_side,
                 &problem.comm,
                 None,
                 Some(&mut workspace),

--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -25,7 +25,7 @@
 //! | Solver            | Allowed sides   | Notes                                                   |
 //! |-------------------|-----------------|---------------------------------------------------------|
 //! | `CG`, `PCG`       | Left only       | Requires HPD `A` and HPD left preconditioner `M`.       |
-//! | `FGMRES`          | Left or Right   | Uses right-preconditioned Arnoldi; Left/Symmetric map to Right. |
+//! | `FGMRES`          | Left/Right/Symmetric (requested) | Uses right-preconditioned Arnoldi; effective side is always Right (Left/Symmetric are normalized). |
 //! | `PCA-GMRES`       | Left or Right   | Mapped to [`PcaPcMode`] during setup.                   |
 //! | All other solvers | Left or Right   | `Symmetric` behaves like left but is passed to PCs.     |
 //!
@@ -519,6 +519,13 @@ impl KspContext {
                 s => s,
             },
         }
+    }
+
+    #[inline]
+    fn effective_pc_side(&self) -> PcSide {
+        self.solver_type
+            .map(|st| Self::effective_side_for_solver(self.pc_side, st))
+            .unwrap_or(self.pc_side)
     }
 
     fn parse_reorth_policy(label: &str) -> Result<ReorthPolicy, KError> {
@@ -1601,7 +1608,24 @@ impl KspContext {
         insert_value(&mut solver_config, "dtol", self.dtol);
         insert_value(&mut solver_config, "maxits", self.maxits);
         insert_value(&mut solver_config, "restart", self.restart);
-        insert_value(&mut solver_config, "pc_side", format!("{:?}", self.pc_side));
+        let effective_pc_side = self.effective_pc_side();
+        insert_value(
+            &mut solver_config,
+            "pc_side_requested",
+            format!("{:?}", self.pc_side),
+        );
+        insert_value(
+            &mut solver_config,
+            "pc_side_effective",
+            format!("{:?}", effective_pc_side),
+        );
+        if effective_pc_side != self.pc_side {
+            insert_value(
+                &mut solver_config,
+                "pc_side_note",
+                "normalized to solver-compatible side",
+            );
+        }
         insert_value(
             &mut solver_config,
             "pc_reuse",
@@ -2521,7 +2545,7 @@ impl KspContext {
         {
             let comm = amat.comm();
             log::debug!(
-                "setup start: comm_id={} size={} rank={} dims=({},{}) pc_dims=({},{}) pc_reuse={:?} solver={:?} pc_side={:?} A_ids=({:?},{:?}) P_ids=({:?},{:?})",
+                "setup start: comm_id={} size={} rank={} dims=({},{}) pc_dims=({},{}) pc_reuse={:?} solver={:?} pc_side_requested={:?} pc_side_effective={:?} A_ids=({:?},{:?}) P_ids=({:?},{:?})",
                 comm.id(),
                 comm.size(),
                 comm.rank(),
@@ -2532,6 +2556,7 @@ impl KspContext {
                 self.pc_reuse,
                 self.solver_type,
                 self.pc_side,
+                self.effective_pc_side(),
                 amat.structure_id(),
                 amat.values_id(),
                 pmat.structure_id(),
@@ -2853,7 +2878,7 @@ impl KspContext {
         {
             let comm = amat.comm();
             log::debug!(
-                "solve start: comm_id={} size={} rank={} dims=({},{}) rhs_len={} x_len={} solver={:?} pc_side={:?} pc_reuse={:?} A_ids=({:?},{:?}) P_ids=({:?},{:?})",
+                "solve start: comm_id={} size={} rank={} dims=({},{}) rhs_len={} x_len={} solver={:?} pc_side_requested={:?} pc_side_effective={:?} pc_reuse={:?} A_ids=({:?},{:?}) P_ids=({:?},{:?})",
                 comm.id(),
                 comm.size(),
                 comm.rank(),
@@ -2863,6 +2888,7 @@ impl KspContext {
                 x.len(),
                 self.solver_type,
                 self.pc_side,
+                self.effective_pc_side(),
                 self.pc_reuse,
                 amat.structure_id(),
                 amat.values_id(),
@@ -3074,7 +3100,7 @@ impl KspContext {
                             pc_k.as_deref_mut(),
                             b,
                             x,
-                            self.pc_side,
+                            self.effective_pc_side(),
                             &comm,
                             monitors,
                             work,
@@ -4030,10 +4056,7 @@ impl KspContext {
 
     /// Configure the underlying solver based on the requested preconditioning side.
     fn configure_pc_side(&mut self) -> Result<(), KError> {
-        let side = self
-            .solver_type
-            .map(|st| Self::effective_side_for_solver(self.pc_side, st))
-            .unwrap_or(self.pc_side);
+        let side = self.effective_pc_side();
 
         if let Some(SolverType::PcaGmres) = self.solver_type {
             if let Some(s) = self
@@ -4696,6 +4719,21 @@ mod tests {
         ksp.set_pc_side(PcSide::Right);
         ksp.set_type(SolverType::Fgmres).unwrap();
         ksp.try_set_pc_side(PcSide::Left).unwrap();
+    }
+
+    #[test]
+    fn fgmres_effective_side_is_always_right() {
+        let mut ksp = KspContext::new();
+        ksp.set_type(SolverType::Fgmres).unwrap();
+
+        ksp.try_set_pc_side(PcSide::Left).unwrap();
+        assert_eq!(ksp.effective_pc_side(), PcSide::Right);
+
+        ksp.try_set_pc_side(PcSide::Symmetric).unwrap();
+        assert_eq!(ksp.effective_pc_side(), PcSide::Right);
+
+        ksp.try_set_pc_side(PcSide::Right).unwrap();
+        assert_eq!(ksp.effective_pc_side(), PcSide::Right);
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Ensure FGMRES always uses the solver-compatible (right) preconditioning side even when users request `Left` or `Symmetric`, and make that normalization visible to users and diagnostics.
- Avoid misleading wording in docs and examples that imply distinct left/right algorithm families for FGMRES.

### Description
- Normalize FGMRES side handling by introducing `effective_pc_side()` and dispatching the effective side to the FGMRES solve path so requested `Left`/`Symmetric` map to effective `Right` at solve time.  (`src/context/ksp_context/mod.rs`).
- Emit both requested and effective side in KSP diagnostics and invariant debug logs by adding `pc_side_requested`, `pc_side_effective`, and a `pc_side_note` when normalization occurs. (`KspContext::view()` and invariants logging). 
- Update the `complex_matrix_market_demo` example to print the normalization policy, show method labels with requested→effective side, and call solves with the normalized FGMRES side. (`examples/complex_matrix_market_demo.rs`).
- Revise `docs/petsc_mapping.md` wording to clarify that `left`/`symmetric` are request aliases normalized to effective `right` for FGMRES and to avoid implying distinct left/right FGMRES modes. 
- Add a unit test `fgmres_effective_side_is_always_right` to assert that requested `Left`, `Symmetric`, and `Right` all produce an effective `Right` for FGMRES. (`src/context/ksp_context/mod.rs` tests). 

### Testing
- Ran formatting with `cargo fmt -- src/context/ksp_context/mod.rs examples/complex_matrix_market_demo.rs` which completed successfully. 
- Ran the new unit test with `cargo test -q fgmres_effective_side_is_always_right --lib` which passed. 
- Ran `cargo check -q --example complex_matrix_market_demo --features complex` which completed successfully (compile warnings pre-existed and are unchanged).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ec951e848329a2d53b6965ac5bc8)