### PR TITLE
Clarify FGMRES orthogonalization labels and docs

### DIFF
--- a/docs/petsc_mapping.md
+++ b/docs/petsc_mapping.md
@@ -85,8 +85,8 @@ features, options, and monitoring/convergence hooks.
 | `-ksp_dtol` | [`KspOptions::dtol`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.dtol) | Supported | Divergence tolerance. |
 | `-ksp_max_it` | [`KspOptions::maxits`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.maxits) | Supported | Max iterations. |
 | `-ksp_restart` | [`KspOptions::restart`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.restart) | Supported | GMRES/GCR restart length. |
-| `-ksp_gmres_*` | [`KspOptions::gmres_*`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html) | Supported | Orthog/reorthog/variant/s-step. |
-| `-ksp_fgmres_*` | [`KspOptions::fgmres_*`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html) | Supported | Orthog/reorthog/variant. |
+| `-ksp_gmres_*` | [`KspOptions::gmres_*`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html) | Supported | Orthog/reorthog/variant/s-step (`cgs` = Classical GS, `mgs` = Modified GS). |
+| `-ksp_fgmres_*` | [`KspOptions::fgmres_*`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html) | Supported | Orthog/reorthog/variant (`cgs`/`classical` and `cgs_refined` for CGS + refinement). |
 | `-ksp_gcr_restart` | [`KspOptions::gcr_restart`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.gcr_restart) | Supported | GCR/PipeGCR restart length. |
 | `-ksp_richardson_omega` | [`KspOptions::richardson_omega`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.richardson_omega) | Supported | Richardson step size. |
 | `-ksp_chebyshev_omega` | [`KspOptions::chebyshev_omega`](https://docs.rs/kryst/latest/kryst/config/options/struct.KspOptions.html#structfield.chebyshev_omega) | Partial | Used for Chebyshev-as-KSP. |

--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -474,9 +474,9 @@ mod complex_demo {
     fn parse_orthog(token: &str) -> Result<Orthog, KError> {
         match token.trim().to_ascii_lowercase().as_str() {
             "classical" | "cgs" => Ok(Orthog::Classical),
-            "modified" | "mgs" => Ok(Orthog::Modified),
+            "cgs_refined" | "cgs-refined" | "refined" => Ok(Orthog::CgsRefined),
             other => Err(KError::InvalidInput(format!(
-                "invalid orthog '{other}', expected classical|cgs|modified|mgs"
+                "invalid orthog '{other}', expected classical|cgs|cgs_refined"
             ))),
         }
     }
@@ -594,8 +594,8 @@ mod complex_demo {
 
     fn orthog_label(orthog: Orthog) -> &'static str {
         match orthog {
-            Orthog::Classical => "classical",
-            Orthog::Modified => "modified",
+            Orthog::Classical => "classical-gs",
+            Orthog::CgsRefined => "cgs-with-refinement",
         }
     }
 

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -108,7 +108,7 @@ pub struct KspOptions {
 
     /// Override restart for FGMRES; falls back to `restart` if unset
     pub fgmres_restart: Option<usize>,
-    /// Orthogonalization method for FGMRES: "mgs" | "cgs"
+    /// Orthogonalization method for FGMRES: "cgs" | "classical" | "cgs_refined"
     pub fgmres_orthog: Option<String>,
     /// If true, perform a second orthogonalization pass (reorthogonalization)
     pub fgmres_reorthog: Option<bool>,

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -159,7 +159,7 @@ pub static SPECS: &[Spec] = &[
         key: "ksp_fgmres_orthog",
         arity: Arity::One,
         kind: ValueKind::Str,
-        doc: "FGMRES orthog: mgs|cgs",
+        doc: "FGMRES orthog: cgs|classical|cgs_refined",
     },
     Spec {
         flag: "-ksp_fgmres_reorth",
@@ -1246,7 +1246,7 @@ pub static SPECS: &[Spec] = &[
         key: "pc_ksp_fgmres_orthog",
         arity: Arity::One,
         kind: ValueKind::Str,
-        doc: "inner FGMRES orthogonalization method",
+        doc: "inner FGMRES orthog: cgs|classical|cgs_refined",
     },
     Spec {
         flag: "-pc_ksp_monitor_rank0",

--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -1224,14 +1224,16 @@ impl KspContext {
                 self.restart = r;
                 self.pending_fgmres.restart = Some(r);
             }
-            // Map "mgs"/"cgs" to Modified/Classical
+            // Map FGMRES orthogonalization labels to implemented algorithms.
             if let Some(ref orth) = opts.fgmres_orthog {
                 let o = match orth.as_str() {
-                    "mgs" | "modified" => crate::solver::fgmres::Orthog::Modified,
                     "cgs" | "classical" => crate::solver::fgmres::Orthog::Classical,
+                    "cgs_refined" | "cgs-refined" | "refined" => {
+                        crate::solver::fgmres::Orthog::CgsRefined
+                    }
                     other => {
                         return Err(KError::SolveError(format!(
-                            "Unrecognized ksp_fgmres_orthog: {other} (expected 'mgs'|'modified'|'cgs'|'classical')"
+                            "Unrecognized ksp_fgmres_orthog: {other} (expected 'cgs'|'classical'|'cgs_refined')"
                         )));
                     }
                 };
@@ -1278,11 +1280,13 @@ impl KspContext {
             }
             if let Some(ref orth) = opts.fgmres_orthog {
                 self.pending_fgmres.orthog = Some(match orth.as_str() {
-                    "mgs" | "modified" => crate::solver::fgmres::Orthog::Modified,
                     "cgs" | "classical" => crate::solver::fgmres::Orthog::Classical,
+                    "cgs_refined" | "cgs-refined" | "refined" => {
+                        crate::solver::fgmres::Orthog::CgsRefined
+                    }
                     other => {
                         return Err(KError::SolveError(format!(
-                            "Unrecognized ksp_fgmres_orthog: {other} (expected 'mgs'|'modified'|'cgs'|'classical')"
+                            "Unrecognized ksp_fgmres_orthog: {other} (expected 'cgs'|'classical'|'cgs_refined')"
                         )));
                     }
                 });
@@ -4880,6 +4884,28 @@ mod tests {
         assert_eq!(s.variant, FgmresVariant::Pipelined);
         assert!(matches!(s.reorth, ReorthPolicy::Never));
         assert!((s.reorth_tol - 0.42).abs() < 1e-12);
+    }
+
+    #[cfg(not(feature = "complex"))]
+    #[test]
+    fn fgmres_orthog_cgs_refined_maps_cleanly() {
+        use crate::solver::fgmres::{FgmresSolver, Orthog};
+        let mut ksp = KspContext::new();
+        ksp.set_type(SolverType::Fgmres).unwrap();
+        let opts = KspOptions {
+            fgmres_orthog: Some("cgs_refined".into()),
+            ..Default::default()
+        };
+        ksp.set_from_options(&opts).unwrap();
+        let s = ksp
+            .solver
+            .as_mut()
+            .unwrap()
+            .as_any_mut()
+            .downcast_mut::<FgmresSolver>()
+            .unwrap();
+        let (_, orth, _, _) = s.debug_config();
+        assert_eq!(orth, Orthog::CgsRefined);
     }
 
     #[cfg(feature = "complex")]

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -29,8 +29,10 @@ use std::any::Any;
 /// Orthogonalization flavor
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum Orthog {
+    /// One-shot Classical Gram-Schmidt (CGS) projection.
     Classical,
-    Modified,
+    /// CGS with an immediate corrective refinement pass.
+    CgsRefined,
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -377,7 +379,7 @@ impl FgmresSolver {
                                 }
                             }
                         }
-                        if matches!(self.orthog, Orthog::Modified) {
+                        if matches!(self.orthog, Orthog::CgsRefined) {
                             let mut corr: SmallVec<[S; 32]> = SmallVec::with_capacity(j + 1);
                             corr.resize(j + 1, S::zero());
                             {


### PR DESCRIPTION
### Motivation
- The FGMRES code used a `Modified` label while actually implementing Classical Gram-Schmidt (CGS) plus an immediate correction/refinement pass, which is misleading for users and options parsing.
- Aligning option names and docs with the implemented behavior prevents confusion and ensures CLI labels map cleanly to solver branches.

### Description
- Renamed the internal FGMRES orthog branch from `Orthog::Modified` to `Orthog::CgsRefined` to reflect that the implementation is CGS plus a corrective/refinement pass, not true MGS (file `src/solver/fgmres.rs`).
- Updated KSP option parsing in `src/context/ksp_context/mod.rs` so `-ksp_fgmres_orthog` accepts `cgs`/`classical` → `Orthog::Classical` and `cgs_refined`/`cgs-refined`/`refined` → `Orthog::CgsRefined`, and removed the misleading `mgs`/`modified` alias for FGMRES.
- Adjusted the options registry/help text in `src/config/options.rs` and `src/config/registry.rs` and the PETSc mapping doc in `docs/petsc_mapping.md` to advertise the new FGMRES labels (`cgs`/`classical` and `cgs_refined`).
- Updated example run parsing/labels in `examples/complex_matrix_market_demo.rs` to accept and print `cgs_refined` as `cgs-with-refinement` and to show `classical-gs` for the classical mapping.
- Added a unit test in `src/context/ksp_context/mod.rs` verifying that `cgs_refined` maps to `Orthog::CgsRefined`.

### Testing
- Ran code formatting with `cargo fmt --all` which completed successfully.
- Ran the library unit test `cargo test -q fgmres_options_apply --lib` which passed (`1 passed`).
- Ran the added mapping test `cargo test -q fgmres_orthog_cgs_refined_maps_cleanly --lib` which passed (`1 passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e3ff7053048329834c4b01c0ae1eca)