### PR TITLE
FGMRES: canonical final residual and populate optional residual stats

### DIFF
--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -315,6 +315,7 @@ impl FgmresSolver {
         } else {
             red.norm2(&ws.tmp1[..n])
         };
+        stats.final_residual = true_res;
         stats.final_true_residual = Some(true_res);
         stats.last_preconditioned_residual = Some(precond_res);
         log_residuals(
@@ -582,10 +583,32 @@ impl FgmresSolver {
                         overlap_global_reductions: async_waits,
                         residual_replacements: async_waits,
                     };
+                    let true_res = recompute_true_residual_norm_s(
+                        a,
+                        b,
+                        x,
+                        comm,
+                        red.engine(),
+                        &mut ws.tmp1[..n],
+                        &mut ws.bridge,
+                    );
+                    let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
+                        pc_ref.apply_mut_s(
+                            pc_apply_side,
+                            &ws.tmp1[..n],
+                            &mut ws.tmp2[..n],
+                            &mut ws.bridge,
+                        )?;
+                        red.norm2(&ws.tmp2[..n])
+                    } else {
+                        red.norm2(&ws.tmp1[..n])
+                    };
                     let mut stats =
-                        SolveStats::new(total_iters, res, ConvergedReason::StoppedByMonitor)
+                        SolveStats::new(total_iters, true_res, ConvergedReason::StoppedByMonitor)
                             .with_counters(counters);
                     stats.final_recurrence_residual = Some(res);
+                    stats.final_true_residual = Some(true_res);
+                    stats.last_preconditioned_residual = Some(precond_res);
                     return Ok(stats);
                 }
 
@@ -837,7 +860,8 @@ impl FgmresSolver {
         }
 
         stats.iterations = total_iters;
-        let true_res = stats.final_residual;
+        let true_res = stats.final_true_residual.unwrap_or(stats.final_residual);
+        stats.final_residual = true_res;
 
         if matches!(stats.reason, ConvergedReason::Continued) {
             stats.reason = if true_res <= self.atol {

--- a/src/solver/tests/sync_counts.rs
+++ b/src/solver/tests/sync_counts.rs
@@ -202,6 +202,12 @@ fn pipegcr_matches_pipelined_fgmres_convergence_on_nonsymmetric_system() -> Resu
 
     assert!(baseline_stats.reason.is_converged());
     assert_eq!(
+        baseline_stats.final_true_residual,
+        Some(baseline_stats.final_residual)
+    );
+    assert!(baseline_stats.final_recurrence_residual.is_some());
+    assert!(baseline_stats.last_preconditioned_residual.is_some());
+    assert_eq!(
         gcr_stats.reason.is_converged(),
         baseline_stats.reason.is_converged()
     );
@@ -256,6 +262,12 @@ fn pipegcr_reports_sync_count_parity_with_alias_baseline() -> Result<(), KError>
         .gcr_counters
         .as_ref()
         .expect("PipeGCR must populate GCR counters");
+    assert_eq!(
+        baseline_stats.final_true_residual,
+        Some(baseline_stats.final_residual)
+    );
+    assert!(baseline_stats.final_recurrence_residual.is_some());
+    assert!(baseline_stats.last_preconditioned_residual.is_some());
     assert_eq!(gcr.sync_count, gcr_stats.counters.num_global_reductions);
     let delta = gcr_stats
         .counters


### PR DESCRIPTION
### Motivation
- Make solver statistics richer and canonical by ensuring `final_residual` prefers the explicit true residual when available and surface recurrence/preconditioned residuals for diagnostics. 
- Preserve existing `SolveStats` construction/usage so callers remain backward-compatible while adding optional fields for improved monitoring and analysis.

### Description
- Ensure `SolveStats<R>` optional fields (`final_recurrence_residual`, `final_true_residual`, `last_preconditioned_residual`) default to `None` and remain preserved by existing constructors in `src/utils/convergence.rs` (no breaking changes to `new`/`with_counters`/`with_reduction_model`).
- In `src/solver/fgmres.rs` populate `final_true_residual` and `last_preconditioned_residual` at initial and inner-monitor early-stop points and set `final_recurrence_residual` where the recurrence value is known.
- Canonicalize `stats.final_residual` to the true residual when available by assigning `stats.final_residual = stats.final_true_residual.unwrap_or(stats.final_residual)` at finalization points in the `FGMRES` code paths.
- Update FGMRES-related test assertions in `src/solver/tests/sync_counts.rs` to validate `final_true_residual`, `final_recurrence_residual`, and `last_preconditioned_residual` for the FGMRES baseline paths.

### Testing
- Ran `cargo test -q pipegcr_matches_pipelined_fgmres_convergence_on_nonsymmetric_system` and it passed.
- Ran `cargo test -q pipegcr_reports_sync_count_parity_with_alias_baseline` and it passed.
- Ran `cargo test -q fgmres_near_zero_subdiag` (covers the happy-breakdown enabled/disabled FGMRES tests) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e413dd675883299cfce23885fb302d)