### PR TITLE
Enforce right-only PC side contract for FGMRES

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -1033,6 +1033,16 @@ impl KspContext {
         if let Some(restart) = opts.restart {
             self.restart = restart;
         }
+        if let (Some(SolverType::Fgmres), Some(side_label)) =
+            (requested_solver_type, opts.pc_side.as_ref())
+        {
+            let parsed_side = PcSide::from_str(side_label)?;
+            if parsed_side != PcSide::Right {
+                return Err(KError::InvalidInput(format!(
+                    "FGMRES supports only right preconditioning; got {parsed_side:?} from -ksp_pc_side={side_label}"
+                )));
+            }
+        }
         if let Some(st) = requested_solver_type {
             self.set_type(st)?;
         } else if scalar_solver_config_changed {

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -182,7 +182,6 @@ impl FgmresSolver {
                 "FGMRES supports only right preconditioning; got {pc_side:?}"
             )));
         }
-        let pc_apply_side = PcSide::Right;
 
         let block_m = if self.preallocate {
             self.restart.min(self.maxits)
@@ -273,12 +272,7 @@ impl FgmresSolver {
                 &mut ws.bridge,
             );
             let last_preconditioned_residual = if let Some(pc_ref) = pc.as_deref_mut() {
-                pc_ref.apply_mut_s(
-                    pc_apply_side,
-                    &ws.tmp1[..n],
-                    &mut ws.tmp2[..n],
-                    &mut ws.bridge,
-                )?;
+                pc_ref.apply_mut_s(pc_side, &ws.tmp1[..n], &mut ws.tmp2[..n], &mut ws.bridge)?;
                 Some(red.norm2(&ws.tmp2[..n]))
             } else {
                 Some(red.norm2(&ws.tmp1[..n]))
@@ -305,12 +299,7 @@ impl FgmresSolver {
             &mut ws.bridge,
         );
         let precond_res = if let Some(pc) = pc.as_deref_mut() {
-            pc.apply_mut_s(
-                pc_apply_side,
-                &ws.tmp1[..n],
-                &mut ws.tmp2[..n],
-                &mut ws.bridge,
-            )?;
+            pc.apply_mut_s(pc_side, &ws.tmp1[..n], &mut ws.tmp2[..n], &mut ws.bridge)?;
             red.norm2(&ws.tmp2[..n])
         } else {
             red.norm2(&ws.tmp1[..n])
@@ -377,7 +366,7 @@ impl FgmresSolver {
                             #[cfg(feature = "metrics")]
                             let pc_start = std::time::Instant::now();
                             pc_ref.apply_mut_s(
-                                pc_apply_side,
+                                pc_side,
                                 &ws.tmp1[..n],
                                 &mut ws.tmp2[..n],
                                 &mut ws.bridge,
@@ -483,7 +472,7 @@ impl FgmresSolver {
                             #[cfg(feature = "metrics")]
                             let pc_start = std::time::Instant::now();
                             pc_ref.apply_mut_s(
-                                pc_apply_side,
+                                pc_side,
                                 &ws.tmp1[..n],
                                 &mut ws.tmp2[..n],
                                 &mut ws.bridge,
@@ -594,7 +583,7 @@ impl FgmresSolver {
                     );
                     let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
                         pc_ref.apply_mut_s(
-                            pc_apply_side,
+                            pc_side,
                             &ws.tmp1[..n],
                             &mut ws.tmp2[..n],
                             &mut ws.bridge,
@@ -650,7 +639,7 @@ impl FgmresSolver {
                     stats.final_recurrence_residual = Some(res);
                     let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
                         pc_ref.apply_mut_s(
-                            pc_apply_side,
+                            pc_side,
                             &ws.tmp1[..n],
                             &mut ws.tmp2[..n],
                             &mut ws.bridge,
@@ -726,7 +715,7 @@ impl FgmresSolver {
                     stats.final_recurrence_residual = Some(res);
                     let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
                         pc_ref.apply_mut_s(
-                            pc_apply_side,
+                            pc_side,
                             &ws.tmp1[..n],
                             &mut ws.tmp2[..n],
                             &mut ws.bridge,
@@ -774,12 +763,7 @@ impl FgmresSolver {
                 &mut ws.bridge,
             );
             let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
-                pc_ref.apply_mut_s(
-                    pc_apply_side,
-                    &ws.tmp1[..n],
-                    &mut ws.tmp2[..n],
-                    &mut ws.bridge,
-                )?;
+                pc_ref.apply_mut_s(pc_side, &ws.tmp1[..n], &mut ws.tmp2[..n], &mut ws.bridge)?;
                 red.norm2(&ws.tmp2[..n])
             } else {
                 red.norm2(&ws.tmp1[..n])

--- a/tests/fgmres_flexible.rs
+++ b/tests/fgmres_flexible.rs
@@ -88,3 +88,34 @@ fn fgmres_solver_rejects_non_right_pc_side() {
         other => panic!("unexpected error: {other:?}"),
     }
 }
+
+#[test]
+fn fgmres_solver_rejects_symmetric_pc_side() {
+    let hits = Arc::new(AtomicUsize::new(0));
+    let mut pc = MutableCountPc { hits };
+
+    let a = faer::Mat::<f64>::from_fn(2, 2, |i, j| if i == j { 1.0 } else { 0.0 });
+    let mut solver = FgmresSolver::new(1e-6, 10, 2);
+    let b = [1.0f64, 2.0];
+    let mut x = [0.0f64; 2];
+    let mut work = Workspace::new(2);
+    let err = solver
+        .solve_f64(
+            &a,
+            Some(&mut pc),
+            &b,
+            &mut x,
+            PcSide::Symmetric,
+            &UniverseComm::NoComm(kryst::parallel::NoComm),
+            None,
+            Some(&mut work),
+        )
+        .expect_err("FGMRES must reject symmetric PC side");
+    match err {
+        KError::InvalidInput(msg) => {
+            assert!(msg.contains("FGMRES"));
+            assert!(msg.to_lowercase().contains("right preconditioning"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}

--- a/tests/fgmres_ksp.rs
+++ b/tests/fgmres_ksp.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use faer::Mat;
 use kryst::algebra::prelude::*;
 use kryst::assert_vec_close;
+use kryst::config::options::KspOptions;
 use kryst::context::ksp_context::{KspContext, SolverType};
 use kryst::context::pc_context::PcType;
 use kryst::error::KError;
@@ -100,6 +101,24 @@ fn fgmres_rejects_non_right_side_via_api() {
         KError::InvalidInput(msg) => {
             assert!(msg.contains("FGMRES"));
             assert!(msg.to_lowercase().contains("right preconditioning"));
+        }
+        other => panic!("unexpected error: {other:?}"),
+    }
+}
+
+#[test]
+fn fgmres_set_from_options_rejects_non_right_pc_side() {
+    let opts = KspOptions::from_args(&["-ksp_type", "fgmres", "-ksp_pc_side", "left"])
+        .expect("options should parse");
+    let mut ksp = KspContext::new();
+    let err = ksp
+        .set_from_options(&opts)
+        .expect_err("FGMRES options must reject non-right sides");
+    match err {
+        KError::InvalidInput(msg) => {
+            assert!(msg.contains("FGMRES"));
+            assert!(msg.to_lowercase().contains("right preconditioning"));
+            assert!(msg.contains("-ksp_pc_side"));
         }
         other => panic!("unexpected error: {other:?}"),
     }


### PR DESCRIPTION
### Motivation
- Replace the previous implicit/coerced preconditioner-side behavior for FGMRES with a deterministic contract to avoid silent coercions and ambiguous runtime semantics.
- Ensure option parsing and solver dispatch produce clear, deterministic errors when an incompatible `pc_side` is requested for FGMRES.

### Description
- Enforce strict right-only validation in `FgmresSolver::solve_k` by rejecting any `pc_side` other than `PcSide::Right` and remove the separate `pc_apply_side` coercion variable so preconditioner `apply`/`apply_mut` calls use the validated caller-provided side directly (`src/solver/fgmres.rs`).
- Add a deterministic options-dispatch guard in `KspContext::set_from_options` that parses `-ksp_pc_side` and returns a clear `KError::InvalidInput` if `-ksp_type fgmres` is requested with a non-right side (`src/context/ksp_context/mod.rs`).
- Add and adjust tests to cover the right-only contract: `tests/fgmres_ksp.rs` now includes `fgmres_set_from_options_rejects_non_right_pc_side`, and `tests/fgmres_flexible.rs` includes `fgmres_solver_rejects_symmetric_pc_side` in addition to existing checks.

### Testing
- Ran `cargo fmt` successfully to normalize formatting.
- Ran `cargo test --test fgmres_ksp --test fgmres_flexible` and both targeted test binaries passed (`6 tests` across the two suites passed).
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e5742fe3ac8329b5ecae877c43719e)