### PR TITLE
FGMRES: detect Arnoldi rank-loss & report orthogonality diagnostics

### DIFF
--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -170,7 +170,13 @@ impl FgmresSolver {
         }
     }
 
-    fn orthogonalize_cgs(&self, ws: &mut Workspace, red: &ReductCtx, n: usize, j: usize) -> R {
+    fn orthogonalize_cgs(
+        &self,
+        ws: &mut Workspace,
+        red: &ReductCtx,
+        n: usize,
+        j: usize,
+    ) -> (R, bool) {
         let wnorm0 = if matches!(self.cgs_refinement_mode(), CgsRefinement::IfNeeded) {
             red.norm2(&ws.tmp2[..n])
         } else {
@@ -195,7 +201,8 @@ impl FgmresSolver {
         }
 
         let mut hnext = red.norm2(&ws.tmp2[..n]);
-        if self.should_run_cgs_refinement(wnorm0, hnext) {
+        let ran_refinement = self.should_run_cgs_refinement(wnorm0, hnext);
+        if ran_refinement {
             let mut corr: SmallVec<[S; 32]> = SmallVec::with_capacity(j + 1);
             corr.resize(j + 1, S::zero());
             {
@@ -219,10 +226,16 @@ impl FgmresSolver {
         for i in 0..=j {
             *ws.h_at_mut(i, j) = hvals[i];
         }
-        hnext
+        (hnext, ran_refinement)
     }
 
-    fn orthogonalize_mgs(&self, ws: &mut Workspace, red: &ReductCtx, n: usize, j: usize) -> R {
+    fn orthogonalize_mgs(
+        &self,
+        ws: &mut Workspace,
+        red: &ReductCtx,
+        n: usize,
+        j: usize,
+    ) -> (R, bool) {
         for i in 0..=j {
             let hij = red.dot(&ws.v_mem[i * n..(i + 1) * n], &ws.tmp2[..n]);
             *ws.h_at_mut(i, j) = hij;
@@ -231,7 +244,7 @@ impl FgmresSolver {
                 *w_i -= hij * vi_val;
             }
         }
-        red.norm2(&ws.tmp2[..n])
+        (red.norm2(&ws.tmp2[..n]), false)
     }
 
     // legacy helpers for in-place Givens rotations removed; Workspace now handles
@@ -337,6 +350,9 @@ impl FgmresSolver {
             .unwrap_or_else(|| comm.reduction_engine(ws.reduction_options()));
         let mut pipeline_reductions = 0usize;
         let mut async_waits = 0usize;
+        let mut orthogonalization_passes = 0usize;
+        let mut orthogonalization_rank_loss = false;
+        let mut max_orthogonality_loss_estimate = R::zero();
         let start_reduct = crate::utils::reduction::test_hooks::wait_counters();
 
         #[cfg(feature = "logging")]
@@ -370,7 +386,12 @@ impl FgmresSolver {
                 residual_replacements: async_waits,
             };
             let mut stats = SolveStats::new(0, true_res, ConvergedReason::StoppedByMonitor)
-                .with_counters(counters);
+                .with_counters(counters)
+                .with_orthogonalization_diagnostics(
+                    orthogonalization_passes,
+                    orthogonalization_rank_loss,
+                    max_orthogonality_loss_estimate,
+                );
             stats.final_recurrence_residual = Some(res);
             stats.final_true_residual = Some(true_res);
             stats.last_preconditioned_residual = last_preconditioned_residual;
@@ -427,7 +448,11 @@ impl FgmresSolver {
                 metrics.reductions = reductions;
                 stats.metrics = metrics;
             }
-            return Ok(stats);
+            return Ok(stats.with_orthogonalization_diagnostics(
+                orthogonalization_passes,
+                orthogonalization_rank_loss,
+                max_orthogonality_loss_estimate,
+            ));
         }
 
         let mut stagnation_residuals: Vec<R> = Vec::with_capacity(6);
@@ -476,10 +501,12 @@ impl FgmresSolver {
                             metrics.matvec_nanos += matvec_start.elapsed().as_nanos() as u64;
                         }
 
-                        let hij1 = match self.orthog {
+                        let wnorm_before = red.norm2(&ws.tmp2[..n]);
+                        let (hij1, used_second_pass) = match self.orthog {
                             OrthogMethod::ClassicalGS => self.orthogonalize_cgs(ws, &red, n, j),
                             OrthogMethod::ModifiedGS => self.orthogonalize_mgs(ws, &red, n, j),
                         };
+                        orthogonalization_passes += 1 + usize::from(used_second_pass);
                         #[cfg(feature = "metrics")]
                         {
                             let dot_reductions = match (self.orthog, self.cgs_refinement_mode()) {
@@ -491,6 +518,13 @@ impl FgmresSolver {
                             metrics.bytes_reduced += dot_reductions * std::mem::size_of::<R>();
                         }
                         *ws.h_at_mut(j + 1, j) = S::from_real(hij1);
+                        if wnorm_before > R::zero() {
+                            let ratio = (hij1 / wnorm_before).clamp(R::zero(), R::one());
+                            let loss_estimate = (R::one() - ratio).max(R::zero());
+                            if loss_estimate > max_orthogonality_loss_estimate {
+                                max_orthogonality_loss_estimate = loss_estimate;
+                            }
+                        }
 
                         if hij1 > R::default() {
                             let inv = S::from_real(1.0 / hij1);
@@ -565,6 +599,10 @@ impl FgmresSolver {
                             }
                         };
                         pipeline_reductions += reductions;
+                        orthogonalization_passes += match self.reorth {
+                            ReorthPolicy::Always => 2,
+                            _ => 1,
+                        };
                         #[cfg(feature = "metrics")]
                         {
                             let payload_len = ws.pipelined_payload.len();
@@ -575,6 +613,12 @@ impl FgmresSolver {
                 }
 
                 let h_subdiag = ws.h_at(j + 1, j).abs();
+                if h_subdiag <= self.haptol {
+                    let loss_estimate = R::one();
+                    if loss_estimate > max_orthogonality_loss_estimate {
+                        max_orthogonality_loss_estimate = loss_estimate;
+                    }
+                }
                 if self.happy_breakdown && h_subdiag <= self.haptol {
                     *ws.h_at_mut(j + 1, j) = S::zero();
                     ws.apply_prev_givens_to_col(j, j);
@@ -584,6 +628,45 @@ impl FgmresSolver {
                     arnoldi_steps = j + 1;
                     converged = true;
                     converged_reason = Some(ConvergedReason::ConvergedHappyBreakdown);
+                    break;
+                }
+                if h_subdiag <= self.haptol {
+                    orthogonalization_rank_loss = true;
+                    let true_res = recompute_true_residual_norm_s(
+                        a,
+                        b,
+                        x,
+                        comm,
+                        red.engine(),
+                        &mut ws.tmp1[..n],
+                        &mut ws.bridge,
+                    );
+                    stats = SolveStats::new(
+                        total_iters,
+                        true_res,
+                        ConvergedReason::DivergedArnoldiRankLoss,
+                    )
+                    .with_orthogonalization_diagnostics(
+                        orthogonalization_passes,
+                        orthogonalization_rank_loss,
+                        max_orthogonality_loss_estimate,
+                    );
+                    stats.final_true_residual = Some(true_res);
+                    stats.final_recurrence_residual = Some(res);
+                    let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
+                        pc_ref.apply_mut_s(
+                            pc_side,
+                            &ws.tmp1[..n],
+                            &mut ws.tmp2[..n],
+                            &mut ws.bridge,
+                        )?;
+                        red.norm2(&ws.tmp2[..n])
+                    } else {
+                        red.norm2(&ws.tmp1[..n])
+                    };
+                    stats.last_preconditioned_residual = Some(precond_res);
+                    converged = true;
+                    converged_reason = Some(ConvergedReason::DivergedArnoldiRankLoss);
                     break;
                 }
 
@@ -631,7 +714,12 @@ impl FgmresSolver {
                     };
                     let mut stats =
                         SolveStats::new(total_iters, true_res, ConvergedReason::StoppedByMonitor)
-                            .with_counters(counters);
+                            .with_counters(counters)
+                            .with_orthogonalization_diagnostics(
+                                orthogonalization_passes,
+                                orthogonalization_rank_loss,
+                                max_orthogonality_loss_estimate,
+                            );
                     stats.final_recurrence_residual = Some(res);
                     stats.final_true_residual = Some(true_res);
                     stats.last_preconditioned_residual = Some(precond_res);
@@ -686,6 +774,11 @@ impl FgmresSolver {
                         red.norm2(&ws.tmp1[..n])
                     };
                     stats.last_preconditioned_residual = Some(precond_res);
+                    stats = stats.with_orthogonalization_diagnostics(
+                        orthogonalization_passes,
+                        orthogonalization_rank_loss,
+                        max_orthogonality_loss_estimate,
+                    );
                     converged = true;
                     break;
                 }
@@ -746,7 +839,7 @@ impl FgmresSolver {
                         &mut ws.bridge,
                     );
                     let reason = ConvergedReason::from_non_finite(diag.real())
-                        .unwrap_or(ConvergedReason::DivergedBreakdown);
+                        .unwrap_or(ConvergedReason::DivergedReducedSystemSingular);
                     stats = SolveStats::new(total_iters, true_res, reason);
                     stats.final_true_residual = Some(true_res);
                     stats.final_recurrence_residual = Some(res);
@@ -770,7 +863,13 @@ impl FgmresSolver {
                         overlap_global_reductions: async_waits,
                         residual_replacements: async_waits,
                     };
-                    return Ok(stats.with_counters(counters));
+                    return Ok(stats
+                        .with_counters(counters)
+                        .with_orthogonalization_diagnostics(
+                            orthogonalization_passes,
+                            orthogonalization_rank_loss,
+                            max_orthogonality_loss_estimate,
+                        ));
                 }
                 y[i] = sum / diag;
             }
@@ -901,7 +1000,13 @@ impl FgmresSolver {
             overlap_global_reductions: async_waits,
             residual_replacements: async_waits,
         };
-        let stats = stats.with_counters(counters);
+        let stats = stats
+            .with_counters(counters)
+            .with_orthogonalization_diagnostics(
+                orthogonalization_passes,
+                orthogonalization_rank_loss,
+                max_orthogonality_loss_estimate,
+            );
         #[cfg(feature = "metrics")]
         {
             metrics.reductions = reductions;

--- a/src/utils/convergence.rs
+++ b/src/utils/convergence.rs
@@ -73,8 +73,12 @@ pub enum ConvergedReason {
     DivergedMaxIts,
     /// Diverged due to a breakdown (generic)
     DivergedBreakdown,
+    /// Diverged because the Arnoldi basis lost rank during orthogonalization.
+    DivergedArnoldiRankLoss,
     /// Diverged due to a BiCG-specific breakdown
     DivergedBreakdownBiCG,
+    /// Diverged because the reduced Hessenberg system became singular/near-singular.
+    DivergedReducedSystemSingular,
     /// Diverged because the matrix is indefinite
     DivergedIndefiniteMatrix,
     /// Diverged because the preconditioner is indefinite
@@ -142,7 +146,9 @@ pub fn classify_acceptance_status(
         | ConvergedReason::DivergedIndefiniteMatrix
         | ConvergedReason::DivergedIndefinitePC => AcceptanceStatus::ContractMismatch,
         ConvergedReason::DivergedBreakdown
+        | ConvergedReason::DivergedArnoldiRankLoss
         | ConvergedReason::DivergedBreakdownBiCG
+        | ConvergedReason::DivergedReducedSystemSingular
         | ConvergedReason::DivergedNan
         | ConvergedReason::DivergedInf => AcceptanceStatus::Breakdown,
         ConvergedReason::DivergedDtol
@@ -172,9 +178,10 @@ impl ConvergedReason {
     /// Group reason codes into stable automation categories.
     pub fn category(self) -> Option<ReasonCategory> {
         match self {
-            ConvergedReason::DivergedBreakdown | ConvergedReason::DivergedBreakdownBiCG => {
-                Some(ReasonCategory::Breakdown)
-            }
+            ConvergedReason::DivergedBreakdown
+            | ConvergedReason::DivergedArnoldiRankLoss
+            | ConvergedReason::DivergedBreakdownBiCG
+            | ConvergedReason::DivergedReducedSystemSingular => Some(ReasonCategory::Breakdown),
             ConvergedReason::DivergedNan => Some(ReasonCategory::Nan),
             ConvergedReason::DivergedInf => Some(ReasonCategory::Inf),
             ConvergedReason::DivergedPcSetupFailed => Some(ReasonCategory::PcSetup),
@@ -195,7 +202,9 @@ impl ConvergedReason {
             ConvergedReason::DivergedDtol => "KSP_DIVERGED_DTOL",
             ConvergedReason::DivergedMaxIts => "KSP_DIVERGED_ITS",
             ConvergedReason::DivergedBreakdown => "KSP_DIVERGED_BREAKDOWN",
+            ConvergedReason::DivergedArnoldiRankLoss => "KSP_DIVERGED_BREAKDOWN",
             ConvergedReason::DivergedBreakdownBiCG => "KSP_DIVERGED_BREAKDOWN_BICG",
+            ConvergedReason::DivergedReducedSystemSingular => "KSP_DIVERGED_BREAKDOWN",
             ConvergedReason::DivergedIndefiniteMatrix => "KSP_DIVERGED_INDEFINITE_MAT",
             ConvergedReason::DivergedIndefinitePC => "KSP_DIVERGED_INDEFINITE_PC",
             ConvergedReason::DivergedPcSetupFailed => "KSP_DIVERGED_PCSETUP_FAILED",
@@ -563,6 +572,12 @@ pub struct SolveStats<R> {
     pub breakdown_reason: Option<ConvergedReason>,
     /// Optional note describing residual-based acceptance override decisions.
     pub residual_override_note: Option<String>,
+    /// Count of orthogonalization passes executed (including reorthogonalization).
+    pub orthogonalization_passes: usize,
+    /// Whether an orthogonalization rank-loss failure was observed.
+    pub orthogonalization_rank_loss: bool,
+    /// Max estimate of orthogonality loss observed during the solve.
+    pub max_orthogonality_loss_estimate: R,
 }
 
 impl<R: Default> SolveStats<R> {
@@ -592,6 +607,9 @@ impl<R: Default> SolveStats<R> {
             },
             breakdown_reason: None,
             residual_override_note: None,
+            orthogonalization_passes: 0,
+            orthogonalization_rank_loss: false,
+            max_orthogonality_loss_estimate: R::default(),
         }
     }
 
@@ -637,6 +655,19 @@ impl<R: Default> SolveStats<R> {
     pub fn reduction_phase_diagnostics(&self) -> Option<ReductionPhaseDiagnostics> {
         self.counters
             .reduction_phase_diagnostics(self.reduction_model.as_ref(), self.iterations)
+    }
+
+    /// Attach orthogonalization diagnostics.
+    pub fn with_orthogonalization_diagnostics(
+        mut self,
+        passes: usize,
+        rank_loss: bool,
+        max_loss_estimate: R,
+    ) -> Self {
+        self.orthogonalization_passes = passes;
+        self.orthogonalization_rank_loss = rank_loss;
+        self.max_orthogonality_loss_estimate = max_loss_estimate;
+        self
     }
 }
 

--- a/src/utils/solver_ladder.rs
+++ b/src/utils/solver_ladder.rs
@@ -167,7 +167,9 @@ pub fn classify_acceptance(
             }
         }
         ConvergedReason::DivergedBreakdown
+        | ConvergedReason::DivergedArnoldiRankLoss
         | ConvergedReason::DivergedBreakdownBiCG
+        | ConvergedReason::DivergedReducedSystemSingular
         | ConvergedReason::DivergedNan
         | ConvergedReason::DivergedInf
         | ConvergedReason::DivergedIndefiniteMatrix


### PR DESCRIPTION
### Motivation
- Improve failure diagnosis in FGMRES by distinguishing Arnoldi orthogonalization rank loss and reduced-system singularity from generic breakdowns.
- Expose lightweight orthogonalization diagnostics so callers and monitors can observe reorth passes, rank-loss flags, and an orthogonality-loss estimate.

### Description
- Added two explicit divergence codes `DivergedArnoldiRankLoss` and `DivergedReducedSystemSingular` to `ConvergedReason` and wired them into category/acceptance/PETSc mappings and ladder classification.
- Extended `SolveStats` with `orthogonalization_passes`, `orthogonalization_rank_loss`, and `max_orthogonality_loss_estimate` plus a helper `with_orthogonalization_diagnostics(...)` to attach these diagnostics.
- Updated FGMRES orthogonalization to return whether a second CGS pass ran, to accumulate pass counts, to estimate max orthogonality loss, to detect near-zero `h_{j+1,j}` (emit `DivergedArnoldiRankLoss` outside happy-breakdown), and to classify near-singular reduced-system diagonals as `DivergedReducedSystemSingular` during backsolve.
- Propagated orthogonalization diagnostics into `SolveStats` on all relevant early-exit and final-return paths, and updated solver-ladder acceptance handling for the new reasons.

### Testing
- Ran formatting with `cargo fmt --all` which completed successfully.
- Ran a type/build check with `cargo check -q` which succeeded (noting the repository still reports unrelated warnings).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6868ff94083298669de0b9f273287)