### PR TITLE
Fix E0502 borrow conflict in complex KSP solve path

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -3056,6 +3056,8 @@ impl KspContext {
             let solver_type = self
                 .solver_type
                 .ok_or_else(|| KError::SolveError("No solver".into()))?;
+            let pc_side = self.pc_side;
+            let effective_pc_side = self.effective_pc_side();
             let solver = self
                 .solver
                 .as_mut()
@@ -3081,7 +3083,7 @@ impl KspContext {
                             pc_k.as_deref(),
                             b,
                             x,
-                            self.pc_side,
+                            pc_side,
                             &comm,
                             monitors,
                             work,
@@ -3097,7 +3099,7 @@ impl KspContext {
                             pc_k.as_deref(),
                             b,
                             x,
-                            self.pc_side,
+                            pc_side,
                             &comm,
                             monitors,
                             work,
@@ -3113,7 +3115,7 @@ impl KspContext {
                             pc_k.as_deref(),
                             b,
                             x,
-                            self.pc_side,
+                            pc_side,
                             &comm,
                             monitors,
                             work,
@@ -3129,7 +3131,7 @@ impl KspContext {
                             pc_k.as_deref_mut(),
                             b,
                             x,
-                            self.effective_pc_side(),
+                            effective_pc_side,
                             &comm,
                             monitors,
                             work,


### PR DESCRIPTION
### Motivation
- Avoid a Rust `E0502` mutable/immutable borrow conflict that occurred when the complex-valued solve path mutably borrowed `self.solver` and then accessed other `self` fields from inside a closure. 
- The change is targeted at the complex solve dispatch so the solver calls no longer require immutable access to `self` while `solver` is mutably borrowed.

### Description
- Capture `pc_side` and `effective_pc_side` into local variables before taking the mutable borrow of `self.solver` in `src/context/ksp_context/mod.rs`.
- Replace uses of `self.pc_side` and `self.effective_pc_side()` inside the solver-dispatch closure with the cached `pc_side` and `effective_pc_side` values.
- Keep the rest of the solver dispatch logic unchanged so behavior is preserved while removing the borrow conflict.

### Testing
- Ran `RUSTFLAGS="-Awarnings" cargo test --lib --features=mpi,rayon,backend-faer,complex` and the library tests passed (`444 passed; 0 failed; 6 ignored`).
- Ran `RUSTFLAGS="-Awarnings" RUST_BACKTRACE=full cargo test --features=mpi,rayon,backend-faer,complex -- --nocapture` which still fails due to an unrelated example build error (`kryst::solver::fgmres::Orthog` unresolved import) and is not caused by this borrow fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e6879a26f88329a6be843a0f8e3f76)