### PR TITLE
fgmres: explicit happy-breakdown handling and reduced-system diagonal checks

### DIFF
--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -468,9 +468,10 @@ impl FgmresSolver {
             let mut arnoldi_steps = 0usize;
             let mut converged = false;
             let mut converged_reason: Option<ConvergedReason> = None;
+            let mut hapend = false;
 
             for j in 0..m_this {
-                match self.variant {
+                let arnoldi_norm_scale = match self.variant {
                     FgmresVariant::Classical => {
                         let base = j * n;
                         ws.tmp1[..n].copy_from_slice(&ws.v_mem[base..base + n]);
@@ -502,6 +503,7 @@ impl FgmresSolver {
                         }
 
                         let wnorm_before = red.norm2(&ws.tmp2[..n]);
+                        let arnoldi_norm_scale = wnorm_before.max(R::one());
                         let (hij1, used_second_pass) = match self.orthog {
                             OrthogMethod::ClassicalGS => self.orthogonalize_cgs(ws, &red, n, j),
                             OrthogMethod::ModifiedGS => self.orthogonalize_mgs(ws, &red, n, j),
@@ -535,6 +537,7 @@ impl FgmresSolver {
                         } else {
                             ws.v_col(j + 1).fill(S::zero());
                         }
+                        arnoldi_norm_scale
                     }
                     FgmresVariant::Pipelined => {
                         let base = j * n;
@@ -567,6 +570,7 @@ impl FgmresSolver {
                         }
 
                         ws.pipelined_w[..n].copy_from_slice(&ws.tmp2[..n]);
+                        let arnoldi_norm_scale = red.norm2(&ws.pipelined_w[..n]).max(R::one());
                         let pipe = ws.pipelined_arnoldi_step(
                             j,
                             n,
@@ -609,64 +613,68 @@ impl FgmresSolver {
                             metrics.bytes_reduced +=
                                 payload_len * std::mem::size_of::<R>() * reductions;
                         }
+                        arnoldi_norm_scale
                     }
-                }
+                };
 
                 let h_subdiag = ws.h_at(j + 1, j).abs();
-                if h_subdiag <= self.haptol {
+                let haptol_scaled = self.haptol.max(0.0) * arnoldi_norm_scale;
+                let hap_event = h_subdiag <= haptol_scaled;
+                if hap_event {
                     let loss_estimate = R::one();
                     if loss_estimate > max_orthogonality_loss_estimate {
                         max_orthogonality_loss_estimate = loss_estimate;
                     }
                 }
-                if self.happy_breakdown && h_subdiag <= self.haptol {
+                if hap_event {
                     *ws.h_at_mut(j + 1, j) = S::zero();
                     ws.apply_prev_givens_to_col(j, j);
-                    ws.g[j + 1] = S::zero();
-                    res = R::zero();
+                    ws.apply_final_givens_and_update_g(j);
+                    res = ws.g[j + 1].abs();
                     total_iters += 1;
                     arnoldi_steps = j + 1;
-                    converged = true;
-                    converged_reason = Some(ConvergedReason::ConvergedHappyBreakdown);
-                    break;
-                }
-                if h_subdiag <= self.haptol {
-                    orthogonalization_rank_loss = true;
-                    let true_res = recompute_true_residual_norm_s(
-                        a,
-                        b,
-                        x,
-                        comm,
-                        red.engine(),
-                        &mut ws.tmp1[..n],
-                        &mut ws.bridge,
-                    );
-                    stats = SolveStats::new(
-                        total_iters,
-                        true_res,
-                        ConvergedReason::DivergedArnoldiRankLoss,
-                    )
-                    .with_orthogonalization_diagnostics(
-                        orthogonalization_passes,
-                        orthogonalization_rank_loss,
-                        max_orthogonality_loss_estimate,
-                    );
-                    stats.final_true_residual = Some(true_res);
                     stats.final_recurrence_residual = Some(res);
-                    let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
-                        pc_ref.apply_mut_s(
-                            pc_side,
-                            &ws.tmp1[..n],
-                            &mut ws.tmp2[..n],
-                            &mut ws.bridge,
-                        )?;
-                        red.norm2(&ws.tmp2[..n])
+                    hapend = true;
+                    if self.happy_breakdown {
+                        converged = true;
+                        converged_reason = Some(ConvergedReason::ConvergedHappyBreakdown);
                     } else {
-                        red.norm2(&ws.tmp1[..n])
-                    };
-                    stats.last_preconditioned_residual = Some(precond_res);
-                    converged = true;
-                    converged_reason = Some(ConvergedReason::DivergedArnoldiRankLoss);
+                        orthogonalization_rank_loss = true;
+                        let true_res = recompute_true_residual_norm_s(
+                            a,
+                            b,
+                            x,
+                            comm,
+                            red.engine(),
+                            &mut ws.tmp1[..n],
+                            &mut ws.bridge,
+                        );
+                        stats = SolveStats::new(
+                            total_iters,
+                            true_res,
+                            ConvergedReason::DivergedArnoldiRankLoss,
+                        )
+                        .with_orthogonalization_diagnostics(
+                            orthogonalization_passes,
+                            orthogonalization_rank_loss,
+                            max_orthogonality_loss_estimate,
+                        );
+                        stats.final_true_residual = Some(true_res);
+                        let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
+                            pc_ref.apply_mut_s(
+                                pc_side,
+                                &ws.tmp1[..n],
+                                &mut ws.tmp2[..n],
+                                &mut ws.bridge,
+                            )?;
+                            red.norm2(&ws.tmp2[..n])
+                        } else {
+                            red.norm2(&ws.tmp1[..n])
+                        };
+                        stats.last_preconditioned_residual = Some(precond_res);
+                        converged = true;
+                        converged_reason = Some(ConvergedReason::DivergedArnoldiRankLoss);
+                    }
                     break;
                 }
 
@@ -821,6 +829,56 @@ impl FgmresSolver {
             }
 
             let k = arnoldi_steps;
+            let reduced_diag_threshold = self.haptol.max(0.0);
+            let reduced_system_diagonal_ok = (0..k).all(|i| {
+                let diag = ws.h_at(i, i);
+                diag.real().is_finite() && diag.abs() > reduced_diag_threshold
+            });
+            if !reduced_system_diagonal_ok {
+                let true_res = recompute_true_residual_norm_s(
+                    a,
+                    b,
+                    x,
+                    comm,
+                    red.engine(),
+                    &mut ws.tmp1[..n],
+                    &mut ws.bridge,
+                );
+                stats = SolveStats::new(
+                    total_iters,
+                    true_res,
+                    ConvergedReason::DivergedReducedSystemSingular,
+                );
+                stats.final_true_residual = Some(true_res);
+                stats.final_recurrence_residual = Some(res);
+                let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
+                    pc_ref.apply_mut_s(
+                        pc_side,
+                        &ws.tmp1[..n],
+                        &mut ws.tmp2[..n],
+                        &mut ws.bridge,
+                    )?;
+                    red.norm2(&ws.tmp2[..n])
+                } else {
+                    red.norm2(&ws.tmp1[..n])
+                };
+                stats.last_preconditioned_residual = Some(precond_res);
+                let end_reduct = crate::utils::reduction::test_hooks::wait_counters();
+                let reductions = end_reduct.0 + end_reduct.1 - start_reduct.0 - start_reduct.1
+                    + pipeline_reductions;
+                let counters = crate::utils::convergence::SolverCounters {
+                    num_global_reductions: reductions,
+                    overlap_global_reductions: async_waits,
+                    residual_replacements: async_waits,
+                };
+                return Ok(stats
+                    .with_counters(counters)
+                    .with_orthogonalization_diagnostics(
+                        orthogonalization_passes,
+                        orthogonalization_rank_loss,
+                        max_orthogonality_loss_estimate,
+                    ));
+            }
             let mut y = vec![S::zero(); k];
             for i in (0..k).rev() {
                 let mut sum = ws.g[i];
@@ -838,9 +896,11 @@ impl FgmresSolver {
                         &mut ws.tmp1[..n],
                         &mut ws.bridge,
                     );
-                    let reason = ConvergedReason::from_non_finite(diag.real())
-                        .unwrap_or(ConvergedReason::DivergedReducedSystemSingular);
-                    stats = SolveStats::new(total_iters, true_res, reason);
+                    stats = SolveStats::new(
+                        total_iters,
+                        true_res,
+                        ConvergedReason::DivergedReducedSystemSingular,
+                    );
                     stats.final_true_residual = Some(true_res);
                     stats.final_recurrence_residual = Some(res);
                     let precond_res = if let Some(pc_ref) = pc.as_deref_mut() {
@@ -928,11 +988,14 @@ impl FgmresSolver {
             }
 
             if converged {
-                stats.reason = converged_reason
-                    .or_else(|| {
+                stats.reason = if hapend {
+                    converged_reason
+                } else {
+                    converged_reason.or_else(|| {
                         true_residual_converged_reason(true_res, bnorm, self.atol, self.rtol)
                     })
-                    .unwrap_or(ConvergedReason::DivergedBreakdown);
+                }
+                .unwrap_or(ConvergedReason::DivergedBreakdown);
                 break;
             }
 

--- a/tests/fgmres_flexible.rs
+++ b/tests/fgmres_flexible.rs
@@ -10,9 +10,14 @@ use kryst::matrix::op::LinOp;
 use kryst::parallel::UniverseComm;
 use kryst::preconditioner::{PcSide, Preconditioner};
 use kryst::solver::FgmresSolver;
+use kryst::utils::convergence::ConvergedReason;
 
 struct MutableCountPc {
     hits: Arc<AtomicUsize>,
+}
+
+struct ScalePc {
+    scale: f64,
 }
 
 impl Preconditioner for MutableCountPc {
@@ -26,6 +31,21 @@ impl Preconditioner for MutableCountPc {
         self.hits.fetch_add(1, Ordering::Relaxed);
         y.copy_from_slice(x);
         Ok(())
+    }
+}
+
+impl Preconditioner for ScalePc {
+    fn setup(&mut self, _a: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        Ok(())
+    }
+    fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        for (dst, &src) in y.iter_mut().zip(x) {
+            *dst = self.scale * src;
+        }
+        Ok(())
+    }
+    fn apply_mut(&mut self, side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
+        self.apply(side, x, y)
     }
 }
 
@@ -118,4 +138,89 @@ fn fgmres_solver_rejects_symmetric_pc_side() {
         }
         other => panic!("unexpected error: {other:?}"),
     }
+}
+
+#[test]
+fn fgmres_one_step_convergence_identity() {
+    let a = faer::Mat::<f64>::from_fn(2, 2, |i, j| if i == j { 1.0 } else { 0.0 });
+    let mut solver = FgmresSolver::new(1e-12, 10, 4);
+    solver.set_happy_breakdown(false);
+    let b = [1.25f64, -0.75];
+    let mut x = [0.0f64; 2];
+    let mut work = Workspace::new(2);
+
+    let stats = solver
+        .solve_f64(
+            &a,
+            None,
+            &b,
+            &mut x,
+            PcSide::Right,
+            &UniverseComm::NoComm(kryst::parallel::NoComm),
+            None,
+            Some(&mut work),
+        )
+        .expect("FGMRES should converge in one step on identity");
+
+    assert_eq!(stats.iterations, 1);
+    assert!(matches!(
+        stats.reason,
+        ConvergedReason::ConvergedRtol | ConvergedReason::ConvergedAtol
+    ));
+    assert!((x[0] - b[0]).abs() <= 1e-12);
+    assert!((x[1] - b[1]).abs() <= 1e-12);
+}
+
+#[test]
+fn fgmres_exact_pc_happy_breakdown() {
+    let a = faer::Mat::<f64>::from_fn(2, 2, |i, j| if i == j { 2.0 } else { 0.0 });
+    let mut solver = FgmresSolver::new(1e-12, 10, 4);
+    solver.set_happy_breakdown(true);
+    let mut pc = ScalePc { scale: 0.5 };
+    let b = [2.0f64, 4.0];
+    let mut x = [0.0f64; 2];
+    let mut work = Workspace::new(2);
+
+    let stats = solver
+        .solve_f64(
+            &a,
+            Some(&mut pc),
+            &b,
+            &mut x,
+            PcSide::Right,
+            &UniverseComm::NoComm(kryst::parallel::NoComm),
+            None,
+            Some(&mut work),
+        )
+        .expect("FGMRES should happy-breakdown with exact right preconditioner");
+
+    assert_eq!(stats.reason, ConvergedReason::ConvergedHappyBreakdown);
+    assert_eq!(stats.iterations, 1);
+    assert!((x[0] - 1.0).abs() <= 1e-12);
+    assert!((x[1] - 2.0).abs() <= 1e-12);
+}
+
+#[test]
+fn fgmres_reports_singular_reduced_system_on_zero_operator() {
+    let a = faer::Mat::<f64>::from_fn(1, 1, |_i, _j| 0.0);
+    let mut solver = FgmresSolver::new(1e-12, 4, 2);
+    solver.set_happy_breakdown(true);
+    let b = [1.0f64];
+    let mut x = [0.0f64; 1];
+    let mut work = Workspace::new(1);
+
+    let stats = solver
+        .solve_f64(
+            &a,
+            None,
+            &b,
+            &mut x,
+            PcSide::Right,
+            &UniverseComm::NoComm(kryst::parallel::NoComm),
+            None,
+            Some(&mut work),
+        )
+        .expect("FGMRES returns stats even on reduced-system singularity");
+
+    assert_eq!(stats.reason, ConvergedReason::DivergedReducedSystemSingular);
 }


### PR DESCRIPTION
### Motivation
- Ensure FGMRES reliably detects and handles "happy breakdown" events relative to the local Arnoldi vector scale so recurrence residuals remain consistent. 
- Make the QR/Givens update path handle happy-breakdown events explicitly and ensure recurrence residual bookkeeping matches the normal path. 
- Convert ambiguous triangular/backsolve failures into a clear `DivergedReducedSystemSingular` outcome when reduced-system diagonals are non-finite or too small. 

### Description
- Add a cycle-local `hapend` flag and detect post-orthogonalization happy-breakdown using a scaled tolerance `haptol * max(1, ||w||)` applied to `h_{j+1,j}`. 
- Route happy-breakdown through the explicit Givens/QR update (`apply_prev_givens_to_col` + `apply_final_givens_and_update_g`) and set the recurrence residual from `|g[j+1]|` so residual accounting is consistent with non-happy iterations. 
- Before performing the backsolve, validate all required triangular diagonals are finite and above threshold and return `ConvergedReason::DivergedReducedSystemSingular` if this check fails. 
- Map diagonal non-finite/near-zero failures during the backsolve to `DivergedReducedSystemSingular`, and make final convergence reason selection respect the `hapend` state. 
- Add focused tests and a tiny `ScalePc` helper in `tests/fgmres_flexible.rs` covering one-step convergence on the identity, exact-PC happy breakdown, and the singular reduced-system edge case. 

### Testing
- Ran code formatting with `cargo fmt --all` successfully. 
- Executed the targeted test binary with `cargo test --test fgmres_flexible` and the suite completed successfully (`6 passed; 0 failed`). 
- Verified the modified `fgmres` paths by running the new tests which include `fgmres_one_step_convergence_identity`, `fgmres_exact_pc_happy_breakdown`, and `fgmres_reports_singular_reduced_system_on_zero_operator`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e688a646288329b5faa4b3c6260cce)