### PR TITLE
Formalize GMRES/FGMRES workspace layout, add FGMRES memory estimator, and unify preallocation

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -122,7 +122,9 @@ pub use execution::{
     AdaptiveExecutionDecision, ExecutionPolicy, NestedPolicyContext, OverlapStrategy,
     ThreadingPolicy,
 };
-pub use workspace::{GmresSStepWorkspace, GmresSpec, PipeReduct, ReorthPolicy, Workspace};
+pub use workspace::{
+    GmresSStepWorkspace, GmresSpec, GmresWorkspaceLayout, PipeReduct, ReorthPolicy, Workspace,
+};
 
 #[cfg(feature = "complex")]
 struct LinOpAsK<'a> {

--- a/src/context/ksp_context/workspace.rs
+++ b/src/context/ksp_context/workspace.rs
@@ -10,8 +10,15 @@ use std::sync::Arc;
 
 #[derive(Debug, Clone, Default)]
 pub struct Workspace {
+    // --- Solve-global scratch (persists for full solve) -----------------------
     pub tmp1: Vec<S>,
     pub tmp2: Vec<S>,
+    pub pipelined_w: Vec<S>,
+    pub pipelined_wtmp: Vec<S>,
+    pub pipelined_payload: Vec<R>,
+    pub bridge: BridgeScratch,
+    pub bridge_tmp: Vec<S>,
+
     // Legacy buffers for solvers not yet migrated
     pub q_s: Vec<Vec<S>>,
     pub z_s: Vec<Vec<S>>,
@@ -19,23 +26,25 @@ pub struct Workspace {
     pub q: Vec<Vec<S>>,
     pub z: Vec<Vec<S>>,
     pub h: Vec<Vec<S>>,
+
+    // --- GMRES/FGMRES restart-local state -------------------------------------
+    // Krylov basis V and flexible/preconditioned basis Z (column-major)
     pub v_mem: Vec<S>,
     pub z_mem: Vec<S>,
-    // Column-major Hessenberg storage for GMRES/FGMRES
+    // Column-major Hessenberg H (ld = m + 1)
     pub h_mem: Vec<S>,
+    // Per-column Givens/QR scratch and rotation state
     pub givens_col_scratch: Vec<S>,
     pub cs: Vec<R>,
     pub sn: Vec<S>,
     pub g: Vec<S>,
+    // Optional s-step/block-Arnoldi payloads (restart-local)
     pub blk_scratch: Vec<S>,
     pub blk_payload: Vec<R>,
-    pub bridge: BridgeScratch,
-    pub bridge_tmp: Vec<S>,
+
+    // Other solver-specific reusable workspaces
     pub block_buf: Option<BlockVec>,
     pub tsqr: Option<TsqrWorkspace>,
-    pub pipelined_w: Vec<S>,
-    pub pipelined_wtmp: Vec<S>,
-    pub pipelined_payload: Vec<R>,
     pub gmres_sstep: Option<GmresSStepWorkspace>,
     pub gmres_recycle: RecyclingSpace,
     pub reduction: crate::utils::reduction::ReductOptions,
@@ -161,6 +170,77 @@ pub struct GmresSpec {
     pub m: usize,
     pub need_z: bool,
     pub block_s: usize,
+}
+
+/// Capacity plan for the GMRES/FGMRES-specific workspace sections.
+///
+/// The sections are grouped by lifecycle:
+/// - **Restart-local state** (`v`, `z`, `h`, Givens/QR, and optional block payload) is
+///   consumed and overwritten within each restart cycle.
+/// - **Solve-global scratch** (`tmp*`, bridge/pipeline vectors) persists across the whole solve.
+#[derive(Debug, Clone, Copy, Default)]
+pub struct GmresWorkspaceLayout {
+    pub n: usize,
+    pub m: usize,
+    pub need_z: bool,
+    pub block_s: usize,
+    pub v_len: usize,
+    pub z_len: usize,
+    pub h_len: usize,
+    pub givens_len: usize,
+    pub g_len: usize,
+    pub pipelined_payload_len: usize,
+    pub pipelined_vec_len: usize,
+    pub tmp_len: usize,
+    pub blk_scratch_len: usize,
+    pub blk_payload_cap: usize,
+}
+
+impl GmresWorkspaceLayout {
+    pub fn from_spec(spec: GmresSpec) -> Self {
+        let n = spec.n;
+        let m = spec.m;
+        let v_len = (m + 1).checked_mul(n).expect("v_len overflow");
+        let z_len = if spec.need_z {
+            m.checked_mul(n).expect("z_len overflow")
+        } else {
+            0
+        };
+        let h_len = (m + 1).checked_mul(m).expect("h_len overflow");
+        let g_len = m + 1;
+        #[cfg(feature = "complex")]
+        let pipelined_payload_len = 2 * (m + 1) + 1;
+        #[cfg(not(feature = "complex"))]
+        let pipelined_payload_len = m + 2;
+
+        let blk_scratch_len = if spec.block_s > 0 {
+            n.saturating_mul(spec.block_s)
+        } else {
+            0
+        };
+        let blk_payload_cap = if spec.block_s > 0 {
+            block_payload_capacity(m.saturating_add(1), spec.block_s)
+        } else {
+            0
+        };
+
+        Self {
+            n,
+            m,
+            need_z: spec.need_z,
+            block_s: spec.block_s,
+            v_len,
+            z_len,
+            h_len,
+            givens_len: m + 1,
+            g_len,
+            pipelined_payload_len,
+            pipelined_vec_len: n,
+            tmp_len: n,
+            blk_scratch_len,
+            blk_payload_cap,
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -319,49 +399,51 @@ impl Workspace {
         self.m = spec.m;
         self.need_z = spec.need_z;
 
-        let n = spec.n;
-        let m = spec.m;
+        let layout = GmresWorkspaceLayout::from_spec(spec);
 
-        let v_len = (m + 1).checked_mul(n).expect("v_len overflow");
-        let z_len = if spec.need_z {
-            m.checked_mul(n).expect("z_len overflow")
-        } else {
-            0
-        };
-        let h_len = (m + 1).checked_mul(m).expect("h_len overflow");
-        let g_len = m + 1;
-
-        ensure_len(&mut self.tmp1, n);
-        ensure_len(&mut self.tmp2, n);
-        ensure_len(&mut self.v_mem, v_len);
+        ensure_len(&mut self.tmp1, layout.tmp_len);
+        ensure_len(&mut self.tmp2, layout.tmp_len);
+        ensure_len(&mut self.v_mem, layout.v_len);
         if spec.need_z {
-            ensure_len(&mut self.z_mem, z_len);
+            ensure_len(&mut self.z_mem, layout.z_len);
         } else {
             // Keep capacity to avoid allocator churn when need_z toggles.
             self.z_mem.clear();
         }
-        ensure_len(&mut self.h_mem, h_len);
-        ensure_len(&mut self.cs, m);
-        ensure_len(&mut self.sn, m);
-        ensure_len(&mut self.g, g_len);
-        ensure_len(&mut self.pipelined_w, n);
-        ensure_len(&mut self.pipelined_wtmp, n);
-        #[cfg(feature = "complex")]
-        let payload_len = 2 * (m + 1) + 1;
-        #[cfg(not(feature = "complex"))]
-        let payload_len = m + 2;
-        ensure_len(&mut self.pipelined_payload, payload_len);
+        ensure_len(&mut self.h_mem, layout.h_len);
+        ensure_len(&mut self.cs, spec.m);
+        ensure_len(&mut self.sn, spec.m);
+        ensure_len(&mut self.g, layout.g_len);
+        ensure_len(&mut self.pipelined_w, layout.pipelined_vec_len);
+        ensure_len(&mut self.pipelined_wtmp, layout.pipelined_vec_len);
+        ensure_len(&mut self.pipelined_payload, layout.pipelined_payload_len);
 
-        if spec.block_s > 0 {
-            ensure_len(&mut self.blk_scratch, n * spec.block_s);
-            let payload_cap = block_payload_capacity(spec.m.saturating_add(1), spec.block_s);
-            ensure_capacity(&mut self.blk_payload, payload_cap);
+        if layout.block_s > 0 {
+            ensure_len(&mut self.blk_scratch, layout.blk_scratch_len);
+            ensure_capacity(&mut self.blk_payload, layout.blk_payload_cap);
         } else {
             self.blk_scratch.clear();
             self.blk_payload.clear();
         }
 
-        self.ensure_sstep(n, spec.block_s, m);
+        self.ensure_sstep(layout.n, layout.block_s, layout.m);
+    }
+
+    /// Clear per-restart GMRES/FGMRES state while preserving allocation capacity.
+    pub fn clear_gmres_restart_state(&mut self) {
+        self.h_mem.fill(S::zero());
+        self.cs.fill(R::default());
+        self.sn.fill(S::zero());
+        self.g.fill(S::zero());
+    }
+
+    /// Clear solve-global scratch vectors used by GMRES/FGMRES without releasing memory.
+    pub fn clear_gmres_global_scratch(&mut self) {
+        self.tmp1.fill(S::zero());
+        self.tmp2.fill(S::zero());
+        self.pipelined_w.fill(S::zero());
+        self.pipelined_wtmp.fill(S::zero());
+        self.pipelined_payload.fill(R::default());
     }
 
     pub fn set_reduction_options(&mut self, opt: crate::utils::reduction::ReductOptions) {

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -6,7 +6,7 @@ use crate::algebra::blas::{dot_conj, nrm2};
 #[allow(unused_imports)]
 use crate::algebra::prelude::*;
 use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
-use crate::context::ksp_context::{GmresSpec, ReorthPolicy, Workspace};
+use crate::context::ksp_context::{GmresSpec, GmresWorkspaceLayout, ReorthPolicy, Workspace};
 use crate::error::KError;
 use crate::matrix::op::LinOp;
 use crate::ops::klinop::KLinOp;
@@ -89,7 +89,11 @@ pub struct FgmresSolver {
     /// Refinement strategy for the ClassicalGS orthogonalization path.
     pub cgs_refinement: CgsRefinement,
     pub haptol: f64,
-    /// If true, size basis/H for maxits; otherwise per-restart sizing.
+    /// Controls workspace provisioning strategy.
+    ///
+    /// - `false` (default): allocate restart-local basis/QR storage for `restart` columns.
+    /// - `true`: preallocate once for `min(restart, maxits)` columns and reuse that capacity
+    ///   across cycles to avoid repeated growth checks.
     pub preallocate: bool,
     /// Optional hook called once per restart (after backsolve) so caller can adapt the PC.
     pub on_restart: Option<Box<dyn FnMut(usize, f64) -> Result<(), KError> + Send + Sync>>,
@@ -205,13 +209,50 @@ impl FgmresSolver {
         }
     }
 
-    fn ensure_workspace(&self, w: &mut Workspace, n: usize, m: usize) {
+    #[inline]
+    fn workspace_cols(&self) -> usize {
+        if self.preallocate {
+            self.restart.min(self.maxits)
+        } else {
+            self.restart
+        }
+    }
+
+    fn ensure_workspace(&self, w: &mut Workspace, n: usize) {
         w.acquire_gmres(GmresSpec {
+            n,
+            m: self.workspace_cols(),
+            need_z: true,
+            block_s: 0,
+        });
+    }
+
+    /// Estimate bytes required by the FGMRES workspace sections for `(n, restart)`.
+    ///
+    /// This includes the formally sized GMRES/FGMRES sections (`V`, `Z`, `H`, Givens/QR,
+    /// pipeline payload) plus solve-global temporary vectors (`tmp1/tmp2`, pipeline vectors).
+    /// It excludes allocator overhead and optional communication arenas.
+    pub fn memory_bytes(n: usize, restart: usize) -> usize {
+        let m = restart.max(1);
+        let layout = GmresWorkspaceLayout::from_spec(GmresSpec {
             n,
             m,
             need_z: true,
             block_s: 0,
         });
+        let scalar_items = layout
+            .v_len
+            .saturating_add(layout.z_len)
+            .saturating_add(layout.h_len)
+            .saturating_add(m)
+            .saturating_add(layout.g_len)
+            .saturating_add(layout.givens_len)
+            .saturating_add(layout.tmp_len.saturating_mul(2))
+            .saturating_add(layout.pipelined_vec_len.saturating_mul(2));
+        let real_items = m.saturating_add(layout.pipelined_payload_len);
+        scalar_items
+            .saturating_mul(std::mem::size_of::<S>())
+            .saturating_add(real_items.saturating_mul(std::mem::size_of::<R>()))
     }
 
     #[inline]
@@ -541,11 +582,7 @@ impl FgmresSolver {
             )));
         }
 
-        let block_m = if self.preallocate {
-            self.restart.min(self.maxits)
-        } else {
-            self.restart
-        };
+        let workspace_cols = self.workspace_cols();
 
         let mut owned_ws;
         let ws = if let Some(w) = work {
@@ -554,7 +591,7 @@ impl FgmresSolver {
             owned_ws = Workspace::new(n);
             &mut owned_ws
         };
-        self.ensure_workspace(ws, n, block_m);
+        self.ensure_workspace(ws, n);
         let red = ReductCtx::new(comm, Some(&*ws));
 
         let mons = monitors.unwrap_or(&[]);
@@ -582,10 +619,7 @@ impl FgmresSolver {
         let bnorm = norms[1].max(1e-32);
         let thr = self.atol.max(self.rtol * bnorm);
 
-        ws.h_mem.fill(S::zero());
-        ws.cs.fill(R::default());
-        ws.sn.fill(S::zero());
-        ws.g.fill(S::zero());
+        ws.clear_gmres_restart_state();
         ws.g[0] = S::from_real(beta0);
 
         if beta0 > R::default() {
@@ -745,7 +779,7 @@ impl FgmresSolver {
 
         while total_iters < self.maxits {
             let m_this = if self.preallocate {
-                block_m.min(self.maxits - total_iters)
+                workspace_cols.min(self.maxits - total_iters)
             } else {
                 self.restart.min(self.maxits - total_iters)
             };
@@ -1233,10 +1267,7 @@ impl FgmresSolver {
                 metrics.bytes_reduced += std::mem::size_of::<R>();
             }
 
-            ws.h_mem.fill(S::zero());
-            ws.cs.fill(R::default());
-            ws.sn.fill(S::zero());
-            ws.g.fill(S::zero());
+            ws.clear_gmres_restart_state();
             ws.g[0] = S::from_real(beta0);
             restart_count += 1;
             if beta0 > R::default() {
@@ -1364,7 +1395,7 @@ impl LinearSolver for FgmresSolver {
         if n == 0 {
             return;
         }
-        self.ensure_workspace(w, n, self.restart);
+        self.ensure_workspace(w, n);
     }
 
     fn solve(


### PR DESCRIPTION
### Motivation
- Make GMRES/FGMRES workspace sizing explicit and maintainable by grouping logically distinct buffers and separating restart-local state from solve-global scratch.
- Provide a user-facing way to estimate memory usage for FGMRES workspaces.
- Ensure `preallocate` semantics are applied uniformly so workspace sizing and per-cycle logic are consistent.

### Description
- Introduced `GmresWorkspaceLayout` and `GmresSpec`-based sizing helpers and use them from `Workspace::acquire_gmres` to centralize allocation calculations (`src/context/ksp_context/workspace.rs`).
- Reorganized `Workspace` to document and group solve-global scratch (e.g., `tmp1`, `tmp2`, pipeline/bridge vectors) versus restart-local GMRES state (`v_mem`, `z_mem`, `h_mem`, Givens/QR state, block payload) to clarify lifecycles (`src/context/ksp_context/workspace.rs`).
- Added lifecycle helpers `clear_gmres_restart_state` and `clear_gmres_global_scratch` to reset per-restart and global scratch without deallocating (`src/context/ksp_context/workspace.rs`).
- Added `FgmresSolver::memory_bytes(n, restart)` to estimate bytes needed for the formalized workspace sections (includes `V`, `Z`, `H`, Givens/QR, pipeline payload and core scratch) (`src/solver/fgmres.rs`).
- Unified `preallocate` behavior via a single `workspace_cols()` helper and applied it consistently in `ensure_workspace`, `setup_workspace`, and per-cycle sizing (`m_this`) so both provisioning and runtime cycle sizing follow the same policy (`src/solver/fgmres.rs`).
- Replaced scattered manual zeroing of restart state with `clear_gmres_restart_state` for consistency in `solve_k` and restart handling (`src/solver/fgmres.rs`).
- Exported the new layout type through the KSP context module API (`src/context/ksp_context/mod.rs`).

### Testing
- Ran `cargo fmt` (succeeded).
- Ran `cargo check -q` (succeeded; repository pre-existing compiler warnings remain but no new errors from these changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e0e4c64c8329a140cf92c700957d)