### PR TITLE
Fix exhaustive ConvergedReason matching in mpi_pc_consistency test

### DIFF
--- a/tests/mpi_pc_consistency.rs
+++ b/tests/mpi_pc_consistency.rs
@@ -75,13 +75,15 @@ fn reason_id(reason: ConvergedReason) -> f64 {
         ConvergedReason::DivergedDtol => 7.0,
         ConvergedReason::DivergedMaxIts => 8.0,
         ConvergedReason::DivergedBreakdown => 9.0,
-        ConvergedReason::DivergedBreakdownBiCG => 10.0,
-        ConvergedReason::DivergedIndefiniteMatrix => 11.0,
-        ConvergedReason::DivergedIndefinitePC => 12.0,
-        ConvergedReason::DivergedPcSetupFailed => 13.0,
-        ConvergedReason::DivergedPcFailed => 14.0,
-        ConvergedReason::StoppedByMonitor => 15.0,
-        ConvergedReason::Continued => 16.0,
+        ConvergedReason::DivergedArnoldiRankLoss => 10.0,
+        ConvergedReason::DivergedBreakdownBiCG => 11.0,
+        ConvergedReason::DivergedReducedSystemSingular => 12.0,
+        ConvergedReason::DivergedIndefiniteMatrix => 13.0,
+        ConvergedReason::DivergedIndefinitePC => 14.0,
+        ConvergedReason::DivergedPcSetupFailed => 15.0,
+        ConvergedReason::DivergedPcFailed => 16.0,
+        ConvergedReason::StoppedByMonitor => 17.0,
+        ConvergedReason::Continued => 18.0,
     }
 }
 


### PR DESCRIPTION
### Motivation
- The `reason_id` match in the MPI consistency test became non-exhaustive after two new `ConvergedReason` variants were added, causing a compilation error during tests.

### Description
- Update `tests/mpi_pc_consistency.rs` to add `DivergedArnoldiRankLoss` and `DivergedReducedSystemSingular` to the `reason_id` match and shift subsequent numeric IDs to preserve a unique mapping used by the MPI all-reduce consistency check.

### Testing
- Ran `RUSTFLAGS='-Awarnings' RUST_BACKTRACE=full cargo test --features=mpi,rayon,backend-faer,logging --test mpi_pc_consistency -- --nocapture` and the test file completed successfully with "8 passed; 0 failed".

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e40ececc83298d898ee3f6dabca6)