### PR TITLE
Fix FGMRES default pc-side handling and align pipelined PCG test

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -695,14 +695,16 @@ impl KspContext {
     }
 
     pub fn set_type(&mut self, solver_type: SolverType) -> Result<&mut Self, KError> {
-        if solver_type == SolverType::Fgmres
-            && self.pc_side_explicit
-            && self.pc_side != PcSide::Right
-        {
-            return Err(KError::InvalidInput(format!(
-                "FGMRES supports only right preconditioning; got {:?}",
-                self.pc_side
-            )));
+        if solver_type == SolverType::Fgmres {
+            if self.pc_side_explicit && self.pc_side != PcSide::Right {
+                return Err(KError::InvalidInput(format!(
+                    "FGMRES supports only right preconditioning; got {:?}",
+                    self.pc_side
+                )));
+            }
+            if !self.pc_side_explicit {
+                self.pc_side = PcSide::Right;
+            }
         }
         if let Some(required) = solver_type.required_pc_side() {
             let normalized = Self::effective_side_for_solver(self.pc_side, solver_type);

--- a/src/solver/tests/sync_counts.rs
+++ b/src/solver/tests/sync_counts.rs
@@ -34,7 +34,7 @@ fn pipelined_cg_uses_single_reduction_per_iteration() -> Result<(), KError> {
         Some(&mut pc),
         &b,
         &mut x,
-        PcSide::Right,
+        PcSide::Left,
         &comm,
         None,
         Some(&mut ws),


### PR DESCRIPTION
### Motivation
- Two tests failed due to mismatched preconditioning side expectations: FGMRES requires right preconditioning but the context could leave the default left side when the user did not explicitly request a side, and pipelined PCG requires left preconditioning but a test passed `PcSide::Right`.

### Description
- Change `KspContext::set_type` so when `SolverType::Fgmres` is selected it rejects an explicitly requested non-right side but automatically sets `pc_side` to `PcSide::Right` when the side was not explicitly chosen (edit: `src/context/ksp_context/mod.rs`).
- Update the pipelined PCG unit test to pass `PcSide::Left` to `PcgSolver::solve` so the test uses the solver-required left preconditioning (edit: `src/solver/tests/sync_counts.rs`).
- The changes preserve the existing explicit validation behavior while making the default selection consistent with solver requirements.

### Testing
- Ran `cargo test --features=mpi,rayon,backend-faer,logging reproducible_ksp_disables_overlap_reduction_counters` and the test passed.
- Ran `cargo test --features=mpi,rayon,backend-faer,logging pipelined_cg_uses_single_reduction_per_iteration` and the test passed.
- Ran a broader `cargo test --features=mpi,rayon,backend-faer,logging`; the unit tests exercised here passed, but the full suite aborted in an unrelated MPI test (`mpi_gmres_sstep`) due to a runtime MPI collective error (invalid `MPI_Allreduce` op/type), which is outside the scope of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7e602f5908329a490008da5069120)