### PR TITLE
Treat GCR/PipeGCR as right-only preconditioning and adjust minimal convergence test

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -238,6 +238,14 @@ impl SolverType {
             _ => None,
         }
     }
+
+    #[inline]
+    pub fn right_only_pc_side(self) -> bool {
+        matches!(
+            self,
+            SolverType::Fgmres | SolverType::Gcr | SolverType::PipeGcr
+        )
+    }
 }
 
 impl FromStr for SolverType {
@@ -517,7 +525,7 @@ impl KspContext {
     #[inline]
     fn effective_side_for_solver(side: PcSide, solver_type: SolverType) -> PcSide {
         match solver_type {
-            SolverType::Fgmres => side,
+            SolverType::Fgmres | SolverType::Gcr | SolverType::PipeGcr => PcSide::Right,
             _ => match side {
                 PcSide::Symmetric => PcSide::Left,
                 s => s,
@@ -596,9 +604,9 @@ impl KspContext {
             side
         };
         if let Some(st) = self.solver_type {
-            if st == SolverType::Fgmres && side != PcSide::Right {
+            if st.right_only_pc_side() && side != PcSide::Right {
                 return Err(KError::InvalidInput(format!(
-                    "FGMRES supports only right preconditioning; got {side:?}"
+                    "{st:?} supports only right preconditioning; got {side:?}"
                 )));
             }
             if let Some(required) = st.required_pc_side() {
@@ -695,10 +703,10 @@ impl KspContext {
     }
 
     pub fn set_type(&mut self, solver_type: SolverType) -> Result<&mut Self, KError> {
-        if solver_type == SolverType::Fgmres {
+        if solver_type.right_only_pc_side() {
             if self.pc_side_explicit && self.pc_side != PcSide::Right {
                 return Err(KError::InvalidInput(format!(
-                    "FGMRES supports only right preconditioning; got {:?}",
+                    "{solver_type:?} supports only right preconditioning; got {:?}",
                     self.pc_side
                 )));
             }
@@ -4094,9 +4102,9 @@ impl KspContext {
         }
 
         if let Some(st) = self.solver_type {
-            if st == SolverType::Fgmres && side != PcSide::Right {
+            if st.right_only_pc_side() && side != PcSide::Right {
                 return Err(KError::InvalidInput(format!(
-                    "FGMRES supports only right preconditioning; got {side:?}"
+                    "{st:?} supports only right preconditioning; got {side:?}"
                 )));
             }
             if let Some(required) = st.required_pc_side() {

--- a/tests/solver_minimal_convergence.rs
+++ b/tests/solver_minimal_convergence.rs
@@ -72,7 +72,9 @@ fn assert_converged(reason: ConvergedReason) {
     assert!(
         matches!(
             reason,
-            ConvergedReason::ConvergedAtol | ConvergedReason::ConvergedRtol
+            ConvergedReason::ConvergedAtol
+                | ConvergedReason::ConvergedRtol
+                | ConvergedReason::ConvergedHappyBreakdown
         ),
         "unexpected convergence reason: {reason:?}"
     );


### PR DESCRIPTION
### Motivation
- Align `KspContext` preconditioning-side handling with solver implementations so GMRES-family flexible/backed solvers that require right preconditioning are enforced consistently. 
- Prevent accidental propagation of a left `pc_side` into solvers (`FGMRES`/`GCR`/`PipeGCR`) that only support right-side mutable preconditioning. 

### Description
- Added `SolverType::right_only_pc_side()` and treated `Gcr` and `PipeGcr` the same as `Fgmres` for side-defaulting and validation by updating `effective_side_for_solver`, `check_pc_side_now`, `set_type`, and `configure_pc_side` in `src/context/ksp_context/mod.rs`. 
- Normalized effective PC side so `Fgmres`, `Gcr`, and `PipeGcr` resolve to `PcSide::Right` to avoid left-side flow-through. 
- Relaxed the minimal convergence assertion in `tests/solver_minimal_convergence.rs` to accept `ConvergedHappyBreakdown` as a valid converged outcome for the tiny diagonal test case. 

### Testing
- Ran `cargo test -q --test solver_minimal_convergence`, which initially reproduced the failure (invalid left-side usage), and after the fix the test suite passed with `4/4` tests. 
- The modified test now accepts `ConvergedHappyBreakdown` and the targeted minimal-convergence tests for `Gcr` succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7ef37d8488329a0368f9f1477f0d5)