### PR TITLE
Fix brittle FGMRES error-message assertion in KSP context test

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -4757,7 +4757,7 @@ mod tests {
             .expect_err("FGMRES must reject left preconditioning");
         match err {
             KError::InvalidInput(msg) => {
-                assert!(msg.contains("FGMRES"));
+                assert!(msg.to_lowercase().contains("fgmres"));
                 assert!(msg.to_lowercase().contains("right preconditioning"));
             }
             other => panic!("unexpected error: {other:?}"),


### PR DESCRIPTION
### Motivation
- The unit test `fgmres_rejects_left_via_try_set_pc_side` was brittle because it required the solver name to appear in a specific capitalization form in the error message (`"FGMRES"`).

### Description
- Relaxed the assertion to be case-insensitive by replacing `msg.contains("FGMRES")` with `msg.to_lowercase().contains("fgmres")` in `src/context/ksp_context/mod.rs` so the test no longer depends on debug-format capitalization.

### Testing
- Ran the targeted test `cargo test fgmres_rejects_left_via_try_set_pc_side -- --nocapture`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e7f74b51f8832984eba95d67ce85d5)