### PR TITLE
Normalize Symmetric PC side to Right for right-only solvers (FGMRES/GCR/PipeGCR)

### DIFF
--- a/src/context/ksp_context/mod.rs
+++ b/src/context/ksp_context/mod.rs
@@ -525,7 +525,10 @@ impl KspContext {
     #[inline]
     fn effective_side_for_solver(side: PcSide, solver_type: SolverType) -> PcSide {
         match solver_type {
-            SolverType::Fgmres | SolverType::Gcr | SolverType::PipeGcr => PcSide::Right,
+            SolverType::Fgmres | SolverType::Gcr | SolverType::PipeGcr => match side {
+                PcSide::Symmetric => PcSide::Right,
+                s => s,
+            },
             _ => match side {
                 PcSide::Symmetric => PcSide::Left,
                 s => s,
@@ -604,7 +607,7 @@ impl KspContext {
             side
         };
         if let Some(st) = self.solver_type {
-            if st.right_only_pc_side() && side != PcSide::Right {
+            if st.right_only_pc_side() && normalized != PcSide::Right {
                 return Err(KError::InvalidInput(format!(
                     "{st:?} supports only right preconditioning; got {side:?}"
                 )));
@@ -704,7 +707,9 @@ impl KspContext {
 
     pub fn set_type(&mut self, solver_type: SolverType) -> Result<&mut Self, KError> {
         if solver_type.right_only_pc_side() {
-            if self.pc_side_explicit && self.pc_side != PcSide::Right {
+            if self.pc_side_explicit
+                && Self::effective_side_for_solver(self.pc_side, solver_type) != PcSide::Right
+            {
                 return Err(KError::InvalidInput(format!(
                     "{solver_type:?} supports only right preconditioning; got {:?}",
                     self.pc_side
@@ -1054,7 +1059,7 @@ impl KspContext {
             (requested_solver_type, opts.pc_side.as_ref())
         {
             let parsed_side = PcSide::from_str(side_label)?;
-            if parsed_side != PcSide::Right {
+            if Self::effective_side_for_solver(parsed_side, SolverType::Fgmres) != PcSide::Right {
                 return Err(KError::InvalidInput(format!(
                     "FGMRES supports only right preconditioning; got {parsed_side:?} from -ksp_pc_side={side_label}"
                 )));


### PR DESCRIPTION
### Motivation
- A nested KSP/PC configuration triggered an invalid-input failure when an outer `symmetric` PC side should logically align with an inner right-only solver (FGMRES), so the context-side normalization and validation need to accept `symmetric` as effectively `right` for those solvers.

### Description
- Change `KspContext::effective_side_for_solver` to treat `PcSide::Symmetric` as `PcSide::Right` when `solver_type` is `Fgmres`, `Gcr`, or `PipeGcr`, while preserving the existing `Symmetric -> Left` mapping for other solvers.
- Update fast-fail checks to validate the normalized side (use `effective_side_for_solver(...)`) in `check_pc_side_now` and `set_type` so compatibility is checked against the effective side rather than the raw requested side.
- Update options parsing in `set_from_options` to use the normalized rule when validating `-ksp_pc_side` for `FGMRES` so `symmetric` is accepted as aligning to `right` while explicit incompatible sides remain rejected.
- The changes are contained in `src/context/ksp_context/mod.rs`.

### Testing
- Ran `cargo test --features complex --test nested_ksp_pc_complex nested_ksp_pc_complex_symmetric_outer_aligns_with_inner_fgmres_side -- --exact` and the test passed.
- Ran `cargo test --test fgmres_ksp fgmres_rejects_non_right_side_via_api -- --exact` and the test passed.
- Project compiled and library tests were exercised during validation with only warnings emitted and no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e92481fce08329be0562d8d6af1c2f)