### PR TITLE
Add DistCSR-aware policy hook to FGMRES and regression tests

### DIFF
--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -8,11 +8,12 @@ use crate::algebra::prelude::*;
 use crate::algebra::scalar::{copy_real_to_scalar_in, copy_scalar_to_real_in};
 use crate::context::ksp_context::{GmresSpec, GmresWorkspaceLayout, ReorthPolicy, Workspace};
 use crate::error::KError;
+use crate::matrix::dist_csr::{DistributedPlanDiagnostics, HaloOverlapMode};
 use crate::matrix::op::LinOp;
 use crate::ops::klinop::KLinOp;
 use crate::ops::kpc::KPreconditioner;
 use crate::ops::wrap::{as_s_op, as_s_pc_mut};
-use crate::parallel::UniverseComm;
+use crate::parallel::{Comm, UniverseComm};
 use crate::preconditioner::{PcSide, Preconditioner};
 use crate::solver::LinearSolver;
 use crate::solver::MonitorCallback;
@@ -73,6 +74,16 @@ pub enum ModifyPcPolicy {
     Never,
     OnRestart,
     EachIteration,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub(crate) struct DistCsrPolicyDecision {
+    pub(crate) variant: FgmresVariant,
+    pub(crate) pipeline_policy: PipelinePolicy,
+    pub(crate) residual_check_policy: ResidualCheckPolicy,
+    pub(crate) restart: usize,
+    pub(crate) tag: &'static str,
+    pub(crate) reason: &'static str,
 }
 
 pub type ModifyPcCallback = dyn FnMut(usize, usize, R, Option<R>, &mut dyn KPreconditioner<Scalar = S>) -> Result<(), KError>
@@ -258,6 +269,77 @@ impl FgmresSolver {
     #[inline]
     fn cgs_refinement_mode(&self) -> CgsRefinement {
         self.cgs_refinement
+    }
+
+    pub(crate) fn select_distcsr_policy(
+        &self,
+        diag: &DistributedPlanDiagnostics,
+        comm_size: usize,
+    ) -> DistCsrPolicyDecision {
+        let halo_volume = (diag.halo_recv_volume + diag.halo_send_volume) as f64;
+        let comm_pressure = diag.expected_communication_fraction;
+        let compute_pressure = diag.expected_computation_fraction;
+        let overlap_enabled = diag.overlap_mode == HaloOverlapMode::Interior;
+        let communication_heavy =
+            comm_size > 1 && (overlap_enabled || comm_pressure >= 0.55 || halo_volume >= 4096.0);
+
+        if communication_heavy {
+            let very_heavy = comm_pressure >= 0.70 || halo_volume >= 16_384.0;
+            let restart = if very_heavy {
+                self.restart.min(24).max(8)
+            } else {
+                self.restart.min(32).max(8)
+            };
+            DistCsrPolicyDecision {
+                variant: FgmresVariant::Pipelined,
+                pipeline_policy: if very_heavy {
+                    PipelinePolicy::PeriodicResidualReplacement
+                } else {
+                    PipelinePolicy::FallbackToClassicalOnStagnation
+                },
+                residual_check_policy: ResidualCheckPolicy::RestartOnly,
+                restart,
+                tag: "distcsr_policy=comm_heavy",
+                reason: "high halo/communication pressure detected",
+            }
+        } else {
+            DistCsrPolicyDecision {
+                variant: FgmresVariant::Classical,
+                pipeline_policy: PipelinePolicy::Strict,
+                residual_check_policy: if compute_pressure >= 0.70 {
+                    ResidualCheckPolicy::OnConvergence
+                } else {
+                    ResidualCheckPolicy::EveryIteration
+                },
+                restart: self.restart.max(16).min(self.maxits.max(1)),
+                tag: "distcsr_policy=compute_heavy",
+                reason: "low halo pressure and compute-dominant local work",
+            }
+        }
+    }
+
+    fn apply_distcsr_policy_hook(&mut self, diag: &DistributedPlanDiagnostics, comm_size: usize) {
+        let decision = self.select_distcsr_policy(diag, comm_size);
+        self.variant = decision.variant;
+        self.pipeline_policy = decision.pipeline_policy;
+        self.residual_check_policy = decision.residual_check_policy;
+        self.restart = decision.restart.max(1);
+
+        #[cfg(feature = "logging")]
+        if log::log_enabled!(log::Level::Info) {
+            log::info!(
+                "FGMRES DistCSR policy selected: {} reason={} variant={:?} pipeline_policy={:?} residual_check_policy={:?} restart={} comm_pressure={:.3} compute_pressure={:.3} overlap={:?}",
+                decision.tag,
+                decision.reason,
+                decision.variant,
+                decision.pipeline_policy,
+                decision.residual_check_policy,
+                decision.restart,
+                diag.expected_communication_fraction,
+                diag.expected_computation_fraction,
+                diag.overlap_mode,
+            );
+        }
     }
 
     fn should_run_cgs_refinement(&self, wnorm0: R, hnext: R) -> bool {
@@ -553,6 +635,24 @@ impl FgmresSolver {
     pub fn solve_k<A>(
         &mut self,
         a: &A,
+        pc: Option<&mut dyn KPreconditioner<Scalar = S>>,
+        b: &[S],
+        x: &mut [S],
+        pc_side: PcSide,
+        comm: &UniverseComm,
+        monitors: Option<&[Box<MonitorCallback<R>>]>,
+        work: Option<&mut Workspace>,
+    ) -> Result<SolveStats<R>, KError>
+    where
+        A: KLinOp<Scalar = S> + ?Sized,
+    {
+        self.solve_k_with_dist_policy(a, pc, b, x, pc_side, comm, monitors, work, None)
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn solve_k_with_dist_policy<A>(
+        &mut self,
+        a: &A,
         mut pc: Option<&mut dyn KPreconditioner<Scalar = S>>,
         b: &[S],
         x: &mut [S],
@@ -560,6 +660,7 @@ impl FgmresSolver {
         comm: &UniverseComm,
         monitors: Option<&[Box<MonitorCallback<R>>]>,
         work: Option<&mut Workspace>,
+        dist_plan_diag: Option<&DistributedPlanDiagnostics>,
     ) -> Result<SolveStats<R>, KError>
     where
         A: KLinOp<Scalar = S> + ?Sized,
@@ -582,6 +683,9 @@ impl FgmresSolver {
             )));
         }
 
+        if let Some(diag) = dist_plan_diag {
+            self.apply_distcsr_policy_hook(diag, comm.size());
+        }
         let workspace_cols = self.workspace_cols();
 
         let mut owned_ws;
@@ -1348,8 +1452,7 @@ impl FgmresSolver {
         if !op_comm.congruent(comm) {
             return Err(KError::InvalidInput(format!(
                 "FGMRES DistCSR route: communicator mismatch (A={:?}, solve={:?})",
-                op_comm,
-                comm
+                op_comm, comm
             )));
         }
 
@@ -1378,7 +1481,17 @@ impl FgmresSolver {
         monitors: Option<&[Box<MonitorCallback<R>>]>,
         work: Option<&mut Workspace>,
     ) -> Result<SolveStats<f64>, KError> {
-        self.solve_k(a, pc, b, x, pc_side, comm, monitors, work)
+        self.solve_k_with_dist_policy(
+            a,
+            pc,
+            b,
+            x,
+            pc_side,
+            comm,
+            monitors,
+            work,
+            Some(a.plan_diagnostics()),
+        )
     }
 
     #[allow(clippy::too_many_arguments)]

--- a/src/solver/tests/fgmres_distcsr.rs
+++ b/src/solver/tests/fgmres_distcsr.rs
@@ -1,19 +1,26 @@
 use super::util;
 use crate::context::ksp_context::Workspace;
 use crate::error::KError;
+use crate::matrix::dist_csr::{DistributedPlanMetrics, choose_distributed_plan};
 use crate::matrix::op::{DistLayout, LinOp};
 use crate::matrix::{DistCsrOp, sparse::CsrMatrix};
-use crate::parallel::{NoComm, UniverseComm};
 #[cfg(feature = "rayon")]
 use crate::parallel::RayonComm;
+use crate::parallel::{NoComm, UniverseComm};
 use crate::preconditioner::PcSide;
-use crate::solver::fgmres::FgmresSolver;
 use crate::solver::LinearSolver;
+use crate::solver::fgmres::{FgmresSolver, FgmresVariant, PipelinePolicy, ResidualCheckPolicy};
 use approx::assert_abs_diff_eq;
 use std::any::Any;
 
 fn dist_fixture_2x2() -> Result<(DistCsrOp, Vec<f64>, Vec<f64>), KError> {
-    let csr = CsrMatrix::from_csr(2, 2, vec![0, 2, 4], vec![0, 1, 0, 1], vec![4.0, 1.0, 2.0, 3.0]);
+    let csr = CsrMatrix::from_csr(
+        2,
+        2,
+        vec![0, 2, 4],
+        vec![0, 1, 0, 1],
+        vec![4.0, 1.0, 2.0, 3.0],
+    );
     let x_true = vec![1.0, -2.0];
     let mut b = vec![0.0; 2];
     csr.spmv(&x_true, &mut b);
@@ -134,4 +141,60 @@ fn fgmres_distcsr_route_rejects_noncongruent_comm() {
         KError::InvalidInput(msg) => assert!(msg.contains("DistCSR route")),
         other => panic!("unexpected error: {other:?}"),
     }
+}
+
+#[test]
+fn fgmres_distcsr_policy_selector_prefers_low_sync_for_comm_heavy_setup() {
+    let solver = FgmresSolver::new(1e-10, 200, 64);
+    let heavy_diag = choose_distributed_plan(
+        &DistributedPlanMetrics {
+            n_local_rows: 20_000,
+            local_nnz: 80_000,
+            local_diag_nnz: 28_000,
+            ghost_nnz: 52_000,
+            local_only_rows: 7_500,
+            border_rows: 12_500,
+            halo_recv_volume: 14_000,
+            halo_send_volume: 13_500,
+        },
+        None,
+    );
+    let decision = solver.select_distcsr_policy(&heavy_diag, 8);
+    assert_eq!(decision.variant, FgmresVariant::Pipelined);
+    assert!(matches!(
+        decision.pipeline_policy,
+        PipelinePolicy::FallbackToClassicalOnStagnation
+            | PipelinePolicy::PeriodicResidualReplacement
+    ));
+    assert_eq!(
+        decision.residual_check_policy,
+        ResidualCheckPolicy::RestartOnly
+    );
+    assert!(decision.restart <= solver.restart);
+}
+
+#[test]
+fn fgmres_distcsr_policy_selector_prefers_classical_for_compute_heavy_setup() {
+    let solver = FgmresSolver::new(1e-10, 200, 12);
+    let compute_diag = choose_distributed_plan(
+        &DistributedPlanMetrics {
+            n_local_rows: 20_000,
+            local_nnz: 90_000,
+            local_diag_nnz: 86_000,
+            ghost_nnz: 4_000,
+            local_only_rows: 18_500,
+            border_rows: 1_500,
+            halo_recv_volume: 400,
+            halo_send_volume: 450,
+        },
+        None,
+    );
+    let decision = solver.select_distcsr_policy(&compute_diag, 8);
+    assert_eq!(decision.variant, FgmresVariant::Classical);
+    assert_eq!(decision.pipeline_policy, PipelinePolicy::Strict);
+    assert!(matches!(
+        decision.residual_check_policy,
+        ResidualCheckPolicy::OnConvergence | ResidualCheckPolicy::EveryIteration
+    ));
+    assert!(decision.restart >= solver.restart);
 }


### PR DESCRIPTION
### Motivation
- Reduce global-reduction pressure for distributed CSR operators by selecting FGMRES runtime policies tuned to distributed characteristics (halo/overlap/plan diagnostics) before the inner iteration loop.
- Provide a lightweight selector to pick between classical vs pipelined variants, pipeline behavior, residual-check frequency, and restart sizing based on DistCSR diagnostics and communicator size.
- Emit structured logs indicating which distributed policy was chosen and why so operators and users can observe policy decisions.
- Guard correctness by adding regression tests that verify policy selection for communication-heavy and compute-heavy DistCSR scenarios.

### Description
- Added a `DistCsrPolicyDecision` struct and `select_distcsr_policy` method on `FgmresSolver` that maps `DistributedPlanDiagnostics` and `comm.size()` into `FgmresVariant`, `PipelinePolicy`, `ResidualCheckPolicy`, and a restart heuristic plus human-readable `tag`/`reason` strings.
- Added `apply_distcsr_policy_hook` which applies the decision to the solver fields and logs a structured info message with tag/reason and pressure diagnostics when logging is enabled.
- Threaded DistCSR diagnostics into the solver: added `solve_k_with_dist_policy` and made the public `solve_k` call it, and updated the DistCSR dispatch path (`solve_dist_csr`) to forward `a.plan_diagnostics()` so the hook runs before the iteration loop.
- Added regression tests in `src/solver/tests/fgmres_distcsr.rs` that build `DistributedPlanMetrics` + `choose_distributed_plan` fixtures and assert the selector picks a low-sync/pipelined configuration for communication-heavy plans and a classical/strict configuration for compute-heavy plans.

### Testing
- Ran `cargo fmt --all` which completed successfully.
- Ran targeted tests: `fgmres_distcsr_policy_selector_prefers_low_sync_for_comm_heavy_setup` and `fgmres_distcsr_policy_selector_prefers_classical_for_compute_heavy_setup` via `cargo test -q fgmres_distcsr_policy_selector`, which passed.
- Ran `cargo test -q fgmres_distcsr_and_generic_routes_match_numerics`, which also passed; test output contained unrelated project warnings but no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e934b81cc08329b844abd95d88e875)