### PR TITLE
Guard FGMRES DistCSR f64-only tests under complex builds

### DIFF
--- a/src/solver/tests/fgmres_distcsr.rs
+++ b/src/solver/tests/fgmres_distcsr.rs
@@ -13,6 +13,7 @@ use crate::solver::fgmres::{FgmresSolver, FgmresVariant, PipelinePolicy, Residua
 use approx::assert_abs_diff_eq;
 use std::any::Any;
 
+#[cfg(not(feature = "complex"))]
 fn dist_fixture_2x2() -> Result<(DistCsrOp, Vec<f64>, Vec<f64>), KError> {
     let csr = CsrMatrix::from_csr(
         2,
@@ -29,10 +30,12 @@ fn dist_fixture_2x2() -> Result<(DistCsrOp, Vec<f64>, Vec<f64>), KError> {
     Ok((op, b, x_true))
 }
 
+#[cfg(not(feature = "complex"))]
 struct HiddenDistOp {
     inner: DistCsrOp,
 }
 
+#[cfg(not(feature = "complex"))]
 impl LinOp for HiddenDistOp {
     type S = f64;
 
@@ -62,6 +65,7 @@ impl LinOp for HiddenDistOp {
 }
 
 #[test]
+#[cfg(not(feature = "complex"))]
 fn fgmres_distcsr_and_generic_routes_match_numerics() -> Result<(), KError> {
     let (dist, b, x_true) = dist_fixture_2x2()?;
     let comm = UniverseComm::NoComm(NoComm);
@@ -115,6 +119,7 @@ fn fgmres_distcsr_and_generic_routes_match_numerics() -> Result<(), KError> {
 
 #[cfg(feature = "rayon")]
 #[test]
+#[cfg(not(feature = "complex"))]
 fn fgmres_distcsr_route_rejects_noncongruent_comm() {
     let (dist, b, _) = dist_fixture_2x2().expect("fixture");
 


### PR DESCRIPTION
### Motivation
- Fix type mismatches when building with the `complex` feature by preventing tests that assume `f64`-typed `LinOp` from compiling against `DistCsrOp` which uses the `S` alias (becomes `Complex64` when `feature = "complex"`).

### Description
- Added `#[cfg(not(feature = "complex"))]` to the DistCSR test fixture `dist_fixture_2x2` in `src/solver/tests/fgmres_distcsr.rs` so it only compiles for real-scalar builds.
- Added the same `#[cfg(not(feature = "complex"))]` guard to the `HiddenDistOp` wrapper and the two tests that call `solve_f64`, preventing `Complex<f64>` / `f64` type mismatches.

### Testing
- Ran the full test run with complex feature enabled using `RUSTFLAGS="-Awarnings" RUST_BACKTRACE=full cargo test --features=mpi,rayon,backend-faer,logging,complex -- --nocapture`, and the build and test suite completed successfully (tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e9379ea81c8329a4a320feffffbe2f)