### PR TITLE
Use globally reduced RHS norm in complex distributed demo and add MPI parity test

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -21,7 +21,6 @@ mod complex_demo {
     use std::time::Instant;
 
     use super::KError;
-    use kryst::algebra::blas::nrm2;
     use kryst::algebra::bridge::BridgeScratch;
     use kryst::algebra::prelude::*;
     use kryst::context::ksp_context::{ReorthPolicy, Workspace};
@@ -105,7 +104,8 @@ mod complex_demo {
                 }
             };
 
-            let rhs_norm = nrm2(&problem.rhs);
+            let rhs_norm2_local: f64 = problem.rhs.iter().map(|v| v.abs2()).sum();
+            let rhs_norm = problem.comm.all_reduce_f64(rhs_norm2_local).sqrt();
             if rank == 0 {
                 println!("=== {descr} — {} ===", problem.backend_descr);
                 println!(

--- a/tests/mpi_rhs_norm_parity.rs
+++ b/tests/mpi_rhs_norm_parity.rs
@@ -1,0 +1,35 @@
+#![cfg(not(feature = "complex"))]
+#![cfg(feature = "mpi")]
+
+mod fixtures;
+
+use std::sync::Arc;
+
+use kryst::parallel::{Comm, MpiComm, UniverseComm};
+
+#[test]
+fn mpi_rhs_norm_matches_serial_on_same_matrix() {
+    let comm = UniverseComm::Mpi(Arc::new(MpiComm::new()));
+
+    let n_per_rank = 7usize;
+    let n_global = n_per_rank * comm.size();
+    let matrix = fixtures::csr_poisson_1d(n_global);
+
+    let rhs_global: Vec<f64> = (0..matrix.nrows())
+        .map(|i| 1.0 + 0.125 * i as f64)
+        .collect();
+    let serial_norm = rhs_global.iter().map(|v| v * v).sum::<f64>().sqrt();
+
+    let rank = comm.rank();
+    let row_start = rank * n_per_rank;
+    let row_end = row_start + n_per_rank;
+    let rhs_local = &rhs_global[row_start..row_end];
+    let rhs_norm2_local = rhs_local.iter().map(|v| v * v).sum::<f64>();
+    let mpi_norm = comm.all_reduce_f64(rhs_norm2_local).sqrt();
+
+    let tol = 1e-12 * serial_norm.max(1.0);
+    assert!(
+        (mpi_norm - serial_norm).abs() <= tol,
+        "MPI-reduced rhs norm {mpi_norm:.16e} differs from serial {serial_norm:.16e} (tol={tol:.3e})"
+    );
+}


### PR DESCRIPTION
### Motivation
- Ensure distributed demo reporting uses a true global RHS norm instead of per-rank local values for consistent initial reports and convergence summaries. 
- Provide a small automated regression that verifies MPI-allreduce parity with a serial computation on the same matrix to catch future regressions.

### Description
- Change `examples/complex_matrix_market_demo.rs` to compute `rhs_norm` as local sum of squared magnitudes (`.iter().map(|v| v.abs2()).sum()`), then `all_reduce_f64(sum)` and a final `sqrt()` to obtain the global Euclidean norm.
- Replace the previous rank-local `nrm2` usage so the demo prints a globally-consistent `‖rhs‖₂` in MPI runs.
- Add test `tests/mpi_rhs_norm_parity.rs` which constructs the same matrix, computes a serial `rhs` norm and an MPI-reduced norm (using local squared sums + `all_reduce_f64` + `sqrt`) and asserts parity within tolerance.

### Testing
- Ran `cargo fmt --all` to format changes successfully.
- Ran `cargo test --features mpi --test mpi_rhs_norm_parity` and the new MPI parity test passed (`ok`).
- No other automated tests were modified; the change is localized to the demo output and a new regression test.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9cdce95083298b60d98c585398c9)