### PR TITLE
Use PivotStrategy machinery for complex ILU(0)/ILUK pivots

### DIFF
--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -347,6 +347,17 @@ impl IluCsr {
         let mut map = URowMap::new();
         map.ensure_size(n);
         let milu = matches!(self.cfg.kind, IluKind::Milu0);
+        let mut max_diag_abs = 0.0f64;
+        for i in 0..n {
+            let mut di = S::zero();
+            for p in rp[i]..rp[i + 1] {
+                if cj[p] == i {
+                    di = vv[p];
+                    break;
+                }
+            }
+            max_diag_abs = max_diag_abs.max(di.abs());
+        }
 
         for i in 0..n {
             map.prime(&self.u_row, &self.u_col, i);
@@ -386,10 +397,16 @@ impl IluCsr {
                 }
             }
 
-            let d = self.c_u_val[self.u_diag_ix[i]];
-            if d.abs() <= self.cfg.pivot_threshold {
-                return Err(KError::ZeroPivot(i));
-            }
+            let di_pos = self.u_diag_ix[i];
+            let fixed = pivot::handle_pivot_scalar(
+                self.c_u_val[di_pos],
+                self.cfg.pivot,
+                self.cfg.pivot_threshold,
+                self.cfg.diag_perturb_factor,
+                max_diag_abs,
+            )
+            .map_err(|_| KError::ZeroPivot(i))?;
+            self.c_u_val[di_pos] = fixed;
         }
 
         self.native_complex_active = true;
@@ -416,6 +433,17 @@ impl IluCsr {
         let vv = a.values();
         let mut map = URowMap::new();
         map.ensure_size(n);
+        let mut max_diag_abs = 0.0f64;
+        for i in 0..n {
+            let mut di = S::zero();
+            for p in rp[i]..rp[i + 1] {
+                if cj[p] == i {
+                    di = vv[p];
+                    break;
+                }
+            }
+            max_diag_abs = max_diag_abs.max(di.abs());
+        }
 
         for i in 0..n {
             map.prime(&self.u_row, &self.u_col, i);
@@ -453,9 +481,16 @@ impl IluCsr {
                 }
             }
 
-            if self.c_u_val[self.u_diag_ix[i]].abs() <= self.cfg.pivot_threshold {
-                return Err(KError::ZeroPivot(i));
-            }
+            let di_pos = self.u_diag_ix[i];
+            let fixed = pivot::handle_pivot_scalar(
+                self.c_u_val[di_pos],
+                self.cfg.pivot,
+                self.cfg.pivot_threshold,
+                self.cfg.diag_perturb_factor,
+                max_diag_abs,
+            )
+            .map_err(|_| KError::ZeroPivot(i))?;
+            self.c_u_val[di_pos] = fixed;
         }
 
         self.native_complex_active = true;
@@ -1776,4 +1811,75 @@ fn transpose_csr(
         }
     }
     (t_row, t_col, t_val)
+}
+
+#[cfg(all(test, feature = "complex"))]
+mod complex_pivot_tests {
+    use super::*;
+
+    fn checkerboard_zero_diag() -> CsrMatrix<S> {
+        CsrMatrix::from_csr(
+            2,
+            2,
+            vec![0, 1, 2],
+            vec![1, 0],
+            vec![S::from_real(1.0), S::from_real(1.0)],
+        )
+    }
+
+    #[test]
+    fn ilu0_complex_zero_pivot_obeys_strategy() {
+        let a = checkerboard_zero_diag();
+
+        let mut strict = IluCsr::new_with_config(IluCsrConfig {
+            kind: IluKind::Ilu0,
+            pivot: PivotStrategy::Strict,
+            pivot_threshold: 1e-12,
+            diag_perturb_factor: 1e-10,
+            level_sched: false,
+            numeric_update_fixed: true,
+            logging: 0,
+            reordering: ReorderingOptions::default(),
+            conditioning: ConditioningOptions::default(),
+        });
+        assert!(strict.factor_ilu0_complex(&a).is_err());
+
+        let mut threshold = IluCsr::new_with_config(IluCsrConfig {
+            kind: IluKind::Ilu0,
+            pivot: PivotStrategy::Threshold,
+            pivot_threshold: 1e-12,
+            diag_perturb_factor: 1e-10,
+            level_sched: false,
+            numeric_update_fixed: true,
+            logging: 0,
+            reordering: ReorderingOptions::default(),
+            conditioning: ConditioningOptions::default(),
+        });
+        threshold
+            .factor_ilu0_complex(&a)
+            .expect("threshold pivot policy should floor tiny complex pivots");
+        for i in 0..threshold.n {
+            let d = threshold.c_u_val[threshold.u_diag_ix[i]];
+            assert!(d.abs() >= 1e-12, "row {i} pivot should be floored");
+        }
+
+        let mut perturb = IluCsr::new_with_config(IluCsrConfig {
+            kind: IluKind::Ilu0,
+            pivot: PivotStrategy::DiagonalPerturbation,
+            pivot_threshold: 1e-12,
+            diag_perturb_factor: 1e-10,
+            level_sched: false,
+            numeric_update_fixed: true,
+            logging: 0,
+            reordering: ReorderingOptions::default(),
+            conditioning: ConditioningOptions::default(),
+        });
+        perturb
+            .factor_ilu0_complex(&a)
+            .expect("diag perturbation should repair tiny complex pivots");
+        for i in 0..perturb.n {
+            let d = perturb.c_u_val[perturb.u_diag_ix[i]];
+            assert!(d.abs() > 0.0, "row {i} pivot should be nonzero");
+        }
+    }
 }

--- a/src/preconditioner/ilu_csr/pivot.rs
+++ b/src/preconditioner/ilu_csr/pivot.rs
@@ -17,6 +17,17 @@ pub fn handle_pivot(
     diag_perturb_factor: R,
     max_diag_abs: R,
 ) -> Result<Real, KError> {
+    handle_pivot_scalar(raw_pivot, strategy, thr, diag_perturb_factor, max_diag_abs)
+}
+
+#[inline]
+pub fn handle_pivot_scalar<T: KrystScalar<Real = R>>(
+    raw_pivot: T,
+    strategy: PivotStrategy,
+    thr: R,
+    diag_perturb_factor: R,
+    max_diag_abs: R,
+) -> Result<T, KError> {
     match strategy {
         PivotStrategy::Strict => {
             if raw_pivot.abs() < thr {
@@ -42,11 +53,11 @@ pub fn handle_pivot(
                     1.0
                 };
                 let delta = (diag_perturb_factor.abs().max(thr.min(1.0) * 1e-12)) * base;
-                let delta_s = Real::from_real(delta);
+                let delta_s = T::from_real(delta);
                 let direction = if abs > 0.0 {
-                    raw_pivot / Real::from_real(abs)
+                    raw_pivot / T::from_real(abs)
                 } else {
-                    Real::one()
+                    T::one()
                 };
                 Ok(direction * delta_s)
             } else {
@@ -57,14 +68,14 @@ pub fn handle_pivot(
 }
 
 #[inline]
-fn rescale_to_magnitude(pivot: Real, magnitude: R) -> Real {
+fn rescale_to_magnitude<T: KrystScalar<Real = R>>(pivot: T, magnitude: R) -> T {
     if magnitude == 0.0 {
-        return Real::zero();
+        return T::zero();
     }
     let abs = pivot.abs();
     if abs == 0.0 {
-        Real::from_real(magnitude)
+        T::from_real(magnitude)
     } else {
-        pivot * Real::from_real(magnitude / abs)
+        pivot * T::from_real(magnitude / abs)
     }
 }


### PR DESCRIPTION
### Motivation
- Complex ILU numeric kernels used ad-hoc hard-fail checks for tiny/zero pivots which diverged from the real-scalar pivot policy machinery and caused previously failing complex cases (e.g., DWG-style zero pivot). 

### Description
- Add a generic scalar helper `handle_pivot_scalar` in `preconditioner::ilu_csr::pivot` and keep `handle_pivot` forwarding to it so both real and complex pivots share `PivotStrategy` semantics (`Strict`, `Threshold`, `DiagonalPerturbation`).
- Replace direct threshold hard-fail checks in `factor_ilu0_complex` and `factor_iluk_complex` with calls to `handle_pivot_scalar`, and precompute `max_diag_abs` for consistent diagonal-perturbation scaling.
- Add a unit test `ilu0_complex_zero_pivot_obeys_strategy` (guarded by `#[cfg(all(test, feature = "complex"))]`) that exercises a 2x2 checkerboard zero-diagonal CSR matrix and verifies `Strict` fails while `Threshold` and `DiagonalPerturbation` recover.
- Files changed: `src/preconditioner/ilu_csr/pivot.rs`, `src/preconditioner/ilu_csr/mod.rs` (complex kernels + new tests).

### Testing
- Ran the focused unit test with complex features: `cargo test --features "complex complex_ilu" --lib ilu0_complex_zero_pivot_obeys_strategy`, and the new test passed (1 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ea9f1f0280832984d67754c8e75faf)