### PR TITLE
Fix complex ILU CSR symmetric/nonsymmetric permutation routing

### DIFF
--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -12,7 +12,9 @@ use crate::preconditioner::{
 use crate::utils::conditioning::ConditioningOptions;
 use crate::utils::permutation::Permutation;
 #[cfg(feature = "complex")]
-use crate::utils::permutation::{amd_csr, permute_csr_symmetric, rcm_csr};
+use crate::utils::permutation::{
+    amd_csr, permute_csr_nonsymmetric, permute_csr_symmetric, rcm_csr,
+};
 use crate::utils::preconditioning_pipeline::{
     PreconditioningMetadata, apply_preconditioning_pipeline,
 };
@@ -1421,14 +1423,34 @@ impl Preconditioner for IluCsr {
                 }
             };
             let a_perm = if self.cfg.reordering.symmetric {
-                permute_csr_symmetric(csr, &perm)
+                self.perm = perm.clone();
+                self.pipeline_meta = PreconditioningMetadata::identity(csr.nrows());
+                self.pipeline_meta.left_perm = perm.clone();
+                self.pipeline_meta.right_perm = perm;
+                permute_csr_symmetric(csr, &self.pipeline_meta.left_perm)
             } else {
-                permute_csr_symmetric(csr, &perm)
+                let a_real = CsrMatrix::from_csr(
+                    csr.nrows(),
+                    csr.ncols(),
+                    csr.row_ptr().to_vec(),
+                    csr.col_idx().to_vec(),
+                    csr.values().iter().map(|v| v.real()).collect(),
+                );
+                let pipeline = apply_preconditioning_pipeline(
+                    &a_real,
+                    &ConditioningOptions::default(),
+                    &self.cfg.reordering,
+                )?;
+                self.perm = pipeline.metadata.left_perm.clone();
+                self.pipeline_meta = PreconditioningMetadata::identity(csr.nrows());
+                self.pipeline_meta.left_perm = pipeline.metadata.left_perm.clone();
+                self.pipeline_meta.right_perm = pipeline.metadata.right_perm;
+                permute_csr_nonsymmetric(
+                    csr,
+                    &self.pipeline_meta.left_perm,
+                    &self.pipeline_meta.right_perm,
+                )
             };
-            self.perm = perm.clone();
-            self.pipeline_meta = PreconditioningMetadata::identity(csr.nrows());
-            self.pipeline_meta.left_perm = perm.clone();
-            self.pipeline_meta.right_perm = perm;
 
             match self.cfg.kind {
                 IluKind::Ilu0 | IluKind::Milu0 => {
@@ -1544,7 +1566,15 @@ impl Preconditioner for IluCsr {
         let csr = op.as_any().downcast_ref::<CsrMatrix<S>>().ok_or_else(|| {
             KError::Unsupported("IluCsr complex numeric update requires CSR".into())
         })?;
-        let a_perm = permute_csr_symmetric(csr, &self.perm);
+        let a_perm = if self.cfg.reordering.symmetric {
+            permute_csr_symmetric(csr, &self.pipeline_meta.left_perm)
+        } else {
+            permute_csr_nonsymmetric(
+                csr,
+                &self.pipeline_meta.left_perm,
+                &self.pipeline_meta.right_perm,
+            )
+        };
         match self.cfg.kind {
             IluKind::Ilu0 | IluKind::Milu0 => {
                 if self.complex_force_degraded {

--- a/src/preconditioner/tests/ilu_csr_complex.rs
+++ b/src/preconditioner/tests/ilu_csr_complex.rs
@@ -4,7 +4,8 @@ use crate::algebra::prelude::*;
 use crate::matrix::sparse::CsrMatrix;
 use crate::preconditioner::Preconditioner;
 use crate::preconditioner::ilu_csr::{
-    IluComplexKernelMode, IluCsr, IluCsrConfig, IluKind, IlutParams, ReorderingOptions,
+    IluComplexKernelMode, IluCsr, IluCsrConfig, IluKind, IlutParams, ReorderingKind,
+    ReorderingOptions,
 };
 use crate::utils::conditioning::ConditioningOptions;
 
@@ -233,4 +234,122 @@ fn iluk_complex_native_beats_degraded_residual() {
         rn <= rd * 1.1,
         "ILU(k) native residual {rn} should be <= degraded residual {rd}"
     );
+}
+
+#[test]
+fn complex_setup_uses_distinct_nonsymmetric_permutation_path() {
+    let row_ptr = vec![0, 2, 4, 6, 8];
+    let col_idx = vec![0, 1, 0, 2, 1, 3, 2, 3];
+    let vals = vec![
+        S::from_parts(1.0, 0.0),
+        S::from_parts(9.0, 0.5),
+        S::from_parts(8.0, -0.3),
+        S::from_parts(1.2, 0.0),
+        S::from_parts(0.8, 0.1),
+        S::from_parts(7.5, -0.2),
+        S::from_parts(6.0, 0.4),
+        S::from_parts(1.1, 0.0),
+    ];
+    let a = CsrMatrix::from_csr(4, 4, row_ptr, col_idx, vals);
+    let rhs = vec![
+        S::from_parts(1.0, -0.2),
+        S::from_parts(0.3, 0.6),
+        S::from_parts(-0.5, 0.1),
+        S::from_parts(0.9, -0.4),
+    ];
+
+    let mut cfg = IluCsrConfig {
+        kind: IluKind::Ilu0,
+        ..IluCsrConfig::default()
+    };
+    cfg.reordering = ReorderingOptions {
+        kind: ReorderingKind::None,
+        symmetric: true,
+        deterministic: true,
+    };
+
+    let mut sym = IluCsr::new_with_config(cfg.clone());
+    sym.setup(&a).unwrap();
+    let mut y_sym = vec![S::zero(); 4];
+    sym.apply(crate::preconditioner::PcSide::Left, &rhs, &mut y_sym)
+        .unwrap();
+
+    cfg.reordering.symmetric = false;
+    let mut nonsym = IluCsr::new_with_config(cfg);
+    nonsym.setup(&a).unwrap();
+    let mut y_nonsym = vec![S::zero(); 4];
+    nonsym
+        .apply(crate::preconditioner::PcSide::Left, &rhs, &mut y_nonsym)
+        .unwrap();
+
+    let diff: f64 = y_sym
+        .iter()
+        .zip(y_nonsym.iter())
+        .map(|(a, b)| (*a - *b).abs())
+        .sum();
+    assert!(
+        diff > 1e-8,
+        "expected different outputs between symmetric and nonsymmetric permutation paths"
+    );
+}
+
+#[test]
+fn complex_nonsymmetric_numeric_update_matches_fresh_setup() {
+    let row_ptr = vec![0, 2, 4, 6, 8];
+    let col_idx = vec![0, 1, 0, 2, 1, 3, 2, 3];
+    let vals = vec![
+        S::from_parts(1.0, 0.0),
+        S::from_parts(10.0, 0.0),
+        S::from_parts(8.0, 0.0),
+        S::from_parts(1.0, 0.0),
+        S::from_parts(1.0, 0.0),
+        S::from_parts(7.0, 0.0),
+        S::from_parts(6.0, 0.0),
+        S::from_parts(1.0, 0.0),
+    ];
+    let a = CsrMatrix::from_csr(4, 4, row_ptr.clone(), col_idx.clone(), vals);
+    let rhs = vec![
+        S::from_parts(1.0, 0.2),
+        S::from_parts(-0.4, 0.1),
+        S::from_parts(0.7, -0.3),
+        S::from_parts(0.2, 0.5),
+    ];
+
+    let cfg = IluCsrConfig {
+        kind: IluKind::Iluk { k: 1 },
+        reordering: ReorderingOptions {
+            kind: ReorderingKind::None,
+            symmetric: false,
+            deterministic: true,
+        },
+        ..IluCsrConfig::default()
+    };
+
+    let mut updated = IluCsr::new_with_config(cfg.clone());
+    updated.setup(&a).unwrap();
+
+    let mut vals2 = a.values().to_vec();
+    for (k, v) in vals2.iter_mut().enumerate() {
+        *v += S::from_parts(0.05 * (k as f64 + 1.0), -0.01 * (k as f64));
+    }
+    let a2 = CsrMatrix::from_csr(4, 4, row_ptr, col_idx, vals2);
+    updated.update_numeric(&a2).unwrap();
+    let mut y_update = vec![S::zero(); 4];
+    updated
+        .apply(crate::preconditioner::PcSide::Left, &rhs, &mut y_update)
+        .unwrap();
+
+    let mut fresh = IluCsr::new_with_config(cfg);
+    fresh.setup(&a2).unwrap();
+    let mut y_fresh = vec![S::zero(); 4];
+    fresh
+        .apply(crate::preconditioner::PcSide::Left, &rhs, &mut y_fresh)
+        .unwrap();
+
+    for (i, (yu, yf)) in y_update.iter().zip(y_fresh.iter()).enumerate() {
+        assert!(
+            (*yu - *yf).abs() < 1e-8,
+            "numeric update should match fresh setup at index {i}"
+        );
+    }
 }

--- a/src/utils/permutation.rs
+++ b/src/utils/permutation.rs
@@ -74,6 +74,44 @@ pub fn permute_csr_symmetric<T: KrystScalar>(a: &CsrMatrix<T>, perm: &Permutatio
     CsrMatrix::from_csr(n, n, row_ptr, col_idx, values)
 }
 
+/// Nonsymmetric permutation of CSR matrix: A' = P_row A P_col^T
+pub fn permute_csr_nonsymmetric<T: KrystScalar>(
+    a: &CsrMatrix<T>,
+    row_perm: &Permutation,
+    col_perm: &Permutation,
+) -> CsrMatrix<T> {
+    let n = a.nrows();
+    assert_eq!(n, a.ncols());
+    let rp = a.row_ptr();
+    let cj = a.col_idx();
+    let vv = a.values();
+
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx = Vec::with_capacity(vv.len());
+    let mut values = Vec::with_capacity(vv.len());
+    row_ptr.push(0);
+
+    for new_i in 0..n {
+        let old_i = row_perm.p[new_i];
+        let rs = rp[old_i];
+        let re = rp[old_i + 1];
+        let mut entries = Vec::with_capacity(re - rs);
+        for k in rs..re {
+            let old_j = cj[k];
+            let new_j = col_perm.pinv[old_j];
+            entries.push((new_j, vv[k]));
+        }
+        entries.sort_unstable_by_key(|e| e.0);
+        for (j, v) in entries {
+            col_idx.push(j);
+            values.push(v);
+        }
+        row_ptr.push(col_idx.len());
+    }
+
+    CsrMatrix::from_csr(n, n, row_ptr, col_idx, values)
+}
+
 /// Reverse Cuthill-McKee ordering for a symmetric graph given by CSR matrix.
 pub fn rcm_csr<T>(a: &CsrMatrix<T>) -> Permutation {
     let n = a.nrows();

--- a/src/utils/preconditioning_pipeline.rs
+++ b/src/utils/preconditioning_pipeline.rs
@@ -2,7 +2,9 @@ use crate::error::KError;
 use crate::matrix::sparse::CsrMatrix;
 use crate::preconditioner::ilu_csr::{ReorderingKind, ReorderingOptions};
 use crate::utils::conditioning::{ConditioningOptions, ScaleDirection, ScaleNorm};
-use crate::utils::permutation::{Permutation, amd_csr, permute_csr_symmetric, rcm_csr};
+use crate::utils::permutation::{
+    Permutation, amd_csr, permute_csr_nonsymmetric, permute_csr_symmetric, rcm_csr,
+};
 
 #[derive(Clone, Debug)]
 pub struct PreconditioningMetadata {
@@ -107,41 +109,6 @@ fn compose_perm(new_then_old: &Permutation, old: &Permutation) -> Permutation {
         pinv[old_i] = new_i;
     }
     Permutation { p, pinv }
-}
-
-fn permute_csr_nonsymmetric<T: crate::algebra::scalar::KrystScalar>(
-    a: &CsrMatrix<T>,
-    row_perm: &Permutation,
-    col_perm: &Permutation,
-) -> CsrMatrix<T> {
-    let n = a.nrows();
-    let rp = a.row_ptr();
-    let cj = a.col_idx();
-    let vv = a.values();
-    let mut row_ptr = Vec::with_capacity(n + 1);
-    let mut col_idx = Vec::with_capacity(vv.len());
-    let mut values = Vec::with_capacity(vv.len());
-    row_ptr.push(0);
-
-    for new_i in 0..n {
-        let old_i = row_perm.p[new_i];
-        let rs = rp[old_i];
-        let re = rp[old_i + 1];
-        let mut entries = Vec::with_capacity(re - rs);
-        for k in rs..re {
-            let old_j = cj[k];
-            let new_j = col_perm.pinv[old_j];
-            entries.push((new_j, vv[k]));
-        }
-        entries.sort_unstable_by_key(|e| e.0);
-        for (j, v) in entries {
-            col_idx.push(j);
-            values.push(v);
-        }
-        row_ptr.push(col_idx.len());
-    }
-
-    CsrMatrix::from_csr(n, n, row_ptr, col_idx, values)
 }
 
 fn greedy_transversal_permutations(


### PR DESCRIPTION
### Motivation
- Ensure the complex `IluCsr` code follows the intended routing for symmetric vs nonsymmetric reordering so factorization and numeric updates use the same permutation semantics.
- Provide a reusable nonsymmetric CSR permutation utility so the pipeline and ILU code can share a correct implementation.
- Add tests that assert behavior differs between symmetric and nonsymmetric permutation paths and that numeric update yields the same result as a fresh setup for the nonsymmetric case.

### Description
- Added `permute_csr_nonsymmetric` to `src/utils/permutation.rs` and exposed it to callers. 
- Updated `src/utils/preconditioning_pipeline.rs` to import and use `permute_csr_nonsymmetric` for nonsymmetric reordering steps and pipeline composition. 
- Wired `IluCsr::setup` (complex branch) to: use `permute_csr_symmetric` when `reordering.symmetric=true`, and run the nonsymmetric pipeline (collect left/right perms) and apply `permute_csr_nonsymmetric` when `reordering.symmetric=false`, storing `pipeline_meta` accordingly. 
- Made complex `update_numeric` follow the stored `pipeline_meta` and use the symmetric or nonsymmetric permutation path consistently. 
- Added tests in `src/preconditioner/tests/ilu_csr_complex.rs` that (1) assert outputs differ between symmetric and nonsymmetric permutation paths and (2) check that `update_numeric` on a nonsymmetric path matches a fresh setup. 

### Testing
- Ran code formatting with `cargo fmt --all` which completed successfully. 
- Ran targeted unit tests with the complex feature: `cargo test --features complex complex_setup_uses_distinct_nonsymmetric_permutation_path` and `cargo test --features complex complex_nonsymmetric_numeric_update_matches_fresh_setup`, and both new tests passed. 
- Executed the test suite with `cargo test --features complex` during development and observed the new tests run and pass (no failures related to the changes).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eaabe5a7848329b796d616a4b7656c)