### PR TITLE
Gate row-filter ILUT behind explicit opt-in and prefer CSR ILU family in benchmarks/docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -514,12 +514,12 @@ Example AMG invocation:
 - `-pc_type approxinv` - Approximate inverse preconditioner
 
 #### ILU preconditioners
-`-pc_type ilu` selects Kryst's HYPRE-inspired incomplete LU family (`Ilu`). `-pc_type ilut`/`-pc_type
-ilutp` run the lighter-weight row-filter ILUT or pivoting ILUTP preconditioners, while
-`-pc_type blockjacobi` with `-pc_local <ilu|ilut|ilutp>` wraps a local ILU variant inside MPI
-block-Jacobi. Setting `-pc_type ilu` with `-pc_ilu_type ilut` runs the canonical ILU threshold
-factorization; `Ilu::create_specialized` may route that variant to `crate::preconditioner::ilut::Ilut`
-for simplicity/efficiency.
+`-pc_type ilu` selects Kryst's canonical CSR ILU family (`ILU0`/`ILUK`/`ILUT`), and `-pc_type ilutp`
+selects pivoting ILUTP. For serious benchmarks and comparisons, prefer this CSR ILU family
+(`-pc_type ilu` + `-pc_ilu_type iluk|ilut`, or `-pc_type ilutp`) and avoid row-filter mode.
+`-pc_type ilut` and `-pc_local ilut` select the experimental row-filter path
+(`src/preconditioner/ilut.rs`), which is non-comparable by default and requires explicit opt-in via
+`-pc_ilut_row_filter_opt_in true` (or `KRYST_PC_ILUT_ROW_FILTER_OPT_IN=1`).
 
 | CLI flag | Config field | Notes |
 | --- | --- | --- |
@@ -532,12 +532,13 @@ for simplicity/efficiency.
 | `-pc_ilu_lower_jacobi_iters <int>` / `-pc_ilu_upper_jacobi_iters <int>` | Jacobi iteration counts | Only used when the triangular solve is iterative. |
 | `-pc_ilu_tolerance <float>` / `-pc_ilu_max_iterations <int>` | Iterative solve controls | Defaults 1e-6 & 1; iterative delivers residual-based refinement. |
 | `-pc_ilu_parallel_factorization` / `-pc_ilu_parallel_trisolve` / `-pc_ilu_parallel_chunk_size <int>` | `IluConfig::enable_parallel_*`, `parallel_chunk_size` | Enable experimental rayon paths; chunk size typically 16–256. |
-| `-pc_ilut_drop_tol <float>` | `IluConfig::drop_tolerance` (row-filter ILUT) | Simple heuristic ILUT drop threshold (1e-3–1e-6). |
-| `-pc_ilut_max_fill <int>` | `IluConfig::max_fill_per_row` (row-filter ILUT) | Limits kept entries per row (10–100). |
-| `-pc_ilut_perm_tol <float>` | Pivot tolerance for row-filter ILUT | Not used by canonical `Ilu` but available for the lightweight ILUT preconditioner. |
+| `-pc_ilut_drop_tol <float>` | `IluConfig::drop_tolerance` (for `pc_ilu_type=ilut`) | Canonical CSR-ILUT drop threshold (typical 1e-3–1e-6). |
+| `-pc_ilut_max_fill <int>` | `IluConfig::max_fill_per_row` (for `pc_ilu_type=ilut`) | Per-row retention limit used by CSR ILUT (10–100 typical). |
+| `-pc_ilut_perm_tol <float>` | Pivot/perm heuristic | Reserved/compat knob; primarily relevant to experimental row-filter mode. |
+| `-pc_ilut_row_filter_opt_in <bool>` | `PcOptions::ilut_row_filter_opt_in` | Required to enable experimental `pc_type=ilut` / `pc_local=ilut` paths. |
 | `-pc_ilutp_max_fill <int>` / `-pc_ilutp_drop_tol <float>` / `-pc_ilutp_perm_tol <float>` | `Ilutp` parameters | Controls density, drop tolerance, and pivoting aggressiveness for ILUTP. |
 
-Environment variables mirror the flags: `KRYST_PC_ILU_TYPE`, `KRYST_PC_ILU_LEVEL_OF_FILL`, `KRYST_PC_ILU_MAX_FILL_PER_ROW`, `KRYST_PC_ILU_OFFDIAG_DROP_TOL`, `KRYST_PC_ILU_SCHUR_DROP_TOL`, `KRYST_PC_ILU_TRI_SOLVE`, `KRYST_PC_ILU_LOWER_JACOBI_ITERS`, `KRYST_PC_ILU_UPPER_JACOBI_ITERS`, `KRYST_PC_ILU_PARALLEL_FACTORIZATION`, `KRYST_PC_ILU_PARALLEL_TRISOLVE`, `KRYST_PC_ILU_PARALLEL_CHUNK_SIZE`, plus `KRYST_PC_ILUT_DROP_TOL`, `KRYST_PC_ILUT_MAX_FILL`, `KRYST_PC_ILUT_PERM_TOL`, `KRYST_PC_ILUTP_MAX_FILL`, `KRYST_PC_ILUTP_DROP_TOL`, and `KRYST_PC_ILUTP_PERM_TOL`. Command-line flags override environment variables, which in turn override the built-in defaults.
+Environment variables mirror the flags: `KRYST_PC_ILU_TYPE`, `KRYST_PC_ILU_LEVEL_OF_FILL`, `KRYST_PC_ILU_MAX_FILL_PER_ROW`, `KRYST_PC_ILU_OFFDIAG_DROP_TOL`, `KRYST_PC_ILU_SCHUR_DROP_TOL`, `KRYST_PC_ILU_TRI_SOLVE`, `KRYST_PC_ILU_LOWER_JACOBI_ITERS`, `KRYST_PC_ILU_UPPER_JACOBI_ITERS`, `KRYST_PC_ILU_PARALLEL_FACTORIZATION`, `KRYST_PC_ILU_PARALLEL_TRISOLVE`, `KRYST_PC_ILU_PARALLEL_CHUNK_SIZE`, plus `KRYST_PC_ILUT_DROP_TOL`, `KRYST_PC_ILUT_MAX_FILL`, `KRYST_PC_ILUT_PERM_TOL`, `KRYST_PC_ILUT_ROW_FILTER_OPT_IN`, `KRYST_PC_ILUTP_MAX_FILL`, `KRYST_PC_ILUTP_DROP_TOL`, and `KRYST_PC_ILUTP_PERM_TOL`. Command-line flags override environment variables, which in turn override the built-in defaults.
 
 ##### Examples
 

--- a/examples/optimized_solver_demo.rs
+++ b/examples/optimized_solver_demo.rs
@@ -183,8 +183,8 @@ fn get_optimal_config(matrix_name: &str) -> OptimalConfig {
         },
         "fidap001" => OptimalConfig {
             solver: "gmres",
-            preconditioner: "ilut",
-            _description: "GMRES (ILUT) - nonsymmetric-safe structural default",
+            preconditioner: "ilu",
+            _description: "GMRES (CSR ILU family) - nonsymmetric-safe structural default",
             expected_iterations: 500,
             fallback_solver: "bicgstab",
             amg_nonsymmetric_override: false,
@@ -215,8 +215,8 @@ fn get_optimal_config(matrix_name: &str) -> OptimalConfig {
         },
         _ => OptimalConfig {
             solver: "gmres",
-            preconditioner: "ilut",
-            _description: "GMRES (ILUT) - general nonsymmetric-safe sparse default",
+            preconditioner: "ilu",
+            _description: "GMRES (CSR ILUK/ILUT family) - general nonsymmetric-safe sparse default",
             expected_iterations: 500,
             fallback_solver: "bicgstab",
             amg_nonsymmetric_override: false,
@@ -479,13 +479,13 @@ fn build_preconditioner_options(
         return None;
     }
 
-    if pc != "ilu" && pc != "ilut" {
+    if pc != "ilu" {
         return None;
     }
 
     let mut opts = PcOptions::default();
     let prep_cfg = prep_config_for(matrix_name);
-    opts.ilu_type = Some(if pc == "ilut" { "ilut" } else { "iluk" }.to_string());
+    opts.ilu_type = Some("iluk".to_string());
     opts.ilu_level_of_fill = Some(1);
     opts.ilu_max_fill_per_row = Some(24);
     opts.ilu_offdiag_drop_tolerance = Some(1e-4);
@@ -508,7 +508,7 @@ fn build_preconditioner_options(
     }
 
     match matrix_name {
-        "e05r0100" if fallback_rung == Some(1) && pc == "ilut" => {
+        "e05r0100" if fallback_rung == Some(1) => {
             opts.ilu_max_fill_per_row = Some(48);
             opts.ilu_offdiag_drop_tolerance = Some(1e-6);
             opts.ilu_reordering_type = Some("amd".to_string());
@@ -554,7 +554,7 @@ fn build_preconditioner_options(
         }
         _ => {}
     }
-    if fallback_rung == Some(1) && matches!(solver, "gmres" | "fgmres") && pc == "ilut" {
+    if fallback_rung == Some(1) && matches!(solver, "gmres" | "fgmres") {
         opts.ilu_type = Some("ilut".to_string());
         opts.ilu_max_fill_per_row = Some(opts.ilu_max_fill_per_row.unwrap_or(48).max(64));
         opts.ilu_offdiag_drop_tolerance =
@@ -1234,15 +1234,15 @@ fn default_fallback_ladder() -> Vec<FallbackStep> {
     vec![
         FallbackStep {
             solver: "fgmres".to_string(),
-            pc: "ilut".to_string(),
+            pc: "ilu".to_string(),
             rung: 1,
-            note: "rung=1 fallback: GMRES/FGMRES(right) + stronger ILUT profile".to_string(),
+            note: "rung=1 fallback: GMRES/FGMRES(right) + stronger CSR-ILUT profile".to_string(),
         },
         FallbackStep {
             solver: "bicgstab".to_string(),
-            pc: "ilut".to_string(),
+            pc: "ilu".to_string(),
             rung: 2,
-            note: "rung=2 fallback: BiCGStab + ILUT".to_string(),
+            note: "rung=2 fallback: BiCGStab + CSR-ILUT".to_string(),
         },
     ]
 }
@@ -1309,7 +1309,7 @@ fn select_solver_policy(
                 "gmres"
             };
         primary_solver = safe_solver.to_string();
-        primary_pc = "ilut".to_string();
+        primary_pc = "ilu".to_string();
         contract_checks.push(cg_screen.reason.clone());
         contract_checks.push(format!(
             "CG diagnostics (base): pairs={}, sym_violations={} ({:.2}%), non_positive_diag={}, weak_gershgorin={}, mm_structural_symmetry_hint={:?}",
@@ -1325,7 +1325,7 @@ fn select_solver_policy(
             cg_screen.diagnostics.symmetry.verdict
         ));
         rationale.push(format!(
-            "CG screened out; switched primary to {} + ILUT",
+            "CG screened out; switched primary to {} + CSR-ILU",
             safe_solver.to_uppercase()
         ));
     } else {
@@ -1456,7 +1456,7 @@ fn select_solver_policy(
             }
             AmgMode::Disabled => {
                 primary_pc = if screen.diagonal_healthy {
-                    "ilut".to_string()
+                    "ilu".to_string()
                 } else {
                     "ilu".to_string()
                 };
@@ -1489,14 +1489,14 @@ fn select_solver_policy(
             primary_solver = "gmres".to_string();
             primary_pc = "none".to_string();
             rationale.push(
-                "policy override: hard nonsymmetric ladder ordering = baseline GMRES+NONE, rung1 FGMRES(right)+ILUT, rung2 BiCGStab+ILUT"
+                "policy override: hard nonsymmetric ladder ordering = baseline GMRES+NONE, rung1 FGMRES(right)+CSR-ILUT, rung2 BiCGStab+CSR-ILUT"
                     .to_string(),
             );
         }
         "fidap001" => {
             if cg_screen.is_hard_reject {
                 primary_solver = "gmres".to_string();
-                primary_pc = "ilut".to_string();
+                primary_pc = "ilu".to_string();
                 rationale.push(
                     "policy override: CG hard reject; keep nonsymmetric fallback ladder"
                         .to_string(),
@@ -1514,7 +1514,7 @@ fn select_solver_policy(
 
     if !screen.diagonal_healthy && jacobi_strength_mode == JacobiStrengthMode::Plain {
         if primary_pc == "jacobi" {
-            primary_pc = "ilut".to_string();
+            primary_pc = "ilu".to_string();
             rationale.push(
                 "diagonal-bad screen: avoided plain Jacobi primary (enable KRYST_DEMO_JACOBI_STRENGTH=fixdiag|rowl1 to allow Jacobi)"
                     .to_string(),
@@ -1522,7 +1522,7 @@ fn select_solver_policy(
         }
         for step in &mut fallback_ladder {
             if step.pc == "jacobi" {
-                step.pc = "ilut".to_string();
+                step.pc = "ilu".to_string();
                 rationale.push(
                     "diagonal-bad screen: avoided plain Jacobi fallback (enable KRYST_DEMO_JACOBI_STRENGTH=fixdiag|rowl1 to allow Jacobi)"
                         .to_string(),
@@ -1741,6 +1741,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         println!("Optimized Matrix Market Solver Demonstration");
         println!("===========================================");
         println!("Using benchmark-proven optimal configurations");
+        println!(
+            "Comparison scope: canonical CSR ILU family (ILUK/ILUT/ILUTP); row-filter pc_type=ilut is experimental/non-comparable and excluded by default"
+        );
         println!(
             "Recommended structural-CG compare workflow: KRYST_DEMO_COMPARE_STRUCTURAL_CG_SCREEN=1 cargo run --example optimized_solver_demo --features backend-faer"
         );

--- a/examples/support/benchmark_catalog.rs
+++ b/examples/support/benchmark_catalog.rs
@@ -29,6 +29,10 @@ pub(crate) struct BenchmarkDelta {
 }
 
 const CATALOG: &[MatrixExpectation] = &[
+    // Catalog expectations intentionally track canonical CSR ILU-family methods
+    // (ILUK/ILUT via `pc_type=ilu`, plus ILUTP). The row-filter `pc_type=ilut`
+    // implementation (`src/preconditioner/ilut.rs`) is experimental and excluded
+    // from default comparable benchmark rows.
     MatrixExpectation {
         matrix: "fidap005",
         solver_families: &["cg"],
@@ -48,7 +52,7 @@ const CATALOG: &[MatrixExpectation] = &[
     MatrixExpectation {
         matrix: "fidap001",
         solver_families: &["gmres"],
-        preconditioner_families: &["ilu", "ilut"],
+        preconditioner_families: &["ilu", "ilutp"],
         iteration_range: IterationRange { min: 350, max: 700 },
         time_note: None,
         confidence: ComparisonConfidence::Approximate,
@@ -56,7 +60,7 @@ const CATALOG: &[MatrixExpectation] = &[
     MatrixExpectation {
         matrix: "sherman3",
         solver_families: &["gmres", "fgmres"],
-        preconditioner_families: &["ilu", "ilut"],
+        preconditioner_families: &["ilu", "ilutp"],
         iteration_range: IterationRange { min: 20, max: 80 },
         time_note: Some("ILU-family preconditioners should dominate wall time tradeoffs"),
         confidence: ComparisonConfidence::Approximate,
@@ -64,7 +68,7 @@ const CATALOG: &[MatrixExpectation] = &[
     MatrixExpectation {
         matrix: "add20",
         solver_families: &["cg", "bicgstab", "gmres"],
-        preconditioner_families: &["ilu", "ilut"],
+        preconditioner_families: &["ilu", "ilutp"],
         iteration_range: IterationRange { min: 2, max: 10 },
         time_note: None,
         confidence: ComparisonConfidence::Exact,
@@ -72,7 +76,7 @@ const CATALOG: &[MatrixExpectation] = &[
     MatrixExpectation {
         matrix: "memplus",
         solver_families: &["bicgstab", "gmres"],
-        preconditioner_families: &["ilu", "ilut"],
+        preconditioner_families: &["ilu", "ilutp"],
         iteration_range: IterationRange { min: 3, max: 12 },
         time_note: Some("without ILU-family preconditioning this matrix may stall badly"),
         confidence: ComparisonConfidence::Approximate,

--- a/src/config/options.rs
+++ b/src/config/options.rs
@@ -184,6 +184,8 @@ pub struct PcOptions {
     /// Maximum fill for ILUT.
     pub ilut_max_fill: Option<usize>,
     pub ilut_perm_tol: Option<f64>,
+    /// Explicit opt-in gate for the experimental row-filter ILUT path (`pc_type=ilut` / `pc_local=ilut`).
+    pub ilut_row_filter_opt_in: Option<bool>,
     pub ilutp_max_fill: Option<usize>,
     pub ilutp_drop_tol: Option<f64>,
     pub ilutp_perm_tol: Option<f64>,
@@ -583,6 +585,20 @@ impl PcOptions {
         }
         if let Some(ref t) = self.sor_mat_side {
             kinds::SorMatSideKind::from_str(t)?;
+        }
+        if matches!(self.pc_type.as_deref(), Some("ilut"))
+            && !self.ilut_row_filter_opt_in.unwrap_or(false)
+        {
+            return Err(KError::InvalidInput(
+                "pc_type=ilut selects the experimental row-filter ILUT path (src/preconditioner/ilut.rs) and is excluded from default benchmark comparisons; set -pc_ilut_row_filter_opt_in true to enable it".into(),
+            ));
+        }
+        if matches!(self.pc_local.as_deref(), Some("ilut"))
+            && !self.ilut_row_filter_opt_in.unwrap_or(false)
+        {
+            return Err(KError::InvalidInput(
+                "pc_local=ilut selects the experimental row-filter ILUT path (src/preconditioner/ilut.rs); set -pc_ilut_row_filter_opt_in true to enable it".into(),
+            ));
         }
         self.sync_ilu_all();
         Ok(())
@@ -1144,6 +1160,7 @@ impl Sink for PcOptions {
             "pc_approxinv_parallel" => set_opt!(&mut self.approxinv_parallel, v),
             "pc_dist_native_required" => set_opt!(&mut self.pc_dist_native_required, v),
             "pc_fixdiag" => set_opt!(&mut self.pc_fixdiag, v),
+            "pc_ilut_row_filter_opt_in" => set_opt!(&mut self.ilut_row_filter_opt_in, v),
             "pc_bddc_use_vertices" => set_opt!(&mut self.pc_bddc_use_vertices, v),
             "pc_view" => set_opt!(&mut self.pc_view, v),
             _ => Err(KError::SolveError(format!("Unknown PC bool key: {key}"))),
@@ -2432,6 +2449,10 @@ impl PcOptions {
                     KError::SolveError(format!("Invalid KRYST_PC_ILUT_PERM_TOL: {v}"))
                 })?);
         }
+        if let Ok(v) = std::env::var("KRYST_PC_ILUT_ROW_FILTER_OPT_IN") {
+            let l = v.to_ascii_lowercase();
+            me.ilut_row_filter_opt_in = Some(matches!(l.as_str(), "true" | "1" | "yes" | "on"));
+        }
         if let Ok(v) = std::env::var("KRYST_PC_REORDER") {
             me.reorder = Some(v.to_lowercase());
         }
@@ -2551,6 +2572,7 @@ impl PcOptions {
         o!(ilut_drop_tol);
         o!(ilut_max_fill);
         o!(ilut_perm_tol);
+        o!(ilut_row_filter_opt_in);
         o!(ilutp_max_fill);
         o!(ilutp_drop_tol);
         o!(ilutp_perm_tol);
@@ -4185,6 +4207,35 @@ mod old_tests {
         assert_eq!(opts.ilu_reordering_type, Some("none".to_string()));
         assert!(matches!(opts.ilu.kind, IluKind::ILU0));
         assert_eq!(opts.ilu.reordering, ReorderingType::None);
+    }
+
+    #[test]
+    fn test_pc_type_ilut_requires_explicit_opt_in() {
+        let args = vec!["-pc_type", "ilut"];
+        let err = PcOptions::from_args(&args).expect_err("pc_type=ilut should be gated");
+        match err {
+            KError::InvalidInput(msg) => {
+                assert!(msg.contains("-pc_ilut_row_filter_opt_in"));
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+
+        let args_opt_in = vec!["-pc_type", "ilut", "-pc_ilut_row_filter_opt_in", "true"];
+        let opts = PcOptions::from_args(&args_opt_in).expect("opt-in should allow pc_type=ilut");
+        assert_eq!(opts.pc_type.as_deref(), Some("ilut"));
+        assert_eq!(opts.ilut_row_filter_opt_in, Some(true));
+    }
+
+    #[test]
+    fn test_pc_local_ilut_requires_explicit_opt_in() {
+        let args = vec!["-pc_type", "blockjacobi", "-pc_local", "ilut"];
+        let err = PcOptions::from_args(&args).expect_err("pc_local=ilut should be gated");
+        match err {
+            KError::InvalidInput(msg) => {
+                assert!(msg.contains("-pc_ilut_row_filter_opt_in"));
+            }
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
     }
 
     #[test]

--- a/src/config/registry.rs
+++ b/src/config/registry.rs
@@ -412,7 +412,7 @@ pub static SPECS: &[Spec] = &[
         key: "pc_local",
         arity: Arity::One,
         kind: ValueKind::Str,
-        doc: "local PC for block Jacobi: ilu | ilut | ilutp | jacobi | sor | chebyshev | fsai | spai",
+        doc: "local PC for block Jacobi: ilu | ilutp | jacobi | sor | chebyshev | fsai | spai (ilut row-filter is experimental, requires -pc_ilut_row_filter_opt_in)",
     },
     Spec {
         flag: "-pc_dist_local_apply",
@@ -535,6 +535,13 @@ pub static SPECS: &[Spec] = &[
         doc: "ILUTP pivot tol",
     },
     Spec {
+        flag: "-pc_ilut_row_filter_opt_in",
+        key: "pc_ilut_row_filter_opt_in",
+        arity: Arity::Zero,
+        kind: ValueKind::Bool,
+        doc: "explicitly allow experimental row-filter ILUT mode (pc_type=ilut / pc_local=ilut)",
+    },
+    Spec {
         flag: "-pc_ilutp_max_fill",
         key: "pc_ilutp_max_fill",
         arity: Arity::One,
@@ -637,7 +644,7 @@ pub static SPECS: &[Spec] = &[
         key: "pc_asm_inner_pc",
         arity: Arity::One,
         kind: ValueKind::Str,
-        doc: "jacobi|ilu|ilut|ilutp",
+        doc: "jacobi|ilu|ilutp (ilut row-filter is experimental, requires -pc_ilut_row_filter_opt_in)",
     },
     Spec {
         flag: "-pc_chebyshev_lambda_min",


### PR DESCRIPTION
### Motivation

- Prevent accidental use of the experimental row-filter `ilut` implementation in benchmark/comparison runs by requiring an explicit opt-in. 
- Encourage reproducible/serious studies to use the canonical CSR ILU family (`ILU0`/`ILUK`/`ILUT` via `pc_type=ilu` or pivoting `ILUTP`) so comparison rows remain meaningful. 

### Description

- Add a new opt-in flag `ilut_row_filter_opt_in` exposed as CLI `-pc_ilut_row_filter_opt_in` and env `KRYST_PC_ILUT_ROW_FILTER_OPT_IN`, wired into `PcOptions` and the option registry. 
- Validate during options parsing so `pc_type=ilut` or `pc_local=ilut` returns `KError::InvalidInput` unless the opt-in is explicitly set. 
- Parse the env var and include the field in option overlays so scoped/child options propagate correctly. 
- Update benchmark/demo code (`examples/optimized_solver_demo.rs`) and the benchmark catalog (`examples/support/benchmark_catalog.rs`) to prefer CSR ILU family paths (`pc=ilu` + `pc_ilu_type=...`, and `ilutp`) and to mark the row-filter `pc_type=ilut` path as experimental/non-comparable. 
- Update `README.md` and `src/config/registry.rs` help text to document the recommended CSR ILU family and the required explicit opt-in for row-filter `ilut`. 
- Add unit tests that assert `pc_type=ilut` and `pc_local=ilut` are gated and that explicit opt-in allows `pc_type=ilut`.

### Testing

- Ran `cargo fmt` to normalize formatting (succeeded). 
- Ran `cargo test test_pc_type_ilut_requires_explicit_opt_in --lib` (passed). 
- Ran `cargo test test_pc_local_ilut_requires_explicit_opt_in --lib` (passed). 
- Ran `cargo check --example optimized_solver_demo --features backend-faer` to validate the demo build with the updated defaults (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebc7f7b44c8329b57053eb84010bf7)