### PR TITLE
Report effective FGMRES runtime policy in stats and demo

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -25,6 +25,7 @@ mod complex_demo {
     use kryst::algebra::prelude::*;
     use kryst::context::ksp_context::{ReorthPolicy, Workspace};
     use kryst::matrix::DistCsrOp;
+    use kryst::matrix::dist_csr::DistributedPlanDiagnostics;
     use kryst::matrix::sparse::CsrMatrix as SparseCsrMatrix;
     use kryst::ops::klinop::KLinOp;
     use kryst::ops::kpc::KPreconditioner;
@@ -34,7 +35,7 @@ mod complex_demo {
     use kryst::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind};
     use kryst::preconditioner::jacobi::Jacobi;
     use kryst::solver::LinearSolver;
-    use kryst::solver::fgmres::{FgmresSolver, FgmresVariant, OrthogMethod};
+    use kryst::solver::fgmres::{FgmresSolver, FgmresVariant, OrthogMethod, ResidualCheckPolicy};
     use kryst::utils::convergence::ConvergedReason;
     use kryst::utils::matrix_market::read_matrix_market;
 
@@ -144,8 +145,10 @@ mod complex_demo {
                 );
                 if include_dof_col {
                     println!(
-                        "{:<36} {:>9} {:>9} {:>9} {:>7} {:>6} {:>14} {:>14} {:>26} {:>12}",
+                        "{:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>6} {:>14} {:>14} {:>26} {:>12}",
                         "Method",
+                        "Requested policy",
+                        "Effective policy",
                         "Setup(s)",
                         "Med(s)",
                         "Min(s)",
@@ -158,8 +161,10 @@ mod complex_demo {
                     );
                 } else {
                     println!(
-                        "{:<36} {:>9} {:>9} {:>9} {:>7} {:>6} {:>14} {:>14} {:>26}",
+                        "{:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>6} {:>14} {:>14} {:>26}",
                         "Method",
+                        "Requested policy",
+                        "Effective policy",
                         "Setup(s)",
                         "Med(s)",
                         "Min(s)",
@@ -170,7 +175,7 @@ mod complex_demo {
                         "Reason"
                     );
                 }
-                println!("{}", "-".repeat(if include_dof_col { 160 } else { 146 }));
+                println!("{}", "-".repeat(if include_dof_col { 236 } else { 222 }));
             }
 
             let runs = RunSpec::build_default_matrix(&config, &problem);
@@ -188,44 +193,19 @@ mod complex_demo {
                                 .map(|v| format!("{v:.2e}"))
                                 .unwrap_or_else(|| "N/A".to_string());
                             if include_dof_col {
-                                let dof = row
-                                    .dof_per_sec
-                                    .map(|v| format!("{v:.2e}"))
-                                    .unwrap_or_else(|| "N/A".to_string());
-                                println!(
-                                    "{:<36} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>6} {:>14.2e} {:>14} {:>26?} {:>12}",
-                                    row.method,
-                                    row.setup_secs,
-                                    row.median_solve_secs,
-                                    row.min_solve_secs,
-                                    row.iterations,
-                                    row.reductions,
-                                    row.reported_residual,
-                                    explicit_true,
-                                    row.reason,
-                                    dof
-                                );
+                                println!("{}", render_result_row(&row, explicit_true, true));
                             } else {
-                                println!(
-                                    "{:<36} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>6} {:>14.2e} {:>14} {:>26?}",
-                                    row.method,
-                                    row.setup_secs,
-                                    row.median_solve_secs,
-                                    row.min_solve_secs,
-                                    row.iterations,
-                                    row.reductions,
-                                    row.reported_residual,
-                                    explicit_true,
-                                    row.reason
-                                );
+                                println!("{}", render_result_row(&row, explicit_true, false));
                             }
                         }
                     }
                     Err(err) => {
                         if rank == 0 {
                             println!(
-                                "{:<36} {:>9} {:>9} {:>9} {:>7} {:>6} {:>14} {:>14} {:>26}",
+                                "{:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>6} {:>14} {:>14} {:>26}",
                                 spec.method_label(),
+                                spec.requested_policy_label(),
+                                "N/A",
                                 "FAIL",
                                 "FAIL",
                                 "FAIL",
@@ -266,6 +246,7 @@ mod complex_demo {
 
     struct Problem {
         op: Arc<dyn KLinOp<Scalar = S>>,
+        dist_plan_diagnostics: DistributedPlanDiagnostics,
         rhs: Vec<S>,
         csr_for_pc: Arc<SparseCsrMatrix<S>>,
         local_n: usize,
@@ -311,6 +292,8 @@ mod complex_demo {
 
     struct ResultRow {
         method: String,
+        requested_policy: String,
+        effective_policy: String,
         setup_secs: f64,
         median_solve_secs: f64,
         min_solve_secs: f64,
@@ -325,6 +308,7 @@ mod complex_demo {
     struct RunSpec {
         restart: usize,
         variant: FgmresVariant,
+        residual_check_policy: ResidualCheckPolicy,
         orthog: OrthogMethod,
         reorth: ReorthPolicy,
         pc_side: PcSide,
@@ -552,6 +536,7 @@ mod complex_demo {
                             runs.push(Self {
                                 restart,
                                 variant,
+                                residual_check_policy: ResidualCheckPolicy::OnConvergence,
                                 orthog,
                                 reorth,
                                 pc_side: PcSide::Right,
@@ -561,6 +546,7 @@ mod complex_demo {
                                 runs.push(Self {
                                     restart,
                                     variant,
+                                    residual_check_policy: ResidualCheckPolicy::OnConvergence,
                                     orthog,
                                     reorth,
                                     pc_side: PcSide::Right,
@@ -570,6 +556,7 @@ mod complex_demo {
                             runs.push(Self {
                                 restart,
                                 variant,
+                                residual_check_policy: ResidualCheckPolicy::OnConvergence,
                                 orthog,
                                 reorth,
                                 pc_side: PcSide::Right,
@@ -578,6 +565,7 @@ mod complex_demo {
                             runs.push(Self {
                                 restart,
                                 variant,
+                                residual_check_policy: ResidualCheckPolicy::OnConvergence,
                                 orthog,
                                 reorth,
                                 pc_side: PcSide::Right,
@@ -602,14 +590,24 @@ mod complex_demo {
                 )
             };
             format!(
-                "FGMRES+{} [m={}, v={}, orth={}, reorth={}, pc=requested {}, effective {}]",
+                "FGMRES+{} [m={}, v={}, reschk={}, orth={}, reorth={}, pc=requested {}, effective {}]",
                 self.pc.label(),
                 self.restart,
                 variant_label(self.variant),
+                residual_check_policy_label(self.residual_check_policy),
                 orthog_label(self.orthog),
                 reorth_label(self.reorth),
                 pc_side_label(self.pc_side),
                 side_desc,
+            )
+        }
+
+        fn requested_policy_label(&self) -> String {
+            format!(
+                "variant={}, restart={}, residual-check={}",
+                variant_label(self.variant),
+                self.restart,
+                residual_check_policy_label(self.residual_check_policy)
             )
         }
     }
@@ -661,6 +659,15 @@ mod complex_demo {
             ReorthPolicy::Never => "never",
             ReorthPolicy::IfNeeded => "if-needed",
             ReorthPolicy::Always => "always",
+        }
+    }
+
+    fn residual_check_policy_label(policy: ResidualCheckPolicy) -> &'static str {
+        match policy {
+            ResidualCheckPolicy::RestartOnly => "restart-only",
+            ResidualCheckPolicy::OnConvergence => "on-convergence",
+            ResidualCheckPolicy::EveryIteration => "every-iteration",
+            ResidualCheckPolicy::Debug => "debug",
         }
     }
 
@@ -728,6 +735,7 @@ mod complex_demo {
         for _ in 0..bench_cfg.warmup_runs {
             let mut x = vec![S::zero(); problem.local_n];
             let mut solver = configured_solver(spec);
+            apply_dist_plan_policy(&mut solver, problem);
             let mut workspace = Workspace::new(problem.local_n);
             solver.setup_workspace(&mut workspace);
             let _ = solver.solve_k(
@@ -750,6 +758,7 @@ mod complex_demo {
             problem.comm.barrier();
             let start = Instant::now();
             let mut solver = configured_solver(spec);
+            apply_dist_plan_policy(&mut solver, problem);
             let mut workspace = Workspace::new(problem.local_n);
             solver.setup_workspace(&mut workspace);
             let stats = solver.solve_k(
@@ -794,6 +803,19 @@ mod complex_demo {
 
         Ok(ResultRow {
             method: spec.method_label(),
+            requested_policy: spec.requested_policy_label(),
+            effective_policy: format!(
+                "variant={}, restart={}, residual-check={}",
+                stats
+                    .effective_variant
+                    .as_deref()
+                    .unwrap_or(variant_label(spec.variant)),
+                stats.effective_restart.unwrap_or(spec.restart),
+                stats
+                    .effective_residual_check_policy
+                    .as_deref()
+                    .unwrap_or(residual_check_policy_label(spec.residual_check_policy))
+            ),
             setup_secs,
             median_solve_secs,
             min_solve_secs,
@@ -818,11 +840,16 @@ mod complex_demo {
     fn configured_solver(spec: &RunSpec) -> FgmresSolver {
         let mut solver = FgmresSolver::new(1e-8, 500, spec.restart);
         solver.variant = spec.variant;
+        solver.residual_check_policy = spec.residual_check_policy;
         solver.orthog = spec.orthog;
         solver.reorth = spec.reorth;
         solver.atol = 1e-12;
         solver.dtol = 1e6;
         solver
+    }
+
+    fn apply_dist_plan_policy(solver: &mut FgmresSolver, problem: &Problem) {
+        solver.apply_distcsr_policy(&problem.dist_plan_diagnostics, problem.comm.size());
     }
 
     fn median(samples: &mut [f64]) -> f64 {
@@ -832,6 +859,45 @@ mod complex_demo {
             samples[n / 2]
         } else {
             (samples[n / 2 - 1] + samples[n / 2]) * 0.5
+        }
+    }
+
+    fn render_result_row(row: &ResultRow, explicit_true: String, include_dof_col: bool) -> String {
+        if include_dof_col {
+            let dof = row
+                .dof_per_sec
+                .map(|v| format!("{v:.2e}"))
+                .unwrap_or_else(|| "N/A".to_string());
+            format!(
+                "{:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>6} {:>14.2e} {:>14} {:>26?} {:>12}",
+                row.method,
+                row.requested_policy,
+                row.effective_policy,
+                row.setup_secs,
+                row.median_solve_secs,
+                row.min_solve_secs,
+                row.iterations,
+                row.reductions,
+                row.reported_residual,
+                explicit_true,
+                row.reason,
+                dof
+            )
+        } else {
+            format!(
+                "{:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>6} {:>14.2e} {:>14} {:>26?}",
+                row.method,
+                row.requested_policy,
+                row.effective_policy,
+                row.setup_secs,
+                row.median_solve_secs,
+                row.min_solve_secs,
+                row.iterations,
+                row.reductions,
+                row.reported_residual,
+                explicit_true,
+                row.reason
+            )
         }
     }
 
@@ -848,6 +914,7 @@ mod complex_demo {
         let local_pc_block = slice_csr_rows_owned_cols(&csr_sparse, row_start, row_end);
 
         let op = DistCsrOp::from_local_rows(nrows, row_start, &local_csr, &row_part, comm.clone())?;
+        let dist_plan_diagnostics = op.plan_diagnostics().clone();
         let op_arc: Arc<dyn KLinOp<Scalar = S>> = Arc::new(op);
 
         let rhs_global = match try_load_rhs_s(mat_path, nrows) {
@@ -867,6 +934,7 @@ mod complex_demo {
 
         Ok(Problem {
             op: op_arc,
+            dist_plan_diagnostics,
             rhs,
             csr_for_pc: Arc::new(local_pc_block),
             local_n,
@@ -1014,6 +1082,17 @@ mod complex_demo {
             SparseCsrMatrix::from_csr(2, 3, vec![0, 1, 2], vec![0, 1], vec![S::one(), S::one()]);
         let problem = Problem {
             op: Arc::new(op),
+            dist_plan_diagnostics: DistributedPlanDiagnostics {
+                overlap_mode: kryst::matrix::dist_csr::HaloOverlapMode::Disabled,
+                kernel_strategy: kryst::matrix::dist_csr::DistLocalKernelStrategy::RowSplitScalar,
+                local_spmv_kernel: None,
+                row_locality_ratio: 1.0,
+                border_ratio: 0.0,
+                halo_recv_volume: 0,
+                halo_send_volume: 0,
+                expected_communication_fraction: 0.0,
+                expected_computation_fraction: 1.0,
+            },
             rhs: vec![S::one(), S::one()],
             csr_for_pc: Arc::new(rectangular_pc),
             local_n: 2,
@@ -1026,6 +1105,7 @@ mod complex_demo {
         let spec = RunSpec {
             restart: 10,
             variant: FgmresVariant::Classical,
+            residual_check_policy: ResidualCheckPolicy::OnConvergence,
             orthog: OrthogMethod::ClassicalGS,
             reorth: ReorthPolicy::IfNeeded,
             pc_side: PcSide::Right,
@@ -1044,6 +1124,73 @@ mod complex_demo {
             Err(other) => panic!("unexpected error variant: {other:?}"),
             Ok(_) => panic!("expected rectangular ILU error"),
         }
+    }
+
+    #[test]
+    fn run_once_reports_requested_and_effective_policy_after_dist_policy_mutation() {
+        #[cfg(feature = "mpi")]
+        let comm = UniverseComm::Mpi(Arc::new(MpiComm::new()));
+        #[cfg(not(feature = "mpi"))]
+        let comm = UniverseComm::NoComm(NoComm);
+
+        let op_local =
+            SparseCsrMatrix::from_csr(2, 2, vec![0, 1, 2], vec![0, 1], vec![S::one(), S::one()]);
+        let row_part = vec![0, 2];
+        let op = DistCsrOp::from_local_rows(2, 0, &op_local, &row_part, comm.clone())
+            .expect("build local dist op");
+
+        let problem = Problem {
+            op: Arc::new(op),
+            dist_plan_diagnostics: DistributedPlanDiagnostics {
+                overlap_mode: kryst::matrix::dist_csr::HaloOverlapMode::Disabled,
+                kernel_strategy: kryst::matrix::dist_csr::DistLocalKernelStrategy::RowSplitScalar,
+                local_spmv_kernel: None,
+                row_locality_ratio: 1.0,
+                border_ratio: 0.0,
+                halo_recv_volume: 0,
+                halo_send_volume: 0,
+                expected_communication_fraction: 0.1,
+                expected_computation_fraction: 0.5,
+            },
+            rhs: vec![S::one(), S::one()],
+            csr_for_pc: Arc::new(op_local),
+            local_n: 2,
+            global_n: 2,
+            global_row_start: 0,
+            comm,
+            backend: CsrBackend::Serial,
+            backend_descr: "unit-test".to_string(),
+        };
+        let spec = RunSpec {
+            restart: 5,
+            variant: FgmresVariant::Classical,
+            residual_check_policy: ResidualCheckPolicy::OnConvergence,
+            orthog: OrthogMethod::ClassicalGS,
+            reorth: ReorthPolicy::IfNeeded,
+            pc_side: PcSide::Right,
+            pc: PcKind::None,
+        };
+        let bench_cfg = BenchmarkConfig {
+            warmup_runs: 0,
+            measured_runs: 1,
+            ..BenchmarkConfig::default()
+        };
+
+        let row = run_once(&problem, &spec, &bench_cfg).expect("run once");
+        assert!(row.requested_policy.contains("restart=5"));
+        assert!(
+            row.requested_policy
+                .contains("residual-check=on-convergence")
+        );
+        assert!(row.effective_policy.contains("restart=16"));
+        assert!(
+            row.effective_policy
+                .contains("residual-check=every-iteration")
+        );
+
+        let rendered = render_result_row(&row, "1.00e-16".to_string(), false);
+        assert!(rendered.contains(&row.requested_policy));
+        assert!(rendered.contains(&row.effective_policy));
     }
 
     #[test]

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -223,6 +223,24 @@ impl FgmresSolver {
     }
 
     #[inline]
+    fn effective_variant_label(&self) -> &'static str {
+        match self.variant {
+            FgmresVariant::Classical => "classical",
+            FgmresVariant::Pipelined => "pipelined",
+        }
+    }
+
+    #[inline]
+    fn effective_residual_check_policy_label(&self) -> &'static str {
+        match self.residual_check_policy {
+            ResidualCheckPolicy::RestartOnly => "restart-only",
+            ResidualCheckPolicy::OnConvergence => "on-convergence",
+            ResidualCheckPolicy::EveryIteration => "every-iteration",
+            ResidualCheckPolicy::Debug => "debug",
+        }
+    }
+
+    #[inline]
     fn workspace_cols(&self) -> usize {
         if self.preallocate {
             self.restart.min(self.maxits)
@@ -342,6 +360,10 @@ impl FgmresSolver {
                 diag.overlap_mode,
             );
         }
+    }
+
+    pub fn apply_distcsr_policy(&mut self, diag: &DistributedPlanDiagnostics, comm_size: usize) {
+        self.apply_distcsr_policy_hook(diag, comm_size);
     }
 
     fn should_run_cgs_refinement(&self, wnorm0: R, hnext: R) -> bool {
@@ -845,7 +867,12 @@ impl FgmresSolver {
 
         let mut total_iters = 0usize;
         let mut res = beta0;
-        let mut stats = SolveStats::new(0, res, ConvergedReason::Continued);
+        let mut stats = SolveStats::new(0, res, ConvergedReason::Continued)
+            .with_effective_runtime_policy(
+                self.effective_variant_label(),
+                self.restart,
+                self.effective_residual_check_policy_label(),
+            );
         stats.final_recurrence_residual = Some(res);
         let red_engine = ws
             .reduction_engine()
@@ -898,6 +925,11 @@ impl FgmresSolver {
                 residual_replacements: async_waits,
             };
             let mut stats = SolveStats::new(0, true_res, ConvergedReason::StoppedByMonitor)
+                .with_effective_runtime_policy(
+                    self.effective_variant_label(),
+                    self.restart,
+                    self.effective_residual_check_policy_label(),
+                )
                 .with_counters(counters)
                 .with_fgmres_counters(FgmresCounters {
                     restart_count,
@@ -1675,7 +1707,12 @@ mod tests {
             (self.diag.len(), self.diag.len())
         }
 
-        fn matvec_s(&self, x: &[Self::Scalar], y: &mut [Self::Scalar], _scratch: &mut BridgeScratch) {
+        fn matvec_s(
+            &self,
+            x: &[Self::Scalar],
+            y: &mut [Self::Scalar],
+            _scratch: &mut BridgeScratch,
+        ) {
             for ((yi, &ai), &xi) in y.iter_mut().zip(self.diag.iter()).zip(x.iter()) {
                 *yi = ai * xi;
             }
@@ -1684,9 +1721,19 @@ mod tests {
 
     fn run_pipelined_with_options(comm: UniverseComm, exec: ReductExec) -> SolveStats<f64> {
         let a = DiagOp {
-            diag: vec![S::from_real(4.0), S::from_real(3.0), S::from_real(2.0), S::from_real(1.5)],
+            diag: vec![
+                S::from_real(4.0),
+                S::from_real(3.0),
+                S::from_real(2.0),
+                S::from_real(1.5),
+            ],
         };
-        let b = vec![S::from_real(1.0), S::from_real(-2.0), S::from_real(3.0), S::from_real(-1.0)];
+        let b = vec![
+            S::from_real(1.0),
+            S::from_real(-2.0),
+            S::from_real(3.0),
+            S::from_real(-1.0),
+        ];
         let mut x = vec![S::zero(); b.len()];
         let mut solver = FgmresSolver::new(1e-12, 60, 8);
         solver.set_variant(FgmresVariant::Pipelined);
@@ -1699,7 +1746,16 @@ mod tests {
         });
 
         let stats = solver
-            .solve_k(&a, None, &b, &mut x, PcSide::Right, &comm, None, Some(&mut ws))
+            .solve_k(
+                &a,
+                None,
+                &b,
+                &mut x,
+                PcSide::Right,
+                &comm,
+                None,
+                Some(&mut ws),
+            )
             .expect("pipelined FGMRES solve should succeed");
         assert!(
             stats.final_residual < 1e-9,
@@ -1739,9 +1795,13 @@ mod tests {
     #[cfg(feature = "mpi")]
     #[test]
     fn mpi_smoke_pipelined_overlap_counters_are_stable() {
-        let comm = UniverseComm::Mpi(std::sync::Arc::new(crate::parallel::mpi_comm::MpiComm::new()));
+        let comm = UniverseComm::Mpi(std::sync::Arc::new(
+            crate::parallel::mpi_comm::MpiComm::new(),
+        ));
         let stats = run_pipelined_with_options(comm, ReductExec::Async);
-        let counters = stats.fgmres_counters.expect("fgmres counters should be present");
+        let counters = stats
+            .fgmres_counters
+            .expect("fgmres counters should be present");
         assert!(counters.deferred_pipeline_waits >= counters.immediate_pipeline_completions);
     }
 }

--- a/src/utils/convergence.rs
+++ b/src/utils/convergence.rs
@@ -604,6 +604,12 @@ pub struct SolveStats<R> {
     pub orthogonalization_rank_loss: bool,
     /// Max estimate of orthogonality loss observed during the solve.
     pub max_orthogonality_loss_estimate: R,
+    /// Effective solver variant selected at runtime (if policy hooks mutated it).
+    pub effective_variant: Option<String>,
+    /// Effective restart value selected at runtime.
+    pub effective_restart: Option<usize>,
+    /// Effective residual-check policy selected at runtime.
+    pub effective_residual_check_policy: Option<String>,
 }
 
 impl<R: Default> SolveStats<R> {
@@ -637,6 +643,9 @@ impl<R: Default> SolveStats<R> {
             orthogonalization_passes: 0,
             orthogonalization_rank_loss: false,
             max_orthogonality_loss_estimate: R::default(),
+            effective_variant: None,
+            effective_restart: None,
+            effective_residual_check_policy: None,
         }
     }
 
@@ -700,6 +709,19 @@ impl<R: Default> SolveStats<R> {
         self.orthogonalization_passes = passes;
         self.orthogonalization_rank_loss = rank_loss;
         self.max_orthogonality_loss_estimate = max_loss_estimate;
+        self
+    }
+
+    /// Attach runtime-effective policy knobs selected by the solver.
+    pub fn with_effective_runtime_policy(
+        mut self,
+        variant: impl Into<String>,
+        restart: usize,
+        residual_check_policy: impl Into<String>,
+    ) -> Self {
+        self.effective_variant = Some(variant.into());
+        self.effective_restart = Some(restart);
+        self.effective_residual_check_policy = Some(residual_check_policy.into());
         self
     }
 }


### PR DESCRIPTION
### Motivation

- Expose the runtime-effective solver policy (variant, restart, residual-check) so callers and demos can see when `DistributedPlanDiagnostics` or other hooks mutate solver knobs. 
- Surface both the requested policy (from `RunSpec`) and the effective policy (as actually used by the solver) in demo output for clearer diagnostics and benchmarking.

### Description

- Added new fields to `SolveStats`: `effective_variant: Option<String>`, `effective_restart: Option<usize>`, and `effective_residual_check_policy: Option<String>`, plus a helper `with_effective_runtime_policy` to attach them. (`src/utils/convergence.rs`).
- Added helper label methods and a call-site to stamp effective policy into stats at solve startup and monitor-stop paths in `FgmresSolver`, and exposed `apply_distcsr_policy` so external callers can apply the dist-CSR policy decision prior to solving. (`src/solver/fgmres.rs`).
- Extended the complex Matrix Market demo to carry a requested `residual_check_policy` in `RunSpec`, capture `DistributedPlanDiagnostics` from `DistCsrOp::plan_diagnostics()`, apply the distributed-plan policy before each solve, record both requested and effective policies in the result row, and render two policy columns in formatted output. (`examples/complex_matrix_market_demo.rs`).
- Added an example-level unit test that constructs a `DistributedPlanDiagnostics` forcing a policy mutation and asserts that `run_once` returns both the requested and the effective policy strings and that the rendered line contains both entries. (`examples/complex_matrix_market_demo.rs`).

### Testing

- Ran formatting with `cargo fmt` successfully. 
- Executed the example tests with `cargo test --features complex --example complex_matrix_market_demo`, and all example unit tests passed (`4 passed; 0 failed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebccf011d88329becdcca671644c51)