### PR TITLE
Add typed CSR markers for local ILU setup and dist extraction

### DIFF
--- a/examples/mpi_poisson_block_jacobi_ilu.rs
+++ b/examples/mpi_poisson_block_jacobi_ilu.rs
@@ -91,6 +91,8 @@ fn main() -> Result<(), Box<dyn Error>> {
     let local_csr = build_local_poisson_block(n_global, row_start, row_end);
     let dist_op =
         DistCsrOp::from_local_rows(n_global, row_start, &local_csr, &part_prefix, comm.clone())?;
+    let owned_rows = dist_op.local_rows_csr();
+    let local_square = dist_op.local_square_block();
 
     let mut mpi_opts = MpiPcOptions::default();
     mpi_opts.global_pc = GlobalPcKind::BlockJacobi;
@@ -114,10 +116,12 @@ fn main() -> Result<(), Box<dyn Error>> {
     let global_norm_sq = comm.allreduce_sum_real(local_norm_sq);
 
     println!(
-        "Rank {} owns rows {}..{} and preconditioned {} entries",
+        "Rank {} owns rows {}..{} (owned-row nnz={}, local-square nnz={}) and preconditioned {} entries",
         rank,
         row_start,
         row_end,
+        owned_rows.as_csr().nnz(),
+        local_square.as_csr().nnz(),
         row_end - row_start
     );
 

--- a/src/matrix/dist/csr_types.rs
+++ b/src/matrix/dist/csr_types.rs
@@ -1,0 +1,75 @@
+use crate::algebra::scalar::KrystScalar;
+use crate::error::KError;
+use crate::matrix::sparse::CsrMatrix;
+
+/// Marker wrapper for a CSR slice with owned local rows and global columns.
+///
+/// This is the canonical shape extracted from a distributed row partition.
+#[derive(Clone, Debug)]
+pub struct DistRowCsr<S: KrystScalar> {
+    csr: CsrMatrix<S>,
+    row_offset: usize,
+    n_global_cols: usize,
+}
+
+impl<S: KrystScalar> DistRowCsr<S> {
+    pub fn new(csr: CsrMatrix<S>, row_offset: usize, n_global_cols: usize) -> Result<Self, KError> {
+        if csr.ncols() != n_global_cols {
+            return Err(KError::InvalidInput(format!(
+                "DistRowCsr ncols mismatch: csr has {}, expected {n_global_cols}",
+                csr.ncols()
+            )));
+        }
+        Ok(Self {
+            csr,
+            row_offset,
+            n_global_cols,
+        })
+    }
+
+    pub fn as_csr(&self) -> &CsrMatrix<S> {
+        &self.csr
+    }
+
+    pub fn row_offset(&self) -> usize {
+        self.row_offset
+    }
+
+    pub fn n_global_cols(&self) -> usize {
+        self.n_global_cols
+    }
+}
+
+/// Marker wrapper for a locally owned square CSR block.
+///
+/// This type is intended for local factorizations (ILU/ILUT/ILUTP) that
+/// require square ownership semantics.
+#[derive(Clone, Debug)]
+pub struct LocalSquareCsr<S: KrystScalar> {
+    csr: CsrMatrix<S>,
+}
+
+impl<S: KrystScalar> LocalSquareCsr<S> {
+    pub fn try_from_csr(csr: CsrMatrix<S>) -> Result<Self, KError> {
+        if csr.nrows() != csr.ncols() {
+            return Err(KError::InvalidInput(format!(
+                "LocalSquareCsr requires square matrix, got {}x{}",
+                csr.nrows(),
+                csr.ncols()
+            )));
+        }
+        Ok(Self { csr })
+    }
+
+    pub fn as_csr(&self) -> &CsrMatrix<S> {
+        &self.csr
+    }
+}
+
+impl<S: KrystScalar> TryFrom<CsrMatrix<S>> for LocalSquareCsr<S> {
+    type Error = KError;
+
+    fn try_from(value: CsrMatrix<S>) -> Result<Self, Self::Error> {
+        Self::try_from_csr(value)
+    }
+}

--- a/src/matrix/dist/mod.rs
+++ b/src/matrix/dist/mod.rs
@@ -1,5 +1,7 @@
+pub mod csr_types;
 pub mod halo;
 pub mod hierarchy;
 pub mod spmv_dist;
 
+pub use csr_types::{DistRowCsr, LocalSquareCsr};
 pub use hierarchy::DistHierarchyMeta;

--- a/src/matrix/dist_csr.rs
+++ b/src/matrix/dist_csr.rs
@@ -12,6 +12,7 @@ use crate::algebra::bridge::BridgeScratch;
 use crate::algebra::scalar::{KrystScalar, S};
 use crate::error::KError;
 use crate::matrix::csr::CsrMatrix as PlanCsrMatrix;
+use crate::matrix::dist::csr_types::{DistRowCsr, LocalSquareCsr};
 use crate::matrix::dist::halo::{HaloIndexPlan, HaloPlan, HaloTuning};
 use crate::matrix::dist::spmv_dist::RowRanges;
 use crate::matrix::op::{ChangeIds, DistLayout, LinOp, StructureId, ValuesId};
@@ -439,6 +440,12 @@ impl DistCsrOp {
         )
     }
 
+    /// Extract local owned rows with global column indexing.
+    pub fn local_rows_csr(&self) -> DistRowCsr<S> {
+        DistRowCsr::new(self.local_matrix(), self.row_start, self.n_global)
+            .expect("DistCsrOp::local_matrix shape invariant violated")
+    }
+
     /// Extract the owned diagonal block as a CSR matrix (local rows/cols only).
     pub fn local_block_csr(&self) -> CsrMatrix<S> {
         let n = self.n_local;
@@ -457,6 +464,12 @@ impl DistCsrOp {
             row_ptr.push(col_idx.len());
         }
         CsrMatrix::from_csr(n, n, row_ptr, col_idx, vals)
+    }
+
+    /// Extract the owned diagonal block with local square semantics.
+    pub fn local_square_block(&self) -> LocalSquareCsr<S> {
+        LocalSquareCsr::try_from(self.local_block_csr())
+            .expect("DistCsrOp local block must be square by construction")
     }
 
     #[cfg(all(feature = "backend-faer", not(feature = "complex")))]

--- a/src/matrix/mod.rs
+++ b/src/matrix/mod.rs
@@ -74,6 +74,7 @@ pub type Csr = crate::matrix::sparse::CsrMatrix<S>;
 #[cfg(feature = "backend-faer")]
 pub type Csc = crate::matrix::csc::CscMatrix<S>;
 
+pub use dist::{DistRowCsr, LocalSquareCsr};
 pub use dist_csr::DistCsrOp;
 pub use format::OpFormat;
 pub use op::{ChangeIds, LinOp, LinOpF64, StructureId, ValuesId};

--- a/src/preconditioner/block_jacobi.rs
+++ b/src/preconditioner/block_jacobi.rs
@@ -19,10 +19,10 @@ use crate::algebra::prelude::*;
 use crate::core::traits::{MatrixGet, RowPattern};
 use crate::error::KError;
 #[cfg(all(not(feature = "dense-direct"), not(feature = "complex")))]
-use crate::matrix::op::CsrOp;
-#[cfg(feature = "dense-direct")]
-use crate::matrix::sparse::CsrMatrix;
+use crate::matrix::LocalSquareCsr;
 #[cfg(all(not(feature = "dense-direct"), not(feature = "complex")))]
+use crate::matrix::sparse::CsrMatrix;
+#[cfg(feature = "dense-direct")]
 use crate::matrix::sparse::CsrMatrix;
 #[cfg(feature = "complex")]
 use crate::ops::kpc::KPreconditioner;
@@ -158,9 +158,10 @@ impl BlockJacobi {
             }
             let csr =
                 std::sync::Arc::new(CsrMatrix::<f64>::from_csr(n, n, row_ptr, col_idx, values));
+            let local_square =
+                LocalSquareCsr::try_from(csr.as_ref().clone()).expect("block CSR should be square");
             let mut ilu = IluCsr::new_with_config(cfg.clone());
-            let op = CsrOp::new(csr.clone());
-            let _ = ilu.setup(&op);
+            let _ = ilu.setup_local_square(&local_square);
             self.block_factors_ilu
                 .push((block.clone(), std::sync::Arc::new(ilu)));
         }
@@ -260,9 +261,10 @@ impl BlockJacobi {
             }
             let csr =
                 std::sync::Arc::new(CsrMatrix::<f64>::from_csr(n, n, row_ptr, col_idx, values));
+            let local_square =
+                LocalSquareCsr::try_from(csr.as_ref().clone()).expect("block CSR should be square");
             let mut ilu = IluCsr::new_with_config(cfg.clone());
-            let op = CsrOp::new(csr.clone());
-            let _ = ilu.setup(&op);
+            let _ = ilu.setup_local_square(&local_square);
             self.block_factors_ilu
                 .push((block.clone(), std::sync::Arc::new(ilu)));
         }
@@ -395,8 +397,8 @@ impl Preconditioner for BlockJacobi {
             }
             #[cfg(not(feature = "dense-direct"))]
             {
-                let local = dist.local_block_csr();
-                self.setup_from_csr_ilu(&local);
+                let local_square = dist.local_square_block();
+                self.setup_from_csr_ilu(local_square.as_csr());
                 return Ok(());
             }
         }

--- a/src/preconditioner/dist/block_jacobi_ilu.rs
+++ b/src/preconditioner/dist/block_jacobi_ilu.rs
@@ -261,7 +261,8 @@ fn build_obj_block_pc<L>(
 where
     L: ObjPreconditioner + 'static,
 {
-    let local = Arc::new(dist_op.local_block_csr());
+    let local_square = dist_op.local_square_block();
+    let local = Arc::new(local_square.as_csr().clone());
     let op = CsrOp::new(local);
     ObjPreconditioner::setup(&mut local_pc, &op)?;
     let native_plan = if supports_native {
@@ -543,7 +544,8 @@ pub fn build_block_jacobi_pc(
                 )?),
                 LocalPcKind::Jacobi => {
                     let mut jacobi = Jacobi::new();
-                    let local = Arc::new(dist_op.local_block_csr());
+                    let local_square = dist_op.local_square_block();
+                    let local = Arc::new(local_square.as_csr().clone());
                     let op = CsrOp::new(local);
                     ObjPreconditioner::setup(&mut jacobi, &op)?;
                     Box::new(BlockJacobiLocalPc::new(

--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use crate::algebra::scalar::KrystScalar;
 use crate::error::KError;
 use crate::matrix::convert::csr_from_linop;
+use crate::matrix::dist::LocalSquareCsr;
 use crate::matrix::format::OpFormat;
 use crate::matrix::op::{LinOp, StructureId, ValuesId};
 use crate::matrix::sparse::CsrMatrix;
@@ -1271,25 +1272,16 @@ impl IluCsr {
         }
         self.ilut_numeric_only(a, max_diag_abs)
     }
-}
 
-#[cfg(not(feature = "complex"))]
-impl Preconditioner for IluCsr {
-    fn dims(&self) -> (usize, usize) {
-        (self.n, self.n)
-    }
-
-    fn setup(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
-        let drop = 0.0; // use full numerical content by default
-        let a: Arc<CsrMatrix<f64>> = csr_from_linop(op, drop)?;
-        let pipeline = apply_preconditioning_pipeline(
-            a.as_ref(),
-            &self.cfg.conditioning,
-            &self.cfg.reordering,
-        )?;
+    fn setup_from_local_square_ids(
+        &mut self,
+        a: &CsrMatrix<f64>,
+        sid: StructureId,
+        vid: ValuesId,
+    ) -> Result<(), KError> {
+        let pipeline =
+            apply_preconditioning_pipeline(a, &self.cfg.conditioning, &self.cfg.reordering)?;
         let a = &pipeline.matrix;
-        let sid = op.structure_id();
-        let vid = op.values_id();
 
         let structure_changed = self.last_sid != Some(sid);
         let values_changed = self.last_vid != Some(vid);
@@ -1311,6 +1303,25 @@ impl Preconditioner for IluCsr {
         } else {
             Ok(())
         }
+    }
+
+    pub fn setup_local_square(&mut self, local: &LocalSquareCsr<f64>) -> Result<(), KError> {
+        let op = local.as_csr();
+        self.setup_from_local_square_ids(op, op.structure_id(), op.values_id())
+    }
+}
+
+#[cfg(not(feature = "complex"))]
+impl Preconditioner for IluCsr {
+    fn dims(&self) -> (usize, usize) {
+        (self.n, self.n)
+    }
+
+    fn setup(&mut self, op: &dyn LinOp<S = f64>) -> Result<(), KError> {
+        let drop = 0.0; // use full numerical content by default
+        let a: Arc<CsrMatrix<f64>> = csr_from_linop(op, drop)?;
+        let local = LocalSquareCsr::try_from(a.as_ref().clone())?;
+        self.setup_from_local_square_ids(local.as_csr(), op.structure_id(), op.values_id())
     }
 
     fn apply(&self, _side: PcSide, x: &[f64], y: &mut [f64]) -> Result<(), KError> {
@@ -1392,6 +1403,8 @@ impl Preconditioner for IluCsr {
                     "IluCsr complex setup currently requires a CSR operator; non-CSR LinOp paths have no lossless complex ILU fallback".into(),
                 )
             })?;
+        let local = LocalSquareCsr::try_from(csr.clone())?;
+        let csr = local.as_csr();
 
         let sid = op.structure_id();
         let vid = op.values_id();


### PR DESCRIPTION
### Motivation
- Make ownership / shape expectations explicit for distributed → local preconditioner flows so invalid conversions fail at compile-time/explicit conversion points. 
- Restrict ILU setup to inputs that prove local squareness/ownership to avoid accidental use of global-row slices where a square local block is required.

### Description
- Add new marker types `DistRowCsr<S>` and `LocalSquareCsr<S>` in `src/matrix/dist/csr_types.rs` with constructors and `TryFrom`/accessors to validate shapes at creation. 
- Re-export the new types via `matrix::dist` and top-level `matrix` to simplify usage across modules. 
- Extend `DistCsrOp` with explicit extraction APIs `local_rows_csr()` and `local_square_block()` that return `DistRowCsr` and `LocalSquareCsr` respectively. 
- Refactor ILU flow: add `IluCsr::setup_local_square(&LocalSquareCsr<f64>)` and a shared helper `setup_from_local_square_ids` and change the trait `setup` path to attempt conversion to `LocalSquareCsr` before factorization. 
- Update block-Jacobi and distributed block-Jacobi wiring to perform explicit `LocalSquareCsr` extraction and call the new `setup_local_square` path instead of implicitly relying on `CsrMatrix` conversion. 
- Update the MPI demo to show explicit extraction of both `DistRowCsr` and `LocalSquareCsr` and print their nnz metrics. 

### Testing
- Ran `cargo fmt` — succeeded. 
- Ran `cargo check --features backend-faer` — succeeded (build completed; compiler warnings unchanged). 
- Built the distributed block-Jacobi test binary with `cargo test --features backend-faer --test dist_block_jacobi --no-run` — succeeded (test executable built).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ebdc598f908329afa11b0432b347db)