### PR TITLE
Add targeted tests for MPI/serial parity, rectangular-local rejection, ILU promotion path, and policy reporting

### DIFF
--- a/src/bin/distcsr_bench_runner.rs
+++ b/src/bin/distcsr_bench_runner.rs
@@ -596,3 +596,66 @@ fn main() {
     )
     .expect("write artifact");
 }
+
+#[cfg(test)]
+mod tests {
+    use super::{build_part_prefix, fallback_total};
+    use serde_json::{Map, Value};
+    use std::collections::BTreeMap;
+
+    #[test]
+    fn qc324_style_partition_is_deterministic_and_covers_domain() {
+        let first = build_part_prefix(324, 4, 324);
+        let second = build_part_prefix(324, 4, 324);
+        assert_eq!(first, second, "partitioning must be deterministic");
+        assert_eq!(first.first().copied(), Some(0));
+        assert_eq!(first.last().copied(), Some(324));
+        assert_eq!(first.len(), 5);
+        assert!(
+            first.windows(2).all(|w| w[1] > w[0]),
+            "all partitions should own at least one row"
+        );
+    }
+
+    #[test]
+    fn benchmark_summary_route_fields_track_requested_vs_effective_policy() {
+        let mut summary = BTreeMap::new();
+        summary.insert(
+            "pc_dist_requested_distributed_mode".into(),
+            Value::from("native_distributed"),
+        );
+        summary.insert(
+            "pc_dist_selected_route".into(),
+            Value::from("configured_global"),
+        );
+        summary.insert(
+            "pc_dist_fallback_reason".into(),
+            Value::from("native setup failed on dwg961a pivot stress"),
+        );
+
+        let mut counters = Map::new();
+        counters.insert("native_setup_failed".into(), Value::from(1_u64));
+        counters.insert("configured_global_fallback".into(), Value::from(1_u64));
+        summary.insert("pc_dist_fallback_counters".into(), Value::Object(counters));
+
+        assert_eq!(
+            summary
+                .get("pc_dist_requested_distributed_mode")
+                .and_then(Value::as_str),
+            Some("native_distributed")
+        );
+        assert_eq!(
+            summary
+                .get("pc_dist_selected_route")
+                .and_then(Value::as_str),
+            Some("configured_global")
+        );
+        assert_eq!(
+            summary
+                .get("pc_dist_fallback_reason")
+                .and_then(Value::as_str),
+            Some("native setup failed on dwg961a pivot stress")
+        );
+        assert_eq!(fallback_total(&summary), 2);
+    }
+}

--- a/src/context/ksp_context/distcsr_capability.rs
+++ b/src/context/ksp_context/distcsr_capability.rs
@@ -245,4 +245,27 @@ mod tests {
         assert!(report.native_required);
         assert_eq!(report.max_allowed_fallbacks, Some(0));
     }
+
+    #[test]
+    fn route_report_preserves_requested_vs_effective_modes_for_summary_fields() {
+        let mut opts = MpiPcOptions::default();
+        opts.local_apply_mode = DistLocalApplyMode::NativeLocalHalo;
+
+        let report = build_dist_route_decision_report(
+            &opts,
+            DistRouteSelection::ConfiguredGlobal,
+            Some("native setup failed on pivot stress fixture".to_string()),
+            1,
+        );
+        assert_eq!(report.requested_mode, "native_distributed");
+        assert_eq!(
+            report.selected_mode,
+            DistRouteSelection::ConfiguredGlobal.as_str()
+        );
+        assert_eq!(
+            report.fallback_reason.as_deref(),
+            Some("native setup failed on pivot stress fixture")
+        );
+        assert_eq!(report.fallback_chain_len, 1);
+    }
 }

--- a/src/context/pc_context.rs
+++ b/src/context/pc_context.rs
@@ -1319,4 +1319,12 @@ mod tests {
         assert_eq!(specs.len(), 2);
         assert_eq!(specs[1].options.as_ref().and_then(|o| o.ilu_level), Some(4));
     }
+
+    #[test]
+    fn chain_ilu0_to_ilut_to_ilutp_promotion_path_parses_in_order() {
+        let opts = crate::config::options::PcOptions::default();
+        let specs = PcFactory::create_pc_chain_from_str("ilu0->ilut->ilutp", Some(&opts)).unwrap();
+        let labels: Vec<PcType> = specs.iter().map(|s| s.pc_type.clone()).collect();
+        assert_eq!(labels, vec![PcType::Ilu0, PcType::Ilut, PcType::Ilutp]);
+    }
 }

--- a/src/matrix/dist/csr_types.rs
+++ b/src/matrix/dist/csr_types.rs
@@ -73,3 +73,27 @@ impl<S: KrystScalar> TryFrom<CsrMatrix<S>> for LocalSquareCsr<S> {
         Self::try_from_csr(value)
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::LocalSquareCsr;
+    use crate::matrix::sparse::CsrMatrix;
+
+    #[test]
+    fn local_square_csr_rejects_rectangular_with_clear_error() {
+        let rectangular = CsrMatrix::from_csr(
+            2,
+            3,
+            vec![0, 2, 4],
+            vec![0, 1, 1, 2],
+            vec![1.0, 2.0, 3.0, 4.0],
+        );
+
+        let err = LocalSquareCsr::try_from(rectangular).expect_err("rectangular must fail");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("LocalSquareCsr requires square matrix") && msg.contains("2x3"),
+            "unexpected rejection text: {msg}"
+        );
+    }
+}

--- a/tests/mpi_rhs_norm_parity.rs
+++ b/tests/mpi_rhs_norm_parity.rs
@@ -33,3 +33,30 @@ fn mpi_rhs_norm_matches_serial_on_same_matrix() {
         "MPI-reduced rhs norm {mpi_norm:.16e} differs from serial {serial_norm:.16e} (tol={tol:.3e})"
     );
 }
+
+#[test]
+fn mpi_rhs_norm_report_parity_on_qc324_style_partition() {
+    let comm = UniverseComm::Mpi(Arc::new(MpiComm::new()));
+    let n_global = 324usize;
+    let size = comm.size();
+    let rank = comm.rank();
+
+    let base = n_global / size;
+    let rem = n_global % size;
+    let local_n = base + usize::from(rank < rem);
+    let row_start = rank * base + rank.min(rem);
+
+    let rhs_global: Vec<f64> = (0..n_global).map(|i| 1.0 + (i as f64) * 1e-2).collect();
+    let serial_norm = rhs_global.iter().map(|v| v * v).sum::<f64>().sqrt();
+    let rhs_local = &rhs_global[row_start..row_start + local_n];
+    let mpi_norm = comm
+        .all_reduce_f64(rhs_local.iter().map(|v| v * v).sum::<f64>())
+        .sqrt();
+
+    let serial_report = format!("rhs_norm_l2={serial_norm:.12e}");
+    let mpi_report = format!("rhs_norm_l2={mpi_norm:.12e}");
+    assert_eq!(
+        serial_report, mpi_report,
+        "reported norm text should stay stable across serial and MPI paths"
+    );
+}


### PR DESCRIPTION
### Motivation
- Ensure deterministic parity between serial and MPI reductions and stable textual reporting for partitioned fixtures used by benchmarks.
- Explicitly guard against non-square local blocks by asserting clear, actionable error messages for `LocalSquareCsr`.
- Lock in the ILU promotion chain ordering (`ILU0 -> ILUT -> ILUTP`) to avoid regressions in chain parsing.
- Verify that route decision summaries preserve requested vs effective mode fields and fallback metadata consumed by benchmark summaries.

### Description
- Added an MPI parity unit test that compares reported norm text for a deterministic `qc324`-style partition (`n_global = 324`) to ensure serial vs MPI report parity (`tests/mpi_rhs_norm_parity.rs`).
- Added a `LocalSquareCsr` rejection test that constructs a `2x3` CSR and asserts the `InvalidInput` message contains both the square requirement and concrete dimensions (`src/matrix/dist/csr_types.rs`).
- Added a chain-parsing test that asserts `ilu0->ilut->ilutp` yields the expected ordered `PcType` sequence (`src/context/pc_context.rs`).
- Added a route-report test that validates `requested_mode`, `selected_mode`, `fallback_reason`, and `fallback_chain_len` fields in the route decision report (`src/context/ksp_context/distcsr_capability.rs`).
- Added lightweight `distcsr_bench_runner` tests to pin deterministic partitioning behavior and stable summary keys/counters used by the bench runner (including a pivot-stress style fallback reason string) (`src/bin/distcsr_bench_runner.rs`).

### Testing
- Ran `cargo fmt` to format changes successfully.
- Executed focused unit tests which passed: `cargo test --bin distcsr_bench_runner qc324_style_partition_is_deterministic_and_covers_domain` (ok) and `cargo test --bin distcsr_bench_runner benchmark_summary_route_fields_track_requested_vs_effective_policy` (ok).
- Ran library/unit tests which passed: `cargo test --lib local_square_csr_rejects_rectangular_with_clear_error`, `cargo test --lib chain_ilu0_to_ilut_to_ilutp_promotion_path_parses_in_order`, and `cargo test --lib route_report_preserves_requested_vs_effective_modes_for_summary_fields` (all ok).
- Ran MPI-enabled parity tests which passed: `cargo test --features mpi --test mpi_rhs_norm_parity mpi_rhs_norm_report_parity_on_qc324_style_partition` (ok).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69efea6e94008329ba4d994b39218577)