### PR TITLE
Add configurable FGMRES stagnation restart policy

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -38,7 +38,8 @@ mod complex_demo {
     use kryst::preconditioner::jacobi::Jacobi;
     use kryst::solver::{LinearSolver, MonitorAction, MonitorCallback};
     use kryst::solver::fgmres::{
-        FgmresSolver, FgmresVariant, OrthogMethod, PipelinePolicy, ResidualCheckPolicy,
+        FgmresSolver, FgmresStagnationPolicy, FgmresVariant, OrthogMethod, PipelinePolicy,
+        ResidualCheckPolicy,
     };
     use kryst::utils::convergence::ConvergedReason;
     use kryst::utils::matrix_market::read_matrix_market;
@@ -1148,7 +1149,10 @@ mod complex_demo {
         solver.atol = bench_cfg.atol;
         solver.dtol = 1e6;
         if bench_cfg.disable_stagnation_restart {
-            solver.pipeline_policy = PipelinePolicy::Strict;
+            solver.stagnation_policy = match spec.variant {
+                FgmresVariant::Classical => FgmresStagnationPolicy::Disabled,
+                FgmresVariant::Pipelined => FgmresStagnationPolicy::PipelineFallbackOnly,
+            };
         }
         solver
     }

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -60,6 +60,13 @@ pub enum PipelinePolicy {
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum FgmresStagnationPolicy {
+    Disabled,
+    PipelineFallbackOnly,
+    RestartClassicalToo,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub enum ResidualCheckPolicy {
     /// Recompute only at startup and restart boundaries (plus safety checks).
     RestartOnly,
@@ -124,6 +131,7 @@ pub struct FgmresSolver {
     /// Controls how often explicit true residual recomputation is performed.
     pub residual_check_policy: ResidualCheckPolicy,
     pub pipeline_policy: PipelinePolicy,
+    pub stagnation_policy: FgmresStagnationPolicy,
 }
 
 impl FgmresSolver {
@@ -158,6 +166,7 @@ impl FgmresSolver {
             reorth_tol: 0.7,
             residual_check_policy: ResidualCheckPolicy::OnConvergence,
             pipeline_policy: PipelinePolicy::FallbackToClassicalOnStagnation,
+            stagnation_policy: FgmresStagnationPolicy::RestartClassicalToo,
         }
     }
 
@@ -247,6 +256,49 @@ impl FgmresSolver {
         } else {
             self.restart
         }
+    }
+
+    pub(crate) fn stagnation_action(&mut self) -> (&'static str, bool) {
+        let mut should_restart = false;
+        let action = match self.stagnation_policy {
+            FgmresStagnationPolicy::Disabled => "stagnation policy disabled",
+            FgmresStagnationPolicy::PipelineFallbackOnly => match (self.variant, self.pipeline_policy)
+            {
+                (FgmresVariant::Pipelined, PipelinePolicy::FallbackToClassicalOnStagnation) => {
+                    self.variant = FgmresVariant::Classical;
+                    should_restart = true;
+                    "switching to classical restart"
+                }
+                (FgmresVariant::Pipelined, PipelinePolicy::PeriodicResidualReplacement) => {
+                    should_restart = true;
+                    "periodic residual replacement restart"
+                }
+                (FgmresVariant::Pipelined, PipelinePolicy::Strict) => {
+                    "strict pipelined policy: no fallback"
+                }
+                _ => "pipeline-only policy: no classical restart",
+            },
+            FgmresStagnationPolicy::RestartClassicalToo => match (self.variant, self.pipeline_policy)
+            {
+                (FgmresVariant::Pipelined, PipelinePolicy::FallbackToClassicalOnStagnation) => {
+                    self.variant = FgmresVariant::Classical;
+                    should_restart = true;
+                    "switching to classical restart"
+                }
+                (FgmresVariant::Pipelined, PipelinePolicy::PeriodicResidualReplacement) => {
+                    should_restart = true;
+                    "periodic residual replacement restart"
+                }
+                (FgmresVariant::Pipelined, PipelinePolicy::Strict) => {
+                    "strict pipelined policy: no fallback"
+                }
+                _ => {
+                    should_restart = true;
+                    "restarting FGMRES"
+                }
+            },
+        };
+        (action, should_restart)
     }
 
     fn ensure_workspace(&self, w: &mut Workspace, n: usize) {
@@ -1268,28 +1320,7 @@ impl FgmresSolver {
                     stagnation_residuals.remove(0);
                 }
                 if stagnation_detected(&stagnation_residuals, stagnation_threshold) {
-                    let mut should_restart = false;
-                    let action = match (self.variant, self.pipeline_policy) {
-                        (
-                            FgmresVariant::Pipelined,
-                            PipelinePolicy::FallbackToClassicalOnStagnation,
-                        ) => {
-                            self.variant = FgmresVariant::Classical;
-                            should_restart = true;
-                            "switching to classical restart"
-                        }
-                        (FgmresVariant::Pipelined, PipelinePolicy::PeriodicResidualReplacement) => {
-                            should_restart = true;
-                            "periodic residual replacement restart"
-                        }
-                        (FgmresVariant::Pipelined, PipelinePolicy::Strict) => {
-                            "strict pipelined policy: no fallback"
-                        }
-                        _ => {
-                            should_restart = true;
-                            "restarting FGMRES"
-                        }
-                    };
+                    let (action, should_restart) = self.stagnation_action();
                     log_krylov_stagnation("FGMRES", total_iters, res, action);
                     stagnation_residuals.clear();
                     if should_restart {
@@ -1890,6 +1921,10 @@ impl FgmresSolver {
 
     pub fn set_pipeline_policy(&mut self, policy: PipelinePolicy) {
         self.pipeline_policy = policy;
+    }
+
+    pub fn set_stagnation_policy(&mut self, policy: FgmresStagnationPolicy) {
+        self.stagnation_policy = policy;
     }
 
     pub fn set_strict_true_residual_cadence(&mut self, flag: bool) {

--- a/src/solver/tests/fgmres_stagnation_policy.rs
+++ b/src/solver/tests/fgmres_stagnation_policy.rs
@@ -1,0 +1,22 @@
+use crate::solver::fgmres::{
+    FgmresSolver, FgmresStagnationPolicy, FgmresVariant, PipelinePolicy,
+};
+
+#[test]
+fn fgmres_classical_stagnation_disabled_does_not_force_restart() {
+    let mut solver = FgmresSolver::new(1e-10, 20, 5);
+    solver.variant = FgmresVariant::Classical;
+    solver.stagnation_policy = FgmresStagnationPolicy::Disabled;
+    let (_action, restart) = solver.stagnation_action();
+    assert!(!restart);
+}
+
+#[test]
+fn fgmres_classical_stagnation_pipeline_only_does_not_force_restart() {
+    let mut solver = FgmresSolver::new(1e-10, 20, 5);
+    solver.variant = FgmresVariant::Classical;
+    solver.pipeline_policy = PipelinePolicy::FallbackToClassicalOnStagnation;
+    solver.stagnation_policy = FgmresStagnationPolicy::PipelineFallbackOnly;
+    let (_action, restart) = solver.stagnation_action();
+    assert!(!restart);
+}

--- a/src/solver/tests/mod.rs
+++ b/src/solver/tests/mod.rs
@@ -5,6 +5,7 @@ mod breakdown_true_residual;
 mod cg_pipelined;
 mod cg_side;
 mod fgmres_distcsr;
+mod fgmres_stagnation_policy;
 mod gmres_left_right;
 mod gmres_right_z_basis;
 mod gmres_variants;


### PR DESCRIPTION
### Motivation
- Make FGMRES stagnation handling policy-driven so classical/pipelined behavior can be controlled independently and preserve backward-compatible defaults.

### Description
- Add a new `FgmresStagnationPolicy` enum with variants `Disabled`, `PipelineFallbackOnly`, and `RestartClassicalToo` and a `stagnation_policy` field on `FgmresSolver` with default `RestartClassicalToo` to preserve existing behavior.
- Extract the stagnation decision into a helper `stagnation_action()` and replace the previous in-loop branch at `stagnation_detected(...)` to be governed by the new policy while keeping pipelined fallback/replacement semantics policy-gated.
- Expose a setter `set_stagnation_policy(...)` and wire `--disable-stagnation-restart` in the example so it maps to `Disabled` for classical FGMRES and `PipelineFallbackOnly` for pipelined FGMRES.
- Add unit tests in `src/solver/tests/fgmres_stagnation_policy.rs` and register the test module to assert that classical FGMRES does not force a restart under the `Disabled` and `PipelineFallbackOnly` policies.

### Testing
- Added targeted unit tests `fgmres_classical_stagnation_disabled_does_not_force_restart` and `fgmres_classical_stagnation_pipeline_only_does_not_force_restart` in `src/solver/tests/fgmres_stagnation_policy.rs` and executed `cargo test -q fgmres_classical_stagnation_`, which completed successfully (targeted tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2669b9ca08329a5c6b39b5211fd72)