### PR TITLE
Introduce correctness-profile stagnation defaults and fallback gating for FGMRES

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -89,7 +89,19 @@ mod complex_demo {
                     RunMode::Scalability => {
                         "distributed operator + local-block PC only, global norms only, lightweight reporting"
                     }
+                    RunMode::Robustness => {
+                        "robustness stress: fallback-enabled stagnation handling and restart-heavy behavior"
+                    }
                 }
+            );
+            println!(
+                "Stagnation fallback: {} (min_inner_before_fallback={})",
+                if config.run_mode == RunMode::Correctness || !config.allow_stagnation_fallback {
+                    "disabled"
+                } else {
+                    "enabled"
+                },
+                config.min_inner_before_fallback
             );
             if config.run_mode == RunMode::Correctness {
                 println!(
@@ -123,6 +135,7 @@ mod complex_demo {
         let cases: Vec<(&str, &str)> = match config.run_mode {
             RunMode::Correctness => all_cases.to_vec(),
             RunMode::Scalability => all_cases.to_vec(),
+            RunMode::Robustness => all_cases.to_vec(),
         };
 
         for (mat_name, descr) in cases {
@@ -460,7 +473,8 @@ mod complex_demo {
         variants: Vec<FgmresVariant>,
         orthogs: Vec<OrthogMethod>,
         reorths: Vec<ReorthPolicy>,
-        disable_stagnation_restart: bool,
+        allow_stagnation_fallback: bool,
+        min_inner_before_fallback: usize,
         correctness_replicated_check: bool,
         residual_history: bool,
         residual_history_file: Option<PathBuf>,
@@ -473,6 +487,7 @@ mod complex_demo {
     enum RunMode {
         Correctness,
         Scalability,
+        Robustness,
     }
 
     impl RunMode {
@@ -480,6 +495,7 @@ mod complex_demo {
             match self {
                 Self::Correctness => "correctness",
                 Self::Scalability => "scalability",
+                Self::Robustness => "robustness",
             }
         }
 
@@ -487,8 +503,9 @@ mod complex_demo {
             match token.trim().to_ascii_lowercase().as_str() {
                 "correctness" => Ok(Self::Correctness),
                 "scalability" => Ok(Self::Scalability),
+                "robustness" => Ok(Self::Robustness),
                 other => Err(KError::InvalidInput(format!(
-                    "invalid run mode '{other}', expected correctness|scalability"
+                    "invalid run mode '{other}', expected correctness|scalability|robustness"
                 ))),
             }
         }
@@ -509,7 +526,8 @@ mod complex_demo {
                 variants: vec![FgmresVariant::Classical],
                 orthogs: vec![OrthogMethod::ClassicalGS],
                 reorths: vec![ReorthPolicy::IfNeeded],
-                disable_stagnation_restart: false,
+                allow_stagnation_fallback: false,
+                min_inner_before_fallback: 8,
                 correctness_replicated_check: false,
                 residual_history: false,
                 residual_history_file: None,
@@ -545,11 +563,11 @@ mod complex_demo {
                     "--help" | "-h" => {
                         if cfg!(feature = "mpi") {
                             println!(
-                                "Usage: cargo mpirun -n <ranks> --example complex_matrix_market_demo --features complex,mpi,mpi_examples -- [--mode correctness|scalability] [--correctness-replicated-check] [--warmup-runs N] [--measured-runs N] [--rtol F] [--atol F] [--maxits N] [--restarts csv] [--pcs csv] [--include-restart-200] [--disable-stagnation-restart] [--fgmres-variant csv] [--fgmres-orthog csv] [--fgmres-reorth csv] [--residual-history] [--residual-history-file <path>] [--residual-history-force] [--row-scale [tiny]]"
+                                "Usage: cargo mpirun -n <ranks> --example complex_matrix_market_demo --features complex,mpi,mpi_examples -- [--mode correctness|scalability|robustness] [--correctness-replicated-check] [--warmup-runs N] [--measured-runs N] [--rtol F] [--atol F] [--maxits N] [--restarts csv] [--pcs csv] [--include-restart-200] [--allow-stagnation-fallback] [--min-inner-before-fallback N] [--fgmres-variant csv] [--fgmres-orthog csv] [--fgmres-reorth csv] [--residual-history] [--residual-history-file <path>] [--residual-history-force] [--row-scale [tiny]]"
                             );
                         } else {
                             println!(
-                                "Usage: cargo run --example complex_matrix_market_demo --features complex -- [--mode correctness|scalability] [--correctness-replicated-check] [--warmup-runs N] [--measured-runs N] [--rtol F] [--atol F] [--maxits N] [--restarts csv] [--pcs csv] [--include-restart-200] [--disable-stagnation-restart] [--fgmres-variant csv] [--fgmres-orthog csv] [--fgmres-reorth csv] [--residual-history] [--residual-history-file <path>] [--residual-history-force] [--row-scale [tiny]]"
+                                "Usage: cargo run --example complex_matrix_market_demo --features complex -- [--mode correctness|scalability|robustness] [--correctness-replicated-check] [--warmup-runs N] [--measured-runs N] [--rtol F] [--atol F] [--maxits N] [--restarts csv] [--pcs csv] [--include-restart-200] [--allow-stagnation-fallback] [--min-inner-before-fallback N] [--fgmres-variant csv] [--fgmres-orthog csv] [--fgmres-reorth csv] [--residual-history] [--residual-history-file <path>] [--residual-history-force] [--row-scale [tiny]]"
                             );
                         }
                         std::process::exit(0);
@@ -598,8 +616,17 @@ mod complex_demo {
                     "--include-restart-200" => {
                         cfg.include_restart_200 = true;
                     }
-                    "--disable-stagnation-restart" => {
-                        cfg.disable_stagnation_restart = true;
+                    "--allow-stagnation-fallback" => {
+                        cfg.allow_stagnation_fallback = true;
+                    }
+                    "--min-inner-before-fallback" => {
+                        let Some(v) = args.next() else {
+                            return Err(KError::InvalidInput(
+                                "missing value for --min-inner-before-fallback".into(),
+                            ));
+                        };
+                        cfg.min_inner_before_fallback =
+                            parse_positive_usize("--min-inner-before-fallback", &v)?;
                     }
                     "--fgmres-variant" => {
                         let Some(v) = args.next() else {
@@ -834,6 +861,13 @@ mod complex_demo {
                             vec![PcKind::Ilu0Local]
                         }
                     }
+                    RunMode::Robustness => {
+                        if problem.comm.size() > 1 {
+                            vec![PcKind::MpiBlockJacobiIlu0Local, PcKind::JacobiWeak]
+                        } else {
+                            vec![PcKind::Ilu0Local, PcKind::JacobiWeak]
+                        }
+                    }
                 }
             } else {
                 cfg.pcs.clone()
@@ -854,6 +888,7 @@ mod complex_demo {
                                     residual_check_policy: match cfg.run_mode {
                                         RunMode::Correctness => ResidualCheckPolicy::OnConvergence,
                                         RunMode::Scalability => ResidualCheckPolicy::RestartOnly,
+                                        RunMode::Robustness => ResidualCheckPolicy::RestartOnly,
                                     },
                                     orthog,
                                     reorth,
@@ -1547,12 +1582,16 @@ mod complex_demo {
         solver.reorth = spec.reorth;
         solver.atol = bench_cfg.atol;
         solver.dtol = 1e6;
-        if bench_cfg.disable_stagnation_restart {
-            solver.stagnation_policy = match spec.variant {
-                FgmresVariant::Classical => FgmresStagnationPolicy::Disabled,
-                FgmresVariant::Pipelined => FgmresStagnationPolicy::PipelineFallbackOnly,
+        solver.min_inner_before_fallback = bench_cfg.min_inner_before_fallback.max(1);
+        solver.stagnation_policy =
+            if bench_cfg.run_mode == RunMode::Correctness || !bench_cfg.allow_stagnation_fallback {
+                FgmresStagnationPolicy::Disabled
+            } else {
+                match spec.variant {
+                    FgmresVariant::Classical => FgmresStagnationPolicy::RestartClassicalToo,
+                    FgmresVariant::Pipelined => FgmresStagnationPolicy::PipelineFallbackOnly,
+                }
             };
-        }
         solver
     }
 
@@ -2022,6 +2061,13 @@ mod complex_demo {
                         vec![PcKind::Ilu0Local]
                     }
                 }
+                RunMode::Robustness => {
+                    if mpi_mode {
+                        vec![PcKind::MpiBlockJacobiIlu0Local, PcKind::JacobiWeak]
+                    } else {
+                        vec![PcKind::Ilu0Local, PcKind::JacobiWeak]
+                    }
+                }
             }
         } else {
             cfg.pcs.clone()
@@ -2065,6 +2111,29 @@ mod complex_demo {
         let label = PcKind::IlutLocal.label();
         assert!(label.contains("degraded/provisional"));
         assert!(label.contains("real-projection"));
+    }
+
+    #[test]
+    fn correctness_mode_disables_stagnation_fallback_and_keeps_restart_target() {
+        let spec = RunSpec {
+            restart: 50,
+            variant: FgmresVariant::Classical,
+            residual_check_policy: ResidualCheckPolicy::OnConvergence,
+            orthog: OrthogMethod::ClassicalGS,
+            reorth: ReorthPolicy::IfNeeded,
+            pc_side: PcSide::Right,
+            pc: PcKind::None,
+        };
+        let cfg = BenchmarkConfig {
+            run_mode: RunMode::Correctness,
+            allow_stagnation_fallback: true,
+            min_inner_before_fallback: 12,
+            ..BenchmarkConfig::default()
+        };
+        let solver = configured_solver(&spec, &cfg);
+        assert_eq!(solver.restart, 50);
+        assert_eq!(solver.stagnation_policy, FgmresStagnationPolicy::Disabled);
+        assert_eq!(solver.min_inner_before_fallback, 12);
     }
 }
 

--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -132,6 +132,7 @@ pub struct FgmresSolver {
     pub residual_check_policy: ResidualCheckPolicy,
     pub pipeline_policy: PipelinePolicy,
     pub stagnation_policy: FgmresStagnationPolicy,
+    pub min_inner_before_fallback: usize,
 }
 
 impl FgmresSolver {
@@ -167,6 +168,7 @@ impl FgmresSolver {
             residual_check_policy: ResidualCheckPolicy::OnConvergence,
             pipeline_policy: PipelinePolicy::FallbackToClassicalOnStagnation,
             stagnation_policy: FgmresStagnationPolicy::RestartClassicalToo,
+            min_inner_before_fallback: 4,
         }
     }
 
@@ -258,45 +260,50 @@ impl FgmresSolver {
         }
     }
 
-    pub(crate) fn stagnation_action(&mut self) -> (&'static str, bool) {
+    pub(crate) fn stagnation_action(&mut self, inner_iter: usize) -> (&'static str, bool) {
+        if inner_iter < self.min_inner_before_fallback {
+            return ("stagnation fallback gated by min-inner floor", false);
+        }
         let mut should_restart = false;
         let action = match self.stagnation_policy {
             FgmresStagnationPolicy::Disabled => "stagnation policy disabled",
-            FgmresStagnationPolicy::PipelineFallbackOnly => match (self.variant, self.pipeline_policy)
-            {
-                (FgmresVariant::Pipelined, PipelinePolicy::FallbackToClassicalOnStagnation) => {
-                    self.variant = FgmresVariant::Classical;
-                    should_restart = true;
-                    "switching to classical restart"
+            FgmresStagnationPolicy::PipelineFallbackOnly => {
+                match (self.variant, self.pipeline_policy) {
+                    (FgmresVariant::Pipelined, PipelinePolicy::FallbackToClassicalOnStagnation) => {
+                        self.variant = FgmresVariant::Classical;
+                        should_restart = true;
+                        "switching to classical restart"
+                    }
+                    (FgmresVariant::Pipelined, PipelinePolicy::PeriodicResidualReplacement) => {
+                        should_restart = true;
+                        "periodic residual replacement restart"
+                    }
+                    (FgmresVariant::Pipelined, PipelinePolicy::Strict) => {
+                        "strict pipelined policy: no fallback"
+                    }
+                    _ => "pipeline-only policy: no classical restart",
                 }
-                (FgmresVariant::Pipelined, PipelinePolicy::PeriodicResidualReplacement) => {
-                    should_restart = true;
-                    "periodic residual replacement restart"
+            }
+            FgmresStagnationPolicy::RestartClassicalToo => {
+                match (self.variant, self.pipeline_policy) {
+                    (FgmresVariant::Pipelined, PipelinePolicy::FallbackToClassicalOnStagnation) => {
+                        self.variant = FgmresVariant::Classical;
+                        should_restart = true;
+                        "switching to classical restart"
+                    }
+                    (FgmresVariant::Pipelined, PipelinePolicy::PeriodicResidualReplacement) => {
+                        should_restart = true;
+                        "periodic residual replacement restart"
+                    }
+                    (FgmresVariant::Pipelined, PipelinePolicy::Strict) => {
+                        "strict pipelined policy: no fallback"
+                    }
+                    _ => {
+                        should_restart = true;
+                        "restarting FGMRES"
+                    }
                 }
-                (FgmresVariant::Pipelined, PipelinePolicy::Strict) => {
-                    "strict pipelined policy: no fallback"
-                }
-                _ => "pipeline-only policy: no classical restart",
-            },
-            FgmresStagnationPolicy::RestartClassicalToo => match (self.variant, self.pipeline_policy)
-            {
-                (FgmresVariant::Pipelined, PipelinePolicy::FallbackToClassicalOnStagnation) => {
-                    self.variant = FgmresVariant::Classical;
-                    should_restart = true;
-                    "switching to classical restart"
-                }
-                (FgmresVariant::Pipelined, PipelinePolicy::PeriodicResidualReplacement) => {
-                    should_restart = true;
-                    "periodic residual replacement restart"
-                }
-                (FgmresVariant::Pipelined, PipelinePolicy::Strict) => {
-                    "strict pipelined policy: no fallback"
-                }
-                _ => {
-                    should_restart = true;
-                    "restarting FGMRES"
-                }
-            },
+            }
         };
         (action, should_restart)
     }
@@ -1320,7 +1327,7 @@ impl FgmresSolver {
                     stagnation_residuals.remove(0);
                 }
                 if stagnation_detected(&stagnation_residuals, stagnation_threshold) {
-                    let (action, should_restart) = self.stagnation_action();
+                    let (action, should_restart) = self.stagnation_action(j + 1);
                     log_krylov_stagnation("FGMRES", total_iters, res, action);
                     stagnation_residuals.clear();
                     if should_restart {

--- a/src/solver/tests/fgmres_stagnation_policy.rs
+++ b/src/solver/tests/fgmres_stagnation_policy.rs
@@ -1,13 +1,11 @@
-use crate::solver::fgmres::{
-    FgmresSolver, FgmresStagnationPolicy, FgmresVariant, PipelinePolicy,
-};
+use crate::solver::fgmres::{FgmresSolver, FgmresStagnationPolicy, FgmresVariant, PipelinePolicy};
 
 #[test]
 fn fgmres_classical_stagnation_disabled_does_not_force_restart() {
     let mut solver = FgmresSolver::new(1e-10, 20, 5);
     solver.variant = FgmresVariant::Classical;
     solver.stagnation_policy = FgmresStagnationPolicy::Disabled;
-    let (_action, restart) = solver.stagnation_action();
+    let (_action, restart) = solver.stagnation_action(8);
     assert!(!restart);
 }
 
@@ -17,6 +15,24 @@ fn fgmres_classical_stagnation_pipeline_only_does_not_force_restart() {
     solver.variant = FgmresVariant::Classical;
     solver.pipeline_policy = PipelinePolicy::FallbackToClassicalOnStagnation;
     solver.stagnation_policy = FgmresStagnationPolicy::PipelineFallbackOnly;
-    let (_action, restart) = solver.stagnation_action();
+    let (_action, restart) = solver.stagnation_action(8);
     assert!(!restart);
+}
+
+#[test]
+fn fgmres_stagnation_fallback_is_gated_by_min_inner_floor() {
+    let mut solver = FgmresSolver::new(1e-6, 100, 20);
+    solver.stagnation_policy = FgmresStagnationPolicy::RestartClassicalToo;
+    solver.min_inner_before_fallback = 10;
+    let (_action, restart) = solver.stagnation_action(4);
+    assert!(!restart);
+}
+
+#[test]
+fn fgmres_stagnation_fallback_can_trigger_after_min_inner_floor() {
+    let mut solver = FgmresSolver::new(1e-6, 100, 20);
+    solver.stagnation_policy = FgmresStagnationPolicy::RestartClassicalToo;
+    solver.min_inner_before_fallback = 3;
+    let (_action, restart) = solver.stagnation_action(6);
+    assert!(restart);
 }


### PR DESCRIPTION
### Motivation
- Protect correctness-mode experiments from automated stagnation fallbacks so solver validation exercises the requested `restart` and true-residual semantics. 
- Provide an explicit, configurable gate so robustness runs can still enable fallback behavior while correctness runs remain strict.

### Description
- Add `min_inner_before_fallback: usize` to `FgmresSolver` and enforce it in `stagnation_action(inner_iter)` so fallback/restart is suppressed until the configured inner-iteration floor is reached. 
- Wire the new guard into the inner loop by calling `stagnation_action(j + 1)` where stagnation is detected. 
- Update the demo configuration and CLI to add `RunMode::Robustness`, `--allow-stagnation-fallback`, and `--min-inner-before-fallback N`, and make correctness mode default to `stagnation_policy = Disabled` while preserving fallback under the new robustness/profile flag. 
- Print the active stagnation fallback status and `min_inner_before_fallback` in the demo run header and add regression tests that verify the gating and correctness-mode defaults. 

### Testing
- Ran code formatting via `cargo fmt` and it completed successfully. 
- Ran the stagnation-policy unit tests with `cargo test --lib fgmres_stagnation_policy`, which passed (test run emitted existing repository warnings but succeeded). 
- Ran the demo regression test `complex_matrix_market_demo::correctness_mode_disables_stagnation_fallback_and_keeps_restart_target` via `cargo test --example complex_matrix_market_demo --features complex` and it passed (warnings observed but no failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f27fcc1a44832980e9177abdd78e5c)