### PR TITLE
Refactor FGMRES happy-breakdown termination validation

### DIFF
--- a/src/solver/fgmres.rs
+++ b/src/solver/fgmres.rs
@@ -1096,6 +1096,7 @@ impl FgmresSolver {
             let mut converged = false;
             let mut converged_reason: Option<ConvergedReason> = None;
             let mut hapend = false;
+            let mut happy_breakdown_candidate = false;
 
             for j in 0..m_this {
                 let arnoldi_norm_scale = match self.variant {
@@ -1155,7 +1156,7 @@ impl FgmresSolver {
                     hapend = true;
                     if self.happy_breakdown {
                         happy_breakdowns += 1;
-                        converged = true;
+                        happy_breakdown_candidate = true;
                         converged_reason = Some(ConvergedReason::ConvergedHappyBreakdown);
                     } else {
                         orthogonalization_rank_loss = true;
@@ -1515,7 +1516,8 @@ impl FgmresSolver {
                 stats.reason = reason;
             }
             if true_res <= thr {
-                stats.reason = if matches!(stats.reason, ConvergedReason::ConvergedHappyBreakdown) {
+                stats.reason = if happy_breakdown_candidate {
+                    stats.residual_override_note = Some("happy_breakdown_candidate_validated".into());
                     ConvergedReason::ConvergedHappyBreakdown
                 } else if true_res <= self.atol {
                     ConvergedReason::ConvergedAtol
@@ -1540,6 +1542,10 @@ impl FgmresSolver {
                 }
                 .unwrap_or(ConvergedReason::DivergedBreakdown);
                 break;
+            }
+
+            if happy_breakdown_candidate {
+                stats.residual_override_note = Some("false_happy_breakdown_rejected".into());
             }
 
             if total_iters >= self.maxits {

--- a/tests/fgmres_flexible.rs
+++ b/tests/fgmres_flexible.rs
@@ -224,3 +224,34 @@ fn fgmres_reports_singular_reduced_system_on_zero_operator() {
 
     assert_eq!(stats.reason, ConvergedReason::DivergedReducedSystemSingular);
 }
+
+
+#[test]
+fn fgmres_happy_breakdown_candidate_validated_transition() {
+    let a = faer::Mat::<f64>::from_fn(2, 2, |i, j| if i == j { 2.0 } else { 0.0 });
+    let mut solver = FgmresSolver::new(1e-12, 10, 4);
+    solver.set_happy_breakdown(true);
+    let mut pc = ScalePc { scale: 0.5 };
+    let b = [2.0f64, 4.0];
+    let mut x = [0.0f64; 2];
+    let mut work = Workspace::new(2);
+
+    let stats = solver
+        .solve_f64(
+            &a,
+            Some(&mut pc),
+            &b,
+            &mut x,
+            PcSide::Right,
+            &UniverseComm::NoComm(kryst::parallel::NoComm),
+            None,
+            Some(&mut work),
+        )
+        .expect("FGMRES happy-breakdown candidate should validate on true residual");
+
+    assert_eq!(stats.reason, ConvergedReason::ConvergedHappyBreakdown);
+    assert_eq!(
+        stats.residual_override_note.as_deref(),
+        Some("happy_breakdown_candidate_validated")
+    );
+}


### PR DESCRIPTION
### Motivation
- Prevent declaring a terminal happy-breakdown solely from a small Hessenberg subdiagonal entry so the reduced solve, correction and true-residual check still run before acceptance.
- Make the solver robust to spurious/false happy-breakdown triggers by treating the `h_{j+1,j} <= haptol_scaled` event as a candidate until validated.
- Provide explicit metadata and reason notes so callers can distinguish a candidate that was validated from one that was rejected.

### Description
- Replaced immediate convergence on `h_subdiag <= haptol_scaled` with a non-terminal candidate flag `happy_breakdown_candidate` in `src/solver/fgmres.rs` so the reduced-system solve and `x <- x + Z y` correction always execute first.
- After applying the solution correction the code now recomputes the explicit true residual and only sets a happy-breakdown convergence if the true residual meets tolerances, otherwise the solver continues restart/cycle logic.
- Added explicit `residual_override_note` markers: `"happy_breakdown_candidate_validated"` when the candidate is confirmed and `"false_happy_breakdown_rejected"` when validation fails, and preserved prior `converged_reason` behavior where appropriate.
- Added a focused test `fgmres_happy_breakdown_candidate_validated_transition` and updated `tests/fgmres_flexible.rs` to assert the candidate→validated transition and the override note is recorded.

### Testing
- Ran `cargo test -q --test fgmres_flexible fgmres_exact_pc_happy_breakdown` and it passed.
- Ran `cargo test -q --test fgmres_flexible fgmres_happy_breakdown_candidate_validated_transition` (new test) and it passed.
- Verified the modified files: `src/solver/fgmres.rs` and `tests/fgmres_flexible.rs` with the targeted unit tests exercising the candidate→validated flow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f37b058c388329a7d35913c6178a8e)