### PR TITLE
Clarify complex demo metadata and add compact operator/backend/PC labels with snapshot tests

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -217,7 +217,10 @@ mod complex_demo {
                 );
                 if config.run_mode == RunMode::Scalability {
                     println!(
-                        "{:<36} {:<34} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14} {:>12}",
+                        "{:<7} {:<8} {:<6} {:<36} {:<34} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14} {:>12}",
+                        "Op",
+                        "Exec",
+                        "PCdom",
                         "Method",
                         "Effective policy",
                         "Med(s)",
@@ -230,10 +233,13 @@ mod complex_demo {
                         "Rec/Reported",
                         "DOF/s"
                     );
-                    println!("{}", "-".repeat(158));
+                    println!("{}", "-".repeat(184));
                 } else if include_dof_col {
                     println!(
-                        "{:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14} {:>14} {:>14} {:>14} {:>26} {:>12}",
+                        "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14} {:>14} {:>14} {:>14} {:>26} {:>12}",
+                        "Op",
+                        "Exec",
+                        "PCdom",
                         "Method",
                         "Requested policy",
                         "Effective policy",
@@ -252,10 +258,13 @@ mod complex_demo {
                         "Reason",
                         "DOF/s"
                     );
-                    println!("{}", "-".repeat(286));
+                    println!("{}", "-".repeat(312));
                 } else {
                     println!(
-                        "{:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14} {:>14} {:>14} {:>14} {:>26}",
+                        "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14} {:>14} {:>14} {:>14} {:>26}",
+                        "Op",
+                        "Exec",
+                        "PCdom",
                         "Method",
                         "Requested policy",
                         "Effective policy",
@@ -273,8 +282,9 @@ mod complex_demo {
                         "x_err(rel)",
                         "Reason"
                     );
-                    println!("{}", "-".repeat(270));
+                    println!("{}", "-".repeat(296));
                 }
+                println!("Legend: Op=operator storage (csr-cx=complex CSR), Exec=execution backend (ser=serial, mpi-row=MPI row partition, mpi-repl=MPI replicated operator), PCdom=PC domain (full=global matrix ILU, own0=owned-block overlap=0 local ILU/ASM, n/a=no ILU domain).");
             }
 
             let runs = RunSpec::build_default_matrix(&config, &problem);
@@ -401,6 +411,9 @@ mod complex_demo {
     }
 
     struct ResultRow {
+        operator_storage: &'static str,
+        execution_backend: &'static str,
+        pc_domain: &'static str,
         method: String,
         requested_policy: String,
         effective_policy: String,
@@ -995,6 +1008,26 @@ mod complex_demo {
         }
     }
 
+    fn operator_storage_label(_problem: &Problem) -> &'static str {
+        "csr-cx"
+    }
+
+    fn execution_backend_label(problem: &Problem) -> &'static str {
+        match problem.backend {
+            CsrBackend::Serial => "ser",
+            CsrBackend::Replicated => "mpi-repl",
+            CsrBackend::Distributed => "mpi-row",
+        }
+    }
+
+    fn pc_domain_label(pc: PcKind) -> &'static str {
+        match pc {
+            PcKind::ReplicatedFullIlu0 | PcKind::ReplicatedFullIluk { .. } => "full",
+            PcKind::Ilu0Local | PcKind::IlutLocal | PcKind::MpiBlockJacobiIlu0Local | PcKind::LocalIluk { .. } => "own0",
+            PcKind::None | PcKind::JacobiWeak => "n/a",
+        }
+    }
+
     impl PcKind {
         fn label(&self) -> &'static str {
             match self {
@@ -1520,6 +1553,9 @@ mod complex_demo {
         };
 
         Ok(ResultRow {
+            operator_storage: operator_storage_label(problem),
+            execution_backend: execution_backend_label(problem),
+            pc_domain: pc_domain_label(spec.pc),
             method: format!(
                 "{} [row-scale={}]",
                 spec.method_label(),
@@ -1793,7 +1829,10 @@ mod complex_demo {
                 .map(|v| format!("{v:.2e}"))
                 .unwrap_or_else(|| "N/A".to_string());
             return format!(
-                "{:<36} {:<34} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14.2e} {:>12}",
+                "{:<7} {:<8} {:<6} {:<36} {:<34} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14.2e} {:>12}",
+                row.operator_storage,
+                row.execution_backend,
+                row.pc_domain,
                 row.method,
                 row.effective_policy,
                 row.median_solve_secs,
@@ -1825,7 +1864,10 @@ mod complex_demo {
                 .map(|v| format!("{v:.2e}"))
                 .unwrap_or_else(|| "N/A".to_string());
             format!(
-                "{:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14.2e} {:>14} {:>14} {:>14} {:>26?} {:>12}",
+                "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14.2e} {:>14} {:>14} {:>14} {:>26?} {:>12}",
+                row.operator_storage,
+                row.execution_backend,
+                row.pc_domain,
                 row.method,
                 row.requested_policy,
                 row.effective_policy,
@@ -1846,7 +1888,10 @@ mod complex_demo {
             )
         } else {
             format!(
-                "{:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14.2e} {:>14} {:>14} {:>14} {:>26?}",
+                "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14.2e} {:>14} {:>14} {:>14} {:>26?}",
+                row.operator_storage,
+                row.execution_backend,
+                row.pc_domain,
                 row.method,
                 row.requested_policy,
                 row.effective_policy,
@@ -2168,6 +2213,15 @@ mod complex_demo {
         let rendered = render_result_row(&row, RunMode::Correctness, &problem);
         assert!(rendered.contains(&row.requested_policy));
         assert!(rendered.contains(&row.effective_policy));
+        assert!(rendered.contains("csr-cx"));
+        assert!(rendered.contains("ser"));
+    }
+
+    #[test]
+    fn metadata_labels_snapshot() {
+        assert_eq!(pc_domain_label(PcKind::ReplicatedFullIlu0), "full");
+        assert_eq!(pc_domain_label(PcKind::Ilu0Local), "own0");
+        assert_eq!(pc_domain_label(PcKind::None), "n/a");
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make benchmark output unambiguous by exposing operator storage, execution backend, and PC domain so local/owned-block ILU is not misinterpreted as full-domain ILU. 
- Keep the printed table compact by using short shorthands and provide a one-line legend mapping shorthand to semantics. 
- Add lightweight snapshot-style checks to prevent accidental regressions in the wording/labels.

### Description
- Updated `examples/complex_matrix_market_demo.rs` to add three metadata columns to table headers and rows: `Op` (operator storage), `Exec` (execution backend), and `PCdom` (preconditioner domain). 
- Extended `ResultRow` with `operator_storage`, `execution_backend`, and `pc_domain` fields and populated them via helper mappers: `operator_storage_label`, `execution_backend_label`, and `pc_domain_label`. 
- Adjusted all row rendering formats (scalability and non-scalability) to emit the new compact metadata fields and inserted a single-line legend that maps `csr-cx`, `ser`/`mpi-row`/`mpi-repl`, and `full`/`own0`/`n/a` to their semantics. 
- Added snapshot-style unit checks: strengthened an existing test to assert presence of metadata tokens in rendered output and added `metadata_labels_snapshot` which asserts the `pc_domain_label` mappings.

### Testing
- Added unit tests `metadata_labels_snapshot` and strengthened `run_once_reports_requested_and_effective_policy_after_dist_policy_mutation` to assert metadata tokens are present in rendered output. These tests are included in the modified example file. 
- Ran `cargo test --example complex_matrix_market_demo --features complex` but the build failed before executing the example tests due to an unrelated compile error in `src/preconditioner/dist/block_jacobi_ilu.rs` (missing `DistLocalApplyMode` import/type); therefore the new example tests were not executed. 
- No example-level tests were observed passing in this run because the compile failure is outside the changed file and must be resolved separately before running the added snapshot tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f3d9b800008329b911b7db11111bf0)