### PR TITLE
Refine Reds reporting and add reduction-growth guard test

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -217,7 +217,7 @@ mod complex_demo {
                 );
                 if config.run_mode == RunMode::Scalability {
                     println!(
-                        "{:<7} {:<8} {:<6} {:<36} {:<34} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14} {:>12}",
+                        "{:<7} {:<8} {:<6} {:<36} {:<34} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>17} {:>14} {:>12}",
                         "Op",
                         "Exec",
                         "PCdom",
@@ -229,14 +229,14 @@ mod complex_demo {
                         "Rst",
                         "Inn",
                         "Pfb",
-                        "Reds",
+                        "Reds(obs/wait/model)",
                         "Rec/Reported",
                         "DOF/s"
                     );
-                    println!("{}", "-".repeat(184));
+                    println!("{}", "-".repeat(196));
                 } else if include_dof_col {
                     println!(
-                        "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14} {:>14} {:>14} {:>14} {:>26} {:>12}",
+                        "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>14} {:>14} {:>14} {:>14} {:>26} {:>12}",
                         "Op",
                         "Exec",
                         "PCdom",
@@ -250,7 +250,6 @@ mod complex_demo {
                         "Rst",
                         "Inn",
                         "Pfb",
-                        "Reds",
                         "Rec/Reported",
                         "True(explicit)",
                         "True(rel)",
@@ -258,10 +257,10 @@ mod complex_demo {
                         "Reason",
                         "DOF/s"
                     );
-                    println!("{}", "-".repeat(312));
+                    println!("{}", "-".repeat(304));
                 } else {
                     println!(
-                        "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14} {:>14} {:>14} {:>14} {:>26}",
+                        "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9} {:>9} {:>9} {:>7} {:>5} {:>5} {:>5} {:>14} {:>14} {:>14} {:>14} {:>26}",
                         "Op",
                         "Exec",
                         "PCdom",
@@ -275,14 +274,13 @@ mod complex_demo {
                         "Rst",
                         "Inn",
                         "Pfb",
-                        "Reds",
                         "Rec/Reported",
                         "True(explicit)",
                         "True(rel)",
                         "x_err(rel)",
                         "Reason"
                     );
-                    println!("{}", "-".repeat(296));
+                    println!("{}", "-".repeat(288));
                 }
                 println!("Legend: Op=operator storage (csr-cx=complex CSR), Exec=execution backend (ser=serial, mpi-row=MPI row partition, mpi-repl=MPI replicated operator), PCdom=PC domain (full=global matrix ILU, own0=owned-block overlap=0 local ILU/ASM, n/a=no ILU domain).");
             }
@@ -422,6 +420,8 @@ mod complex_demo {
         min_solve_secs: f64,
         iterations: usize,
         reductions: usize,
+        overlapped_reduction_waits: usize,
+        model_predicted_reductions: Option<usize>,
         restart_count: Option<usize>,
         inner_iterations_last_cycle: Option<usize>,
         pipeline_fallbacks: Option<usize>,
@@ -1476,6 +1476,11 @@ mod complex_demo {
         let median_solve_secs = median(&mut solve_times);
 
         let reductions = stats.counters.num_global_reductions;
+        let overlapped_reduction_waits = stats.counters.overlap_global_reductions;
+        let model_predicted_reductions = stats
+            .reduction_model
+            .as_ref()
+            .map(|model| model.total_for(stats.iterations));
         let (explicit_true_residual, explicit_true_residual_rel) =
             if bench_cfg.run_mode == RunMode::Correctness {
                 let mut ax = vec![S::zero(); b.len()];
@@ -1585,6 +1590,8 @@ mod complex_demo {
             min_solve_secs,
             iterations: stats.iterations,
             reductions,
+            overlapped_reduction_waits,
+            model_predicted_reductions,
             restart_count: stats.fgmres_counters.as_ref().map(|c| c.restart_count),
             inner_iterations_last_cycle: stats
                 .fgmres_counters
@@ -1829,7 +1836,7 @@ mod complex_demo {
                 .map(|v| format!("{v:.2e}"))
                 .unwrap_or_else(|| "N/A".to_string());
             return format!(
-                "{:<7} {:<8} {:<6} {:<36} {:<34} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14.2e} {:>12}",
+                "{:<7} {:<8} {:<6} {:<36} {:<34} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>17} {:>14.2e} {:>12}",
                 row.operator_storage,
                 row.execution_backend,
                 row.pc_domain,
@@ -1841,7 +1848,14 @@ mod complex_demo {
                 rst,
                 inn,
                 pfb,
-                row.reductions,
+                format!(
+                    "{}/{}/{}",
+                    row.reductions,
+                    row.overlapped_reduction_waits,
+                    row.model_predicted_reductions
+                        .map(|v| v.to_string())
+                        .unwrap_or_else(|| "n/a".to_string())
+                ),
                 row.reported_residual,
                 dof
             );
@@ -1864,7 +1878,7 @@ mod complex_demo {
                 .map(|v| format!("{v:.2e}"))
                 .unwrap_or_else(|| "N/A".to_string());
             format!(
-                "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14.2e} {:>14} {:>14} {:>14} {:>26?} {:>12}",
+                "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>14.2e} {:>14} {:>14} {:>14} {:>26?} {:>12}",
                 row.operator_storage,
                 row.execution_backend,
                 row.pc_domain,
@@ -1878,7 +1892,6 @@ mod complex_demo {
                 rst,
                 inn,
                 pfb,
-                row.reductions,
                 row.reported_residual,
                 explicit_true,
                 explicit_true_rel,
@@ -1888,7 +1901,7 @@ mod complex_demo {
             )
         } else {
             format!(
-                "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>6} {:>14.2e} {:>14} {:>14} {:>14} {:>26?}",
+                "{:<7} {:<8} {:<6} {:<36} {:<34} {:<34} {:>9.3} {:>9.3} {:>9.3} {:>7} {:>5} {:>5} {:>5} {:>14.2e} {:>14} {:>14} {:>14} {:>26?}",
                 row.operator_storage,
                 row.execution_backend,
                 row.pc_domain,
@@ -1902,7 +1915,6 @@ mod complex_demo {
                 rst,
                 inn,
                 pfb,
-                row.reductions,
                 row.reported_residual,
                 explicit_true,
                 explicit_true_rel,

--- a/tests/pcg_pipelined.rs
+++ b/tests/pcg_pipelined.rs
@@ -151,4 +151,52 @@ fn pipelined_reports_reduction_counts() -> Result<(), KError> {
     Ok(())
 }
 
+#[test]
+fn pipelined_reductions_scale_with_iteration_count() -> Result<(), KError> {
+    let n = 64;
+    let a = csr_poisson_1d(n);
+    let b: Vec<R> = vec![R::from(1.0); n];
+    let comm = UniverseComm::NoComm(NoComm);
+    let op: &dyn LinOp<S = f64> = &a;
+
+    let mut run = |tol: f64, maxits: usize| -> Result<_, KError> {
+        let mut solver =
+            PcgSolver::new(tol, maxits).with_variant(PcgVariant::Pipelined { replace_every: 0 });
+        let mut wk = Workspace::default();
+        solver.setup_workspace(&mut wk);
+        let mut x: Vec<R> = vec![R::default(); n];
+        let mut pc = Jacobi::new();
+        pc.setup(op)?;
+        solver.solve_with_comm(
+            op,
+            Some(&mut pc),
+            &b,
+            &mut x,
+            PcSide::Left,
+            &comm,
+            None,
+            Some(&mut wk),
+        )
+    };
+
+    let short = run(1e-2, 4)?;
+    let long = run(1e-12, 150)?;
+    assert!(long.iterations > short.iterations);
+    assert!(long.counters.num_global_reductions > short.counters.num_global_reductions);
+
+    // Pipelined PCG executes ~2 iterative reductions/iteration plus startup overhead.
+    let delta_iter = long.iterations - short.iterations;
+    let delta_red = long
+        .counters
+        .num_global_reductions
+        .saturating_sub(short.counters.num_global_reductions);
+    assert!(
+        delta_red >= delta_iter,
+        "expected reductions to grow at least linearly with iterations (Δred={}, Δiter={})",
+        delta_red,
+        delta_iter
+    );
+    Ok(())
+}
+
 mod fixtures;


### PR DESCRIPTION
### Motivation
- Ensure the reported `Reds` metric reflects actual solver-runtime reduction events (or is explicitly labeled/hidden if approximate) so correctness tables are not misleading.
- Provide a consistent, auditable model for classical vs pipelined variants by exposing raw components for post-hoc checks.
- Add a targeted guard that validates `Reds` grows with iterations for pipelined PCG to catch regressions in counting logic.

### Description
- Source reduction reporting from runtime `SolveStats` counters by exposing `stats.counters.num_global_reductions`, `stats.counters.overlap_global_reductions`, and the model prediction `reduction_model.total_for(stats.iterations)` in `ResultRow` and the `run_once` return path in `examples/complex_matrix_market_demo.rs`.
- Change the scalability-mode column label from `Reds` to `Reds(obs/wait/model)` and format the output as `obs/wait/model` so users can see observed reductions, overlapped async-wait completions, and model-predicted totals separately; remove the model-derived `Reds` value from correctness-focused table columns to avoid mixing approximate metrics with correctness summaries.
- Add a unit test `pipelined_reductions_scale_with_iteration_count` in `tests/pcg_pipelined.rs` that runs two pipelined PCG solves (short and long) and asserts reductions increase with iterations and that the delta in reductions grows at least linearly with the delta in iterations.

### Testing
- Ran `cargo test --test pcg_pipelined`; the test run executed 3 tests and completed successfully with all tests passing (`pipelined_matches_classic_solution`, `pipelined_reports_reduction_counts`, and the new `pipelined_reductions_scale_with_iteration_count`).
- The new test verifies both that reported reduction counts increase for a longer solve and enforces a simple linear-growth guard on the increments; it passed in the CI-local run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f519d10d24832980988b6ffa670ecb)