### PR TITLE
Fix borrow conflicts in distributed block-Jacobi apply

### DIFF
--- a/src/preconditioner/dist/block_jacobi_ilu.rs
+++ b/src/preconditioner/dist/block_jacobi_ilu.rs
@@ -435,14 +435,15 @@ where
         }
 
         debug_assert!(matches!(side, PcSide::Left));
+        let x_global_len = x.global_len();
         x.with_scratch_input_local_output(|x_local, y_local| {
             #[cfg(all(feature = "mpi", feature = "backend-faer", not(feature = "complex")))]
             if self.local_apply_mode.is_replicated_global()
                 && self.native_plan.is_none()
-                && self.n_local != x.global_len()
+                && self.n_local != x_global_len
             {
-                let x_global = assemble_global_input(&self.comm, x_local, x.global_len())?;
-                let mut y_global = vec![0.0; x.global_len()];
+                let x_global = assemble_global_input(&self.comm, x_local, x_global_len)?;
+                let mut y_global = vec![0.0; x_global_len];
                 self.local_pc.apply_local(&x_global, &mut y_global)?;
                 let start = self.row_offset;
                 let end = start + self.n_local;
@@ -502,14 +503,15 @@ impl DistributedPreconditioner for BlockJacobiObjPc {
         if self.n_local == 0 {
             return Ok(());
         }
+        let x_global_len = x.global_len();
         x.with_scratch_input_local_output(|x_local, y_local| {
             #[cfg(feature = "mpi")]
             if self.local_apply_mode.is_replicated_global()
                 && self.native_plan.is_none()
-                && self.n_local != x.global_len()
+                && self.n_local != x_global_len
             {
-                let x_global = assemble_global_input(&self.comm, x_local, x.global_len())?;
-                let mut y_global = vec![0.0; x.global_len()];
+                let x_global = assemble_global_input(&self.comm, x_local, x_global_len)?;
+                let mut y_global = vec![0.0; x_global_len];
                 self.local_pc.apply(side, &x_global, &mut y_global)?;
                 let start = self.row_offset;
                 let end = start + self.n_local;


### PR DESCRIPTION
### Motivation
- Resolve `E0502` borrow-checker failures in distributed block-Jacobi preconditioner `apply_global` paths caused by calling `x.global_len()` from inside closures passed to `x.with_scratch_input_local_output`, which mutably borrows `x`.

### Description
- Precompute `x.global_len()` into a local `x_global_len` immediately before the `with_scratch_input_local_output` call and use that captured value inside the closure for conditionals and buffer sizing.
- Applied the change to both `BlockJacobiLocalPc::apply_global` and `BlockJacobiObjPc::apply_global` implementations, preserving original behavior while avoiding overlapping borrows.
- No semantic changes to the algorithmic logic; only the borrow pattern was adjusted.

### Testing
- Ran `cargo check --features=mpi,rayon,backend-faer,logging`, which completed successfully with no `E0502` errors.
- Started `RUSTFLAGS="-Awarnings" RUST_BACKTRACE=full cargo test --features=mpi,rayon,backend-faer,logging -- --nocapture`, and compilation progressed without reproducing the reported `E0502` errors before the run stalled in this environment (did not complete here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f519eab9bc83298d66a4cdac5b9af4)