### PR TITLE
Fix missing DistLocalApplyMode import in distributed block Jacobi ILU

### DIFF
--- a/src/preconditioner/dist/block_jacobi_ilu.rs
+++ b/src/preconditioner/dist/block_jacobi_ilu.rs
@@ -35,8 +35,8 @@ use std::sync::Arc;
 use crate::matrix::op::CsrOp;
 
 #[cfg(all(feature = "backend-faer", not(feature = "complex")))]
-use super::{DistLocalApplyMode, GlobalPcKind, LocalPcKind, MpiPcOptions};
-use super::{DistVecS, DistributedPreconditioner};
+use super::{GlobalPcKind, LocalPcKind, MpiPcOptions};
+use super::{DistLocalApplyMode, DistVecS, DistributedPreconditioner};
 
 #[cfg(all(feature = "backend-faer", not(feature = "complex")))]
 #[derive(Clone)]


### PR DESCRIPTION
### Motivation
- Build failed with `E0412` because `DistLocalApplyMode` was imported only under a `backend-faer` feature gate while the type is used in non-gated structs and constructors in `src/preconditioner/dist/block_jacobi_ilu.rs`.

### Description
- Move the `DistLocalApplyMode` re-export into an unconditional `use super::{...}` so `DistLocalApplyMode` is in scope for all builds while keeping `GlobalPcKind`, `LocalPcKind` and `MpiPcOptions` behind their existing `cfg`.

### Testing
- Ran `cargo check -q` in the repository and the crate compiles successfully; existing compiler warnings remain but no errors from this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f526d7e18c83298f2613891096ff4c)