### PR TITLE
Use ReductionModel::estimate_total in complex_matrix_market_demo

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -1480,7 +1480,7 @@ mod complex_demo {
         let model_predicted_reductions = stats
             .reduction_model
             .as_ref()
-            .map(|model| model.total_for(stats.iterations));
+            .map(|model| model.estimate_total(stats.iterations));
         let (explicit_true_residual, explicit_true_residual_rel) =
             if bench_cfg.run_mode == RunMode::Correctness {
                 let mut ax = vec![S::zero(); b.len()];


### PR DESCRIPTION
### Motivation
- Fix a compilation error where the example called a non-existent method `ReductionModel::total_for`, by using the current API `ReductionModel::estimate_total`.

### Description
- Replace `model.total_for(stats.iterations)` with `model.estimate_total(stats.iterations)` in `examples/complex_matrix_market_demo.rs` to match the `ReductionModel` implementation.

### Testing
- Ran `cargo check --example complex_matrix_market_demo` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f53db62f0c8329bb96c60872b16aa1)