### PR TITLE
Stabilize complex demo true residual normalization

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -196,11 +196,14 @@ mod complex_demo {
                         "MPI scalability note: use distributed mode for scaling claims; correctness mode emphasizes solver validation."
                     );
                 }
-                println!("‖rhs‖₂ = {:.3e}", rhs_norm);
+                println!("‖b_unscaled‖₂ = {:.3e}", rhs_norm);
                 println!("Residual semantics: rec/reported = solver recurrence/monitor residual.");
                 if config.run_mode == RunMode::Correctness {
                     println!(
-                        "                    true(explicit) = ||b - A x||₂ recomputed after solve."
+                        "                    true(explicit) = ||b_unscaled - A_unscaled x_unscaled||₂ recomputed after solve."
+                    );
+                    println!(
+                        "                    True(rel) = true(explicit) / ||b_unscaled||₂ (stable under --row-scale)."
                     );
                 }
                 println!(
@@ -1512,7 +1515,7 @@ mod complex_demo {
                 }
                 let r2_local = ax.iter().map(|v| v.abs2()).sum::<f64>();
                 let true_res = problem.comm.all_reduce_f64(r2_local).sqrt();
-                let rhs_norm2_local = b.iter().map(|v| v.abs2()).sum::<f64>();
+                let rhs_norm2_local = b_unscaled.iter().map(|v| v.abs2()).sum::<f64>();
                 let rhs_norm = problem.comm.all_reduce_f64(rhs_norm2_local).sqrt();
                 let rel_true = true_res / rhs_norm.max(f64::MIN_POSITIVE);
                 (Some(true_res), Some(rel_true))


### PR DESCRIPTION
### Motivation
- Ensure the printed `True(rel)` measure is stable when `--row-scale` is used by normalizing the explicit true residual against the original unscaled RHS norm rather than any scaled RHS.

### Description
- Keep the explicit numerator as the unscaled residual computed from `b_unscaled - A * x_unscaled` and compute `explicit_true_residual` from that value.
- Change the denominator used for `explicit_true_residual_rel` from the norm of `b` to the norm of `b_unscaled` by using `b_unscaled` when computing `rhs_norm`.
- Update the demo output header/legend to print `‖b_unscaled‖₂` and explicitly state that `true(explicit)` is computed on the unscaled system and `True(rel) = true(explicit) / ||b_unscaled||₂` is stable under `--row-scale`.

### Testing
- Ran `cargo test --example complex_matrix_market_demo --features complex`, which completed successfully with the example's tests passing (16 passed, 0 failed). 
- Ran `cargo fmt --check`, which reported pre-existing formatting diffs in other files (not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fa81d0c6dc8329971033ce54612983)