### PR TITLE
Fix complex ILU CSR reorder apply pipeline

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -26,16 +26,18 @@ mod complex_demo {
     use kryst::algebra::bridge::BridgeScratch;
     use kryst::algebra::prelude::*;
     use kryst::context::ksp_context::{ReorthPolicy, Workspace};
+    use kryst::matrix::DistCsrOp;
     use kryst::matrix::dist_csr::DistributedPlanDiagnostics;
     use kryst::matrix::sparse::CsrMatrix as SparseCsrMatrix;
-    use kryst::matrix::DistCsrOp;
     use kryst::ops::klinop::KLinOp;
     use kryst::ops::kpc::KPreconditioner;
     use kryst::parallel::{Comm, UniverseComm};
-    use kryst::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind};
-    use kryst::preconditioner::jacobi::Jacobi;
     use kryst::preconditioner::PcSide;
     use kryst::preconditioner::Preconditioner;
+    use kryst::preconditioner::ilu_csr::{
+        IluCsr, IluCsrConfig, IluKind, ReorderingKind, ReorderingOptions,
+    };
+    use kryst::preconditioner::jacobi::Jacobi;
     use kryst::solver::fgmres::{
         FgmresSolver, FgmresStagnationPolicy, FgmresVariant, OrthogMethod, ResidualCheckPolicy,
     };
@@ -104,6 +106,10 @@ mod complex_demo {
                 config.min_inner_before_fallback
             );
             println!("FGMRES haptol: {:.3e}", config.fgmres_haptol);
+            println!(
+                "Complex ILU reordering: kind={:?}, symmetric={}",
+                config.ilu_reordering.kind, config.ilu_reordering.symmetric
+            );
             if config.run_mode == RunMode::Correctness {
                 println!(
                     "Replicated check marker: {}",
@@ -520,6 +526,7 @@ mod complex_demo {
         fgmres_haptol: f64,
         row_scale: bool,
         row_scale_tiny: f64,
+        ilu_reordering: ReorderingOptions,
     }
 
     #[derive(Clone, Copy, Debug, Eq, PartialEq)]
@@ -574,6 +581,7 @@ mod complex_demo {
                 fgmres_haptol: 1e-30,
                 row_scale: false,
                 row_scale_tiny: 1e-15,
+                ilu_reordering: ReorderingOptions::default(),
             }
         }
     }
@@ -610,11 +618,11 @@ mod complex_demo {
                     "--help" | "-h" => {
                         if cfg!(feature = "mpi") {
                             println!(
-                                "Usage: cargo mpirun -n <ranks> --example complex_matrix_market_demo --features complex,mpi,mpi_examples -- [--mode correctness|scalability|robustness] [--mark-replicated-check] [--warmup-runs N] [--measured-runs N] [--rtol F] [--atol F] [--maxits N] [--restarts csv] [--pcs csv] [--include-restart-200] [--allow-stagnation-fallback] [--min-inner-before-fallback N] [--fgmres-variant csv] [--fgmres-orthog csv] [--fgmres-reorth csv] [--fgmres-haptol F] [--residual-history] [--residual-history-file <path>] [--residual-history-force] [--row-scale [tiny]]"
+                                "Usage: cargo mpirun -n <ranks> --example complex_matrix_market_demo --features complex,mpi,mpi_examples -- [--mode correctness|scalability|robustness] [--mark-replicated-check] [--warmup-runs N] [--measured-runs N] [--rtol F] [--atol F] [--maxits N] [--restarts csv] [--pcs csv] [--include-restart-200] [--allow-stagnation-fallback] [--min-inner-before-fallback N] [--fgmres-variant csv] [--fgmres-orthog csv] [--fgmres-reorth csv] [--fgmres-haptol F] [--residual-history] [--residual-history-file <path>] [--residual-history-force] [--row-scale [tiny]] [--ilu-reordering none|rcm|amd[:nonsym]]"
                             );
                         } else {
                             println!(
-                                "Usage: cargo run --example complex_matrix_market_demo --features complex -- [--mode correctness|scalability|robustness] [--mark-replicated-check] [--warmup-runs N] [--measured-runs N] [--rtol F] [--atol F] [--maxits N] [--restarts csv] [--pcs csv] [--include-restart-200] [--allow-stagnation-fallback] [--min-inner-before-fallback N] [--fgmres-variant csv] [--fgmres-orthog csv] [--fgmres-reorth csv] [--fgmres-haptol F] [--residual-history] [--residual-history-file <path>] [--residual-history-force] [--row-scale [tiny]]"
+                                "Usage: cargo run --example complex_matrix_market_demo --features complex -- [--mode correctness|scalability|robustness] [--mark-replicated-check] [--warmup-runs N] [--measured-runs N] [--rtol F] [--atol F] [--maxits N] [--restarts csv] [--pcs csv] [--include-restart-200] [--allow-stagnation-fallback] [--min-inner-before-fallback N] [--fgmres-variant csv] [--fgmres-orthog csv] [--fgmres-reorth csv] [--fgmres-haptol F] [--residual-history] [--residual-history-file <path>] [--residual-history-force] [--row-scale [tiny]] [--ilu-reordering none|rcm|amd[:nonsym]]"
                             );
                         }
                         std::process::exit(0);
@@ -667,6 +675,14 @@ mod complex_demo {
                     }
                     "--include-restart-200" => {
                         cfg.include_restart_200 = true;
+                    }
+                    "--ilu-reordering" | "--pc-ilu-reordering-type" => {
+                        let Some(v) = args.next() else {
+                            return Err(KError::InvalidInput(
+                                "missing value for --ilu-reordering".into(),
+                            ));
+                        };
+                        cfg.ilu_reordering = parse_ilu_reordering(&v)?;
                     }
                     "--allow-stagnation-fallback" => {
                         cfg.allow_stagnation_fallback = true;
@@ -864,6 +880,32 @@ mod complex_demo {
 
     fn parse_reorth_csv(flag: &str, value: &str) -> Result<Vec<ReorthPolicy>, KError> {
         parse_csv(flag, value, parse_reorth)
+    }
+
+    fn parse_ilu_reordering(value: &str) -> Result<ReorderingOptions, KError> {
+        let normalized = value.trim().to_ascii_lowercase();
+        let (base, nonsym) = if let Some(base) = normalized.strip_suffix(":nonsym") {
+            (base, true)
+        } else if let Some(base) = normalized.strip_suffix("_nonsym") {
+            (base, true)
+        } else {
+            (normalized.as_str(), false)
+        };
+        let kind = match base {
+            "none" | "natural" => ReorderingKind::None,
+            "rcm" => ReorderingKind::Rcm,
+            "amd" => ReorderingKind::Amd,
+            other => {
+                return Err(KError::InvalidInput(format!(
+                    "invalid ILU reordering '{other}', expected none|rcm|amd with optional :nonsym suffix"
+                )));
+            }
+        };
+        Ok(ReorderingOptions {
+            kind,
+            symmetric: !nonsym,
+            deterministic: true,
+        })
     }
 
     fn parse_pc(token: &str) -> Result<PcKind, KError> {
@@ -1200,11 +1242,7 @@ mod complex_demo {
                 for nz in row_ptr[r]..row_ptr[r + 1] {
                     row_inf = row_inf.max(vals[nz].abs());
                 }
-                if row_inf > tiny {
-                    1.0 / row_inf
-                } else {
-                    1.0
-                }
+                if row_inf > tiny { 1.0 / row_inf } else { 1.0 }
             })
             .collect()
     }
@@ -1545,6 +1583,7 @@ mod complex_demo {
                     }
                     PcKind::None | PcKind::JacobiWeak => IluKind::Ilu0,
                 };
+                cfg.reordering = bench_cfg.ilu_reordering.clone();
                 let mut ilu = IluCsr::new_with_config(cfg);
                 ilu.setup(pc_csr.as_ref())?;
                 if bench_cfg.run_mode == RunMode::Correctness {
@@ -1583,6 +1622,7 @@ mod complex_demo {
                 cfg.kind = IluKind::Ilut {
                     params: Default::default(),
                 };
+                cfg.reordering = bench_cfg.ilu_reordering.clone();
                 let mut ilu = IluCsr::new_with_config(cfg);
                 ilu.setup(pc_csr.as_ref())?;
                 if bench_cfg.run_mode == RunMode::Correctness {
@@ -2522,13 +2562,15 @@ mod complex_demo {
 
         let row = run_once(&problem, &spec, &bench_cfg).expect("run once");
         assert!(row.requested_policy.contains("restart=5"));
-        assert!(row
-            .requested_policy
-            .contains("residual-check=on-convergence"));
+        assert!(
+            row.requested_policy
+                .contains("residual-check=on-convergence")
+        );
         assert!(row.effective_policy.contains("restart=16"));
-        assert!(row
-            .effective_policy
-            .contains("residual-check=every-iteration"));
+        assert!(
+            row.effective_policy
+                .contains("residual-check=every-iteration")
+        );
 
         let rendered = render_result_row(&row, RunMode::Correctness, &problem);
         assert!(rendered.contains(&row.requested_policy));

--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -1529,7 +1529,9 @@ impl Preconditioner for IluCsr {
         }
 
         if self.native_complex_active {
-            let mut w = x.to_vec();
+            let mut w = vec![S::zero(); n];
+            let mut y_perm = vec![S::zero(); n];
+            self.pipeline_meta.left_perm.apply_vec(x, &mut w);
             for i in 0..n {
                 let mut s = w[i];
                 for p in self.l_row[i]..self.l_row[i + 1] {
@@ -1547,7 +1549,8 @@ impl Preconditioner for IluCsr {
                 }
                 w[i] = s / self.c_u_val[self.u_diag_ix[i]];
             }
-            y.copy_from_slice(&w);
+            self.pipeline_meta.right_perm.apply_vec_t(&w, &mut y_perm);
+            y.copy_from_slice(&y_perm);
             Ok(())
         } else {
             let mut xr = vec![Real::zero(); n];

--- a/src/preconditioner/tests/ilu_csr_complex.rs
+++ b/src/preconditioner/tests/ilu_csr_complex.rs
@@ -353,3 +353,131 @@ fn complex_nonsymmetric_numeric_update_matches_fresh_setup() {
         );
     }
 }
+
+fn grid_csr_complex(nx: usize, ny: usize) -> CsrMatrix<S> {
+    let n = nx * ny;
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx = Vec::new();
+    let mut vals = Vec::new();
+    row_ptr.push(0);
+    for y in 0..ny {
+        for x in 0..nx {
+            let i = y * nx + x;
+            if y > 0 {
+                col_idx.push(i - nx);
+                vals.push(S::from_parts(-0.7, 0.12));
+            }
+            if x > 0 {
+                col_idx.push(i - 1);
+                vals.push(S::from_parts(-0.9, -0.08));
+            }
+            col_idx.push(i);
+            vals.push(S::from_parts(4.4 + 0.03 * i as f64, 0.35));
+            if x + 1 < nx {
+                col_idx.push(i + 1);
+                vals.push(S::from_parts(-0.8, 0.07));
+            }
+            if y + 1 < ny {
+                col_idx.push(i + nx);
+                vals.push(S::from_parts(-0.6, -0.11));
+            }
+            row_ptr.push(col_idx.len());
+        }
+    }
+    CsrMatrix::from_csr(n, n, row_ptr, col_idx, vals)
+}
+
+fn norm2(v: &[S]) -> f64 {
+    v.iter().map(|z| z.abs() * z.abs()).sum::<f64>().sqrt()
+}
+
+fn assert_complex_ilu_reorder_apply_consistency_and_residual_reduction(kind: ReorderingKind) {
+    use crate::preconditioner::PcSide;
+    use crate::utils::permutation::{Permutation, amd_csr, permute_csr_symmetric, rcm_csr};
+
+    let a = grid_csr_complex(4, 4);
+    let n = a.nrows();
+    let rhs: Vec<S> = (0..n)
+        .map(|i| S::from_parts(1.0 + 0.05 * i as f64, -0.4 + 0.02 * i as f64))
+        .collect();
+
+    let cfg = IluCsrConfig {
+        kind: IluKind::Iluk { k: 1 },
+        reordering: ReorderingOptions {
+            kind,
+            symmetric: true,
+            deterministic: true,
+        },
+        conditioning: ConditioningOptions::default(),
+        ..IluCsrConfig::default()
+    };
+    let mut reordered = IluCsr::new_with_config(cfg);
+    reordered.setup(&a).unwrap();
+    assert_eq!(
+        reordered.complex_kernel_mode(),
+        IluComplexKernelMode::Native
+    );
+
+    let mut actual = vec![S::zero(); n];
+    reordered.apply(PcSide::Left, &rhs, &mut actual).unwrap();
+    assert!(actual.iter().all(|v| v.is_finite()));
+
+    let a_real = CsrMatrix::from_csr(
+        a.nrows(),
+        a.ncols(),
+        a.row_ptr().to_vec(),
+        a.col_idx().to_vec(),
+        a.values().iter().map(|v| v.real()).collect(),
+    );
+    let perm = match kind {
+        ReorderingKind::None => Permutation::identity(n),
+        ReorderingKind::Rcm => rcm_csr(&a_real),
+        ReorderingKind::Amd => amd_csr(&a_real),
+    };
+    let a_perm = permute_csr_symmetric(&a, &perm);
+    let manual_cfg = IluCsrConfig {
+        kind: IluKind::Iluk { k: 1 },
+        reordering: ReorderingOptions::default(),
+        conditioning: ConditioningOptions::default(),
+        ..IluCsrConfig::default()
+    };
+    let mut manual = IluCsr::new_with_config(manual_cfg);
+    manual.setup(&a_perm).unwrap();
+    assert_eq!(manual.complex_kernel_mode(), IluComplexKernelMode::Native);
+
+    let mut rhs_perm = vec![S::zero(); n];
+    perm.apply_vec(&rhs, &mut rhs_perm);
+    let mut y_perm = vec![S::zero(); n];
+    manual.apply(PcSide::Left, &rhs_perm, &mut y_perm).unwrap();
+    let mut expected = vec![S::zero(); n];
+    perm.apply_vec_t(&y_perm, &mut expected);
+
+    for (i, (a, e)) in actual.iter().zip(expected.iter()).enumerate() {
+        assert!(
+            (*a - *e).abs() < 1e-9,
+            "reordered apply should match explicit permutation pipeline for {kind:?} at {i}: actual={a:?}, expected={e:?}"
+        );
+    }
+
+    let rhs_norm = norm2(&rhs);
+    let reduced = residual_norm(&a, &actual, &rhs);
+    assert!(
+        reduced < 0.35 * rhs_norm,
+        "{kind:?} residual {reduced:.6e} should reduce RHS norm {rhs_norm:.6e}"
+    );
+}
+
+#[test]
+fn ilu_csr_complex_apply_pipeline_none_is_consistent_and_reduces_residual() {
+    assert_complex_ilu_reorder_apply_consistency_and_residual_reduction(ReorderingKind::None);
+}
+
+#[test]
+fn ilu_csr_complex_apply_pipeline_rcm_is_consistent_and_reduces_residual() {
+    assert_complex_ilu_reorder_apply_consistency_and_residual_reduction(ReorderingKind::Rcm);
+}
+
+#[test]
+fn ilu_csr_complex_apply_pipeline_amd_is_consistent_and_reduces_residual() {
+    assert_complex_ilu_reorder_apply_consistency_and_residual_reduction(ReorderingKind::Amd);
+}


### PR DESCRIPTION
### Motivation
- Ensure native complex ILU apply honors permutation/conditioning metadata produced during setup so complex solves run in factorization ordering and return results in external ordering.
- Add coverage to validate that complex ILU reorder paths (`none`, `rcm`, `amd`) behave identically to an explicit permutation pipeline and reduce the residual.
- Expose ILU reordering selection in the complex Matrix Market demo so users can exercise reorder paths end-to-end.

### Description
- Apply stored preconditioning pipeline permutation metadata on the native complex `IluCsr::apply` path by permuting the input with `pipeline_meta.left_perm`, running complex forward/backward triangular solves on the factorization ordering, and inverse-permuting with `pipeline_meta.right_perm` before returning the result (uses `left_perm.apply_vec` and `right_perm.apply_vec_t`).
- Added tests in `src/preconditioner/tests/ilu_csr_complex.rs` that build a complex 2D-grid CSR, run ILU under `none`, `rcm`, and `amd`, compare reordered `apply` to an explicit manual-permutation pipeline, and assert residual reduction.
- Added `parse_ilu_reordering` and demo plumbing in `examples/complex_matrix_market_demo.rs` to accept `--ilu-reordering` / `--pc-ilu-reordering-type` (supports `none|rcm|amd` with optional `:nonsym` suffix) and pass the chosen `ReorderingOptions` into `IluCsr` setup.
- Minor formatting / tidy adjustments to ensure `rustfmt` checks pass.

### Testing
- Ran `cargo test --features complex preconditioner::tests::ilu_csr_complex -- --nocapture` and all complex ILU reorder tests passed (reported 10 passed, 0 failed).
- Built the complex demo with `cargo test --features complex --example complex_matrix_market_demo --no-run` which compiled the example successfully.
- Verified formatting with `rustfmt --edition 2024 --check` on the modified files and ran `git diff --check`; checks succeeded (no errors reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fb712b208883298b0321f0fe904d71)