### PR TITLE
Adjust MPI correctness PC defaults and accept replicated-full-ilu0 alias

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -990,12 +990,12 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             "jacobi" | "jacobi-weak" | "weak-jacobi" => Ok(PcKind::JacobiWeak),
             "ilu0" | "ilu0-local" | "local-ilu0" => Ok(PcKind::Ilu0Local),
             "ilut" | "ilut-local" | "local-ilut" => Ok(PcKind::IlutLocal),
-            "replicated-ilu0" => Ok(PcKind::ReplicatedFullIlu0),
+            "replicated-ilu0" | "replicated-full-ilu0" => Ok(PcKind::ReplicatedFullIlu0),
             "mpi-block-jacobi-ilu0" | "block-jacobi-ilu0" | "mpi-block-ilu0" => {
                 Ok(PcKind::MpiBlockJacobiIlu0Local)
             }
             other => Err(KError::InvalidInput(format!(
-                "invalid pc '{other}', expected none|jacobi|local-ilu0|local-ilut|local-iluk:<k>|replicated-ilu0|replicated-iluk:<k>|mpi-block-jacobi-ilu0"
+                "invalid pc '{other}', expected none|jacobi|local-ilu0|local-ilut|local-iluk:<k>|replicated-ilu0|replicated-full-ilu0|replicated-iluk:<k>|mpi-block-jacobi-ilu0"
             ))),
         }
     }
@@ -1029,9 +1029,10 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                     RunMode::Correctness => {
                         if problem.comm.size() > 1 {
                             vec![
-                                PcKind::MpiBlockJacobiIlu0Local,
-                                PcKind::JacobiWeak,
+                                PcKind::ReplicatedFullIlu0,
                                 PcKind::None,
+                                PcKind::JacobiWeak,
+                                PcKind::MpiBlockJacobiIlu0Local,
                             ]
                         } else {
                             vec![PcKind::Ilu0Local, PcKind::JacobiWeak, PcKind::None]
@@ -2795,9 +2796,10 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                 RunMode::Correctness => {
                     if mpi_mode {
                         vec![
-                            PcKind::MpiBlockJacobiIlu0Local,
-                            PcKind::JacobiWeak,
+                            PcKind::ReplicatedFullIlu0,
                             PcKind::None,
+                            PcKind::JacobiWeak,
+                            PcKind::MpiBlockJacobiIlu0Local,
                         ]
                     } else {
                         vec![PcKind::Ilu0Local, PcKind::JacobiWeak, PcKind::None]
@@ -2822,15 +2824,52 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             cfg.pcs.clone()
         };
 
+        assert_eq!(
+            pcs,
+            vec![
+                PcKind::ReplicatedFullIlu0,
+                PcKind::None,
+                PcKind::JacobiWeak,
+                PcKind::MpiBlockJacobiIlu0Local,
+            ]
+        );
+
         let mut seen = std::collections::BTreeSet::new();
-        for pc in pcs {
-            let key = pc.semantic_experiment_key(mpi_mode);
-            assert!(
-                seen.insert(key.clone()),
-                "duplicate semantic PC experiment: {key}"
-            );
+        for &restart in &cfg.restarts {
+            for &variant in &cfg.variants {
+                for &orthog in &cfg.orthogs {
+                    for &reorth in &cfg.reorths {
+                        for &pc in &pcs {
+                            let key = format!(
+                                "restart={restart}|variant={}|orthog={}|reorth={}|pc={}",
+                                variant_label(variant),
+                                orthog_label(orthog),
+                                reorth_label(reorth),
+                                pc.semantic_experiment_key(mpi_mode)
+                            );
+                            assert!(
+                                seen.insert(key.clone()),
+                                "duplicate semantic benchmark row: {key}"
+                            );
+                        }
+                    }
+                }
+            }
         }
     }
+
+    #[test]
+    fn parse_pc_accepts_replicated_full_ilu0_alias() {
+        assert_eq!(
+            parse_pc("replicated-full-ilu0").expect("parse replicated-full-ilu0"),
+            PcKind::ReplicatedFullIlu0
+        );
+        assert_eq!(
+            parse_pc("replicated-ilu0").expect("parse replicated-ilu0"),
+            PcKind::ReplicatedFullIlu0
+        );
+    }
+
     #[test]
     fn preconditioner_dispatch_variants_are_distinct_or_explicit_aliases() {
         let variants = [


### PR DESCRIPTION
### Motivation
- Make MPI correctness runs try the replicated full ILU(0) variant first, then `none`, `jacobi-weak`, and finally the MPI block-Jacobi ILU(0) fallback when multiple ranks are present. 
- Keep `Scalability` defaults free of replicated-full ILU unless the user explicitly requests it via `--pcs` to avoid non-scalable defaults.
- Accept an alternate user-facing spelling `replicated-full-ilu0` for the replicated full ILU(0) preconditioner and add tests to lock in the new default order and avoid duplicate semantic benchmark rows.

### Description
- Updated `RunSpec::build_default_matrix(...)` to reorder the `RunMode::Correctness` MPI default `pcs` to `PcKind::ReplicatedFullIlu0`, `PcKind::None`, `PcKind::JacobiWeak`, `PcKind::MpiBlockJacobiIlu0Local` when `problem.comm.size() > 1` and left `Scalability` defaults unchanged unless `--pcs` is provided. 
- Extended `parse_pc(...)` to accept the alias `"replicated-full-ilu0"` in addition to the existing `"replicated-ilu0"` and updated the invalid-input help text accordingly. 
- Enhanced the test `mpi_mode_run_matrix_has_no_duplicate_semantic_pc_experiments` to assert the new MPI correctness `pcs` order and to generate/validate semantic benchmark row keys across restarts/variants/orthog/reorth combinations to ensure no duplicate semantic rows. 
- Added `parse_pc_accepts_replicated_full_ilu0_alias` unit test to cover the new parsing alias and adjusted formatting in the example file for consistency.

### Testing
- Ran `cargo test --example complex_matrix_market_demo --features complex`, which executed the example's unit tests and reported: 21 passed, 0 failed (all tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbabc175a88329835334c4ab09b879)