### PR TITLE
Add overlapping ILU preconditioner and demo wiring (ASM/RAS overlap variants)

### DIFF
--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -1,5 +1,8 @@
 //! to run:
 //! cargo mpirun -n 4 --example complex_matrix_market_demo --features=complex,mpi,mpi_examples
+//!
+//! Manual MPI smoke commands for overlapping ILU rows (enable once MPI execution is available):
+//! cargo mpirun -n 2 --example complex_matrix_market_demo --features=complex,mpi,mpi_examples -- --pcs asm-ilu0-overlap1,asm-ilu0-overlap2,ras-ilu0-overlap1,ras-iluk1-overlap1 --run-mode correctness --warmup-runs 0 --measured-runs 1
 
 #![cfg_attr(not(feature = "complex"), allow(dead_code))]
 
@@ -38,6 +41,7 @@ mod complex_demo {
         IluCsr, IluCsrConfig, IluKind, ReorderingKind, ReorderingOptions,
     };
     use kryst::preconditioner::jacobi::Jacobi;
+    use kryst::preconditioner::overlap_ilu::{OverlapIluPc, OverlapRestriction};
     use kryst::solver::fgmres::{
         FgmresSolver, FgmresStagnationPolicy, FgmresVariant, OrthogMethod, ResidualCheckPolicy,
     };
@@ -411,6 +415,7 @@ mod complex_demo {
         rhs_source: RhsSource,
         solution_reference: SolutionReferenceDiagnostics,
         csr_for_pc: Arc<SparseCsrMatrix<S>>,
+        global_csr: Arc<SparseCsrMatrix<S>>,
         local_rows_nnz: usize,
         zero_global_rows_local: usize,
         local_n: usize,
@@ -587,6 +592,9 @@ mod complex_demo {
         Ilu0Local,
         IlutLocal,
         MpiBlockJacobiIlu0Local,
+        AsmIlu0Overlap { overlap: usize },
+        RasIlu0Overlap { overlap: usize },
+        RasIlukOverlap { k: usize, overlap: usize },
         LocalIluk { k: usize },
         ReplicatedFullIlu0,
         ReplicatedFullIluk { k: usize },
@@ -598,6 +606,7 @@ mod complex_demo {
         JacobiWeak,
         Ilu0Local,
         IlutLocal,
+        OverlapIlu,
     }
 
     #[derive(Clone, Debug)]
@@ -1117,6 +1126,10 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             });
         }
         match token_norm.as_str() {
+            "asm-ilu0-overlap1" => Ok(PcKind::AsmIlu0Overlap { overlap: 1 }),
+            "asm-ilu0-overlap2" => Ok(PcKind::AsmIlu0Overlap { overlap: 2 }),
+            "ras-ilu0-overlap1" => Ok(PcKind::RasIlu0Overlap { overlap: 1 }),
+            "ras-iluk1-overlap1" => Ok(PcKind::RasIlukOverlap { k: 1, overlap: 1 }),
             "none" | "off" => Ok(PcKind::None),
             "jacobi" | "jacobi-weak" | "weak-jacobi" => Ok(PcKind::JacobiWeak),
             "ilu0" | "ilu0-local" | "local-ilu0" => Ok(PcKind::Ilu0Local),
@@ -1127,7 +1140,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             | "block-jacobi-ilu0-overlap0"
             | "mpi-block-ilu0" => Ok(PcKind::MpiBlockJacobiIlu0Local),
             other => Err(KError::InvalidInput(format!(
-                "invalid pc '{other}', expected none|jacobi|local-ilu0|local-ilut|local-iluk:<k>|block-jacobi-ilu0-overlap0|block-jacobi-iluk1|block-jacobi-iluk1-overlap0|block-jacobi-iluk:<k>|block-jacobi-iluk<k>-overlap0|replicated-ilu0|replicated-full-ilu0|replicated-iluk:<k>|mpi-block-jacobi-ilu0"
+                "invalid pc '{other}', expected none|jacobi|local-ilu0|local-ilut|local-iluk:<k>|block-jacobi-ilu0-overlap0|block-jacobi-iluk1|block-jacobi-iluk1-overlap0|block-jacobi-iluk:<k>|block-jacobi-iluk<k>-overlap0|replicated-ilu0|replicated-full-ilu0|replicated-iluk:<k>|mpi-block-jacobi-ilu0|asm-ilu0-overlap1|asm-ilu0-overlap2|ras-ilu0-overlap1|ras-iluk1-overlap1"
             ))),
         }
     }
@@ -1294,6 +1307,13 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                 }
             }
             PcKind::MpiBlockJacobiIlu0Local => "own0",
+            PcKind::AsmIlu0Overlap { overlap }
+            | PcKind::RasIlu0Overlap { overlap }
+            | PcKind::RasIlukOverlap { overlap, .. } => match overlap {
+                1 => "own+ghost1",
+                2 => "own+ghost2",
+                _ => "own+ghostN",
+            },
             PcKind::None | PcKind::JacobiWeak => "n/a",
         }
     }
@@ -1315,6 +1335,10 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             | PcKind::IlutLocal
             | PcKind::MpiBlockJacobiIlu0Local
             | PcKind::LocalIluk { .. } => "owned-block/overlap0",
+            PcKind::AsmIlu0Overlap { .. } => "asm/overlap-gather/owned-output",
+            PcKind::RasIlu0Overlap { .. } | PcKind::RasIlukOverlap { .. } => {
+                "ras/overlap-gather/restricted-owned"
+            }
             PcKind::JacobiWeak => "jacobi/local",
             PcKind::None => "none",
         }
@@ -1334,6 +1358,9 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                 Self::MpiBlockJacobiIlu0Local => {
                     "block-jacobi-ilu0-overlap0 [mpi spelling alias]".to_string()
                 }
+                Self::AsmIlu0Overlap { overlap } => format!("asm-ilu0-overlap{overlap}"),
+                Self::RasIlu0Overlap { overlap } => format!("ras-ilu0-overlap{overlap}"),
+                Self::RasIlukOverlap { k, overlap } => format!("ras-iluk{k}-overlap{overlap}"),
                 Self::LocalIluk { k } => format!("block-jacobi-iluk{k}-overlap0"),
                 Self::ReplicatedFullIlu0 => {
                     "replicated full ILU(0) [correctness only, not scalable]".to_string()
@@ -1353,6 +1380,9 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                 | Self::LocalIluk { .. }
                 | Self::ReplicatedFullIlu0
                 | Self::ReplicatedFullIluk { .. } => PcDispatchBranch::Ilu0Local,
+                Self::AsmIlu0Overlap { .. }
+                | Self::RasIlu0Overlap { .. }
+                | Self::RasIlukOverlap { .. } => PcDispatchBranch::OverlapIlu,
                 Self::IlutLocal => PcDispatchBranch::IlutLocal,
             }
         }
@@ -1365,6 +1395,9 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                 | Self::Ilu0Local
                 | Self::IlutLocal
                 | Self::LocalIluk { .. }
+                | Self::AsmIlu0Overlap { .. }
+                | Self::RasIlu0Overlap { .. }
+                | Self::RasIlukOverlap { .. }
                 | Self::ReplicatedFullIlu0
                 | Self::ReplicatedFullIluk { .. } => None,
             }
@@ -1381,6 +1414,9 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                 Self::JacobiWeak => "jacobi-weak".to_string(),
                 Self::IlutLocal => "local-ilut-real-projection-fallback".to_string(),
                 Self::LocalIluk { k } => format!("local-iluk:{k}"),
+                Self::AsmIlu0Overlap { overlap } => format!("asm-ilu0-overlap{overlap}"),
+                Self::RasIlu0Overlap { overlap } => format!("ras-ilu0-overlap{overlap}"),
+                Self::RasIlukOverlap { k, overlap } => format!("ras-iluk{k}-overlap{overlap}"),
                 Self::ReplicatedFullIlu0 => "replicated-ilu0".to_string(),
                 Self::ReplicatedFullIluk { k } => format!("replicated-iluk:{k}"),
             }
@@ -1758,6 +1794,14 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
         } else {
             problem.csr_for_pc.clone()
         };
+        let global_pc_csr: Arc<SparseCsrMatrix<S>> = if bench_cfg.row_scale {
+            let row_scale = row_scaling.as_ref().ok_or_else(|| {
+                KError::InvalidInput("row scaling requested but factors were not computed".into())
+            })?;
+            Arc::new(scale_csr_rows(problem.global_csr.as_ref(), row_scale))
+        } else {
+            problem.global_csr.clone()
+        };
         let b_scaled: Vec<S> = if let Some(d) = &row_scaling {
             b_unscaled
                 .iter()
@@ -1778,6 +1822,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             Jacobi(Jacobi),
             Ilu0(IluCsr),
             MpiBlockJacobiIlu0(IluCsr),
+            OverlapIlu(OverlapIluPc),
             ReplicatedFull {
                 ilu: IluCsr,
                 comm: UniverseComm,
@@ -1795,6 +1840,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                     Self::Jacobi(pc) => pc,
                     Self::Ilu0(pc) => pc,
                     Self::MpiBlockJacobiIlu0(pc) => pc,
+                    Self::OverlapIlu(pc) => pc,
                     Self::ReplicatedFull { .. } => self,
                 }
             }
@@ -1806,6 +1852,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                     Self::Jacobi(pc) => KPreconditioner::dims(pc),
                     Self::Ilu0(pc) => KPreconditioner::dims(pc),
                     Self::MpiBlockJacobiIlu0(pc) => KPreconditioner::dims(pc),
+                    Self::OverlapIlu(pc) => KPreconditioner::dims(pc),
                     Self::ReplicatedFull { global_n, .. } => (*global_n, *global_n),
                 }
             }
@@ -1820,6 +1867,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                     Self::Jacobi(pc) => pc.apply_s(side, x, y, scratch),
                     Self::Ilu0(pc) => pc.apply_s(side, x, y, scratch),
                     Self::MpiBlockJacobiIlu0(pc) => pc.apply_s(side, x, y, scratch),
+                    Self::OverlapIlu(pc) => pc.apply_s(side, x, y, scratch),
                     Self::ReplicatedFull {
                         ilu,
                         comm,
@@ -1867,7 +1915,11 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                     PcKind::LocalIluk { k } | PcKind::ReplicatedFullIluk { k } => {
                         IluKind::Iluk { k }
                     }
-                    PcKind::None | PcKind::JacobiWeak => IluKind::Ilu0,
+                    PcKind::AsmIlu0Overlap { .. }
+                    | PcKind::RasIlu0Overlap { .. }
+                    | PcKind::RasIlukOverlap { .. }
+                    | PcKind::None
+                    | PcKind::JacobiWeak => IluKind::Ilu0,
                 };
                 cfg.reordering = bench_cfg.ilu_reordering.clone();
                 let mut ilu = IluCsr::new_with_config(cfg);
@@ -1899,8 +1951,39 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                             scratch_out: std::sync::Mutex::new(vec![S::zero(); problem.global_n]),
                         }
                     }
-                    PcKind::None | PcKind::JacobiWeak => unreachable!(),
+                    PcKind::AsmIlu0Overlap { .. }
+                    | PcKind::RasIlu0Overlap { .. }
+                    | PcKind::RasIlukOverlap { .. }
+                    | PcKind::None
+                    | PcKind::JacobiWeak => unreachable!(),
                 });
+            }
+            PcDispatchBranch::OverlapIlu => {
+                let (kind, overlap, restriction) = match spec.pc {
+                    PcKind::AsmIlu0Overlap { overlap } => {
+                        (IluKind::Ilu0, overlap, OverlapRestriction::Asm)
+                    }
+                    PcKind::RasIlu0Overlap { overlap } => {
+                        (IluKind::Ilu0, overlap, OverlapRestriction::Ras)
+                    }
+                    PcKind::RasIlukOverlap { k, overlap } => {
+                        (IluKind::Iluk { k }, overlap, OverlapRestriction::Ras)
+                    }
+                    _ => unreachable!(),
+                };
+                let mut cfg = IluCsrConfig::default();
+                cfg.reordering = bench_cfg.ilu_reordering.clone();
+                let pc_overlap = OverlapIluPc::setup_from_global_csr(
+                    global_pc_csr.as_ref(),
+                    problem.comm.clone(),
+                    problem.global_row_start,
+                    problem.global_row_start + problem.local_n,
+                    overlap,
+                    kind,
+                    cfg,
+                    restriction,
+                )?;
+                pc = Some(PcHandle::OverlapIlu(pc_overlap));
             }
             PcDispatchBranch::IlutLocal => {
                 validate_local_ilu_owned_block(pc_csr.as_ref())?;
@@ -2686,6 +2769,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             rhs_source: RhsSource::GeneratedAOnes,
             solution_reference,
             csr_for_pc: Arc::new(local_pc_block),
+            global_csr: Arc::new(csr_sparse),
             local_rows_nnz: local_csr.values().len(),
             zero_global_rows_local: count_zero_rows(&local_csr),
             local_n,
@@ -2787,6 +2871,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             rhs_source,
             solution_reference,
             csr_for_pc: Arc::new(local_pc_block),
+            global_csr: Arc::new(csr_sparse),
             local_rows_nnz: local_csr.values().len(),
             zero_global_rows_local: count_zero_rows(&local_csr),
             local_n,
@@ -3127,6 +3212,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             rhs_source: RhsSource::GeneratedAOnes,
             solution_reference: solution_reference_diagnostics(&rectangular_pc),
             csr_for_pc: Arc::new(rectangular_pc.clone()),
+            global_csr: Arc::new(op_local.clone()),
             local_rows_nnz: op_local.values().len(),
             zero_global_rows_local: count_zero_rows(&op_local),
             local_n: 2,
@@ -3191,6 +3277,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             rhs_source: RhsSource::GeneratedAOnes,
             solution_reference: solution_reference_diagnostics(&op_local),
             csr_for_pc: Arc::new(op_local.clone()),
+            global_csr: Arc::new(op_local.clone()),
             local_rows_nnz: 2,
             zero_global_rows_local: count_zero_rows(&op_local),
             local_n: 2,
@@ -3271,6 +3358,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             rhs_source: RhsSource::GeneratedAOnes,
             solution_reference: diagnostics,
             csr_for_pc: Arc::new(op_local.clone()),
+            global_csr: Arc::new(op_local.clone()),
             local_rows_nnz: 1,
             zero_global_rows_local: count_zero_rows(&op_local),
             local_n: 2,
@@ -3334,6 +3422,7 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
             rhs_source: RhsSource::GeneratedAOnes,
             solution_reference: solution_reference_diagnostics(&op_local),
             csr_for_pc: Arc::new(op_local.clone()),
+            global_csr: Arc::new(op_local.clone()),
             local_rows_nnz: 2,
             zero_global_rows_local: count_zero_rows(&op_local),
             local_n: 2,
@@ -3429,6 +3518,22 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
         assert_eq!(
             pc_apply_label_for_size(PcKind::Ilu0Local, 2),
             "owned-block/overlap0"
+        );
+        assert_eq!(
+            pc_domain_label_for_size(PcKind::AsmIlu0Overlap { overlap: 1 }, 2),
+            "own+ghost1"
+        );
+        assert_eq!(
+            pc_domain_label_for_size(PcKind::AsmIlu0Overlap { overlap: 2 }, 2),
+            "own+ghost2"
+        );
+        assert_eq!(
+            pc_apply_label_for_size(PcKind::AsmIlu0Overlap { overlap: 1 }, 2),
+            "asm/overlap-gather/owned-output"
+        );
+        assert_eq!(
+            pc_apply_label_for_size(PcKind::RasIlu0Overlap { overlap: 1 }, 2),
+            "ras/overlap-gather/restricted-owned"
         );
         assert_eq!(pc_domain_label_for_size(PcKind::None, 2), "n/a");
         assert_eq!(pc_apply_label_for_size(PcKind::None, 2), "none");
@@ -3561,6 +3666,26 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
         assert_eq!(
             parse_pc("block-jacobi-iluk3-overlap0").expect("parse block-jacobi-iluk3-overlap0"),
             PcKind::LocalIluk { k: 3 }
+        );
+    }
+
+    #[test]
+    fn parse_pc_accepts_overlap_aliases() {
+        assert_eq!(
+            parse_pc("asm-ilu0-overlap1").expect("parse asm-ilu0-overlap1"),
+            PcKind::AsmIlu0Overlap { overlap: 1 }
+        );
+        assert_eq!(
+            parse_pc("asm-ilu0-overlap2").expect("parse asm-ilu0-overlap2"),
+            PcKind::AsmIlu0Overlap { overlap: 2 }
+        );
+        assert_eq!(
+            parse_pc("ras-ilu0-overlap1").expect("parse ras-ilu0-overlap1"),
+            PcKind::RasIlu0Overlap { overlap: 1 }
+        );
+        assert_eq!(
+            parse_pc("ras-iluk1-overlap1").expect("parse ras-iluk1-overlap1"),
+            PcKind::RasIlukOverlap { k: 1, overlap: 1 }
         );
     }
 

--- a/src/preconditioner/mod.rs
+++ b/src/preconditioner/mod.rs
@@ -60,6 +60,8 @@ use crate::matrix::op::LinOp;
 
 pub mod bddc;
 pub mod bridge;
+#[cfg(all(feature = "complex", feature = "backend-faer"))]
+pub mod overlap_ilu;
 pub mod pc_bridge;
 #[cfg(all(feature = "legacy-pc-bridge", feature = "backend-faer"))]
 use faer::Mat;

--- a/src/preconditioner/overlap_ilu.rs
+++ b/src/preconditioner/overlap_ilu.rs
@@ -1,0 +1,336 @@
+#![cfg(all(feature = "complex", feature = "backend-faer"))]
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use crate::algebra::bridge::BridgeScratch;
+use crate::algebra::scalar::{KrystScalar, S};
+use crate::error::KError;
+use crate::matrix::sparse::CsrMatrix;
+use crate::ops::kpc::KPreconditioner;
+use crate::parallel::UniverseComm;
+use crate::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind};
+use crate::preconditioner::{PcSide, Preconditioner};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OverlapRestriction {
+    Asm,
+    Ras,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct OverlapIluDiagnostics {
+    pub owned_start: usize,
+    pub owned_end: usize,
+    pub overlap: usize,
+    pub subdomain_rows: Vec<usize>,
+    pub ghost_rows: Vec<usize>,
+    pub ghost_columns: Vec<usize>,
+}
+
+/// One-subdomain-per-rank overlapping ILU preconditioner for complex CSR examples.
+///
+/// The builder expands the owned row interval through graph-neighbor layers in the
+/// global CSR graph, extracts the induced subdomain matrix, factors it with
+/// [`IluCsr`], gathers the current distributed vector into the ghost entries needed
+/// by the subdomain solve, and returns the owned portion of the correction.
+pub struct OverlapIluPc {
+    comm: UniverseComm,
+    owned_start: usize,
+    owned_end: usize,
+    global_n: usize,
+    subdomain_rows: Vec<usize>,
+    owned_local_positions: Vec<usize>,
+    ilu: IluCsr,
+    restriction: OverlapRestriction,
+    diagnostics: OverlapIluDiagnostics,
+}
+
+impl OverlapIluPc {
+    pub fn setup_from_global_csr(
+        global: &CsrMatrix<S>,
+        comm: UniverseComm,
+        owned_start: usize,
+        owned_end: usize,
+        overlap: usize,
+        kind: IluKind,
+        mut cfg: IluCsrConfig,
+        restriction: OverlapRestriction,
+    ) -> Result<Self, KError> {
+        if global.nrows() != global.ncols() {
+            return Err(KError::InvalidInput(format!(
+                "overlapping ILU requires a square global matrix, got {}x{}",
+                global.nrows(),
+                global.ncols()
+            )));
+        }
+        if owned_start > owned_end || owned_end > global.nrows() {
+            return Err(KError::InvalidInput(format!(
+                "invalid owned range [{owned_start}, {owned_end}) for global size {}",
+                global.nrows()
+            )));
+        }
+
+        cfg.kind = kind;
+        let subdomain_rows =
+            expand_owned_rows_by_graph_overlap(global, owned_start, owned_end, overlap);
+        let (local, global_to_local) = extract_induced_subdomain(global, &subdomain_rows)?;
+        let owned_local_positions = (owned_start..owned_end)
+            .map(|g| {
+                global_to_local.get(&g).copied().ok_or_else(|| {
+                    KError::InvalidInput(format!(
+                        "owned row {g} missing from overlapping ILU subdomain"
+                    ))
+                })
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        let mut ilu = IluCsr::new_with_config(cfg);
+        ilu.setup(&local)?;
+
+        let owned: BTreeSet<_> = (owned_start..owned_end).collect();
+        let ghosts: Vec<_> = subdomain_rows
+            .iter()
+            .copied()
+            .filter(|g| !owned.contains(g))
+            .collect();
+        let ghost_columns = ghosts.clone();
+        let diagnostics = OverlapIluDiagnostics {
+            owned_start,
+            owned_end,
+            overlap,
+            subdomain_rows,
+            ghost_rows: ghosts,
+            ghost_columns,
+        };
+
+        Ok(Self {
+            comm,
+            owned_start,
+            owned_end,
+            global_n: global.nrows(),
+            subdomain_rows: diagnostics.subdomain_rows.clone(),
+            owned_local_positions,
+            ilu,
+            restriction,
+            diagnostics,
+        })
+    }
+
+    pub fn diagnostics(&self) -> &OverlapIluDiagnostics {
+        &self.diagnostics
+    }
+
+    fn gather_owned_input(&self, x_owned: &[S]) -> Result<Vec<S>, KError> {
+        let owned_n = self.owned_end - self.owned_start;
+        if x_owned.len() != owned_n {
+            return Err(KError::InvalidInput(format!(
+                "overlapping ILU apply expected owned input length {owned_n}, got {}",
+                x_owned.len()
+            )));
+        }
+        let mut global_x = vec![S::zero(); self.global_n];
+        global_x[self.owned_start..self.owned_end].copy_from_slice(x_owned);
+        self.comm.allreduce_sum_scalars(&mut global_x);
+        Ok(global_x)
+    }
+}
+
+impl KPreconditioner for OverlapIluPc {
+    type Scalar = S;
+
+    fn dims(&self) -> (usize, usize) {
+        (
+            self.owned_end - self.owned_start,
+            self.owned_end - self.owned_start,
+        )
+    }
+
+    fn apply_s(
+        &self,
+        side: PcSide,
+        x: &[S],
+        y: &mut [S],
+        scratch: &mut BridgeScratch,
+    ) -> Result<(), KError> {
+        let owned_n = self.owned_end - self.owned_start;
+        if y.len() != owned_n {
+            return Err(KError::InvalidInput(format!(
+                "overlapping ILU apply expected owned output length {owned_n}, got {}",
+                y.len()
+            )));
+        }
+        let global_x = self.gather_owned_input(x)?;
+        let local_x: Vec<_> = self.subdomain_rows.iter().map(|&g| global_x[g]).collect();
+        let mut local_y = vec![S::zero(); self.subdomain_rows.len()];
+        self.ilu.apply_s(side, &local_x, &mut local_y, scratch)?;
+        match self.restriction {
+            OverlapRestriction::Asm | OverlapRestriction::Ras => {
+                for (dst, &local_pos) in y.iter_mut().zip(&self.owned_local_positions) {
+                    *dst = local_y[local_pos];
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+pub fn expand_owned_rows_by_graph_overlap(
+    global: &CsrMatrix<S>,
+    owned_start: usize,
+    owned_end: usize,
+    overlap: usize,
+) -> Vec<usize> {
+    let mut subdomain: BTreeSet<usize> = (owned_start..owned_end).collect();
+    let mut frontier = subdomain.clone();
+    for _ in 0..overlap {
+        let mut next = BTreeSet::new();
+        for row in frontier.iter().copied() {
+            for nz in global.row_ptr()[row]..global.row_ptr()[row + 1] {
+                let col = global.col_idx()[nz];
+                if col < global.nrows() && subdomain.insert(col) {
+                    next.insert(col);
+                }
+            }
+        }
+        frontier = next;
+        if frontier.is_empty() {
+            break;
+        }
+    }
+    subdomain.into_iter().collect()
+}
+
+fn extract_induced_subdomain(
+    global: &CsrMatrix<S>,
+    subdomain_rows: &[usize],
+) -> Result<(CsrMatrix<S>, BTreeMap<usize, usize>), KError> {
+    let global_to_local: BTreeMap<usize, usize> = subdomain_rows
+        .iter()
+        .copied()
+        .enumerate()
+        .map(|(l, g)| (g, l))
+        .collect();
+    let mut row_ptr = Vec::with_capacity(subdomain_rows.len() + 1);
+    let mut col_idx = Vec::new();
+    let mut values = Vec::new();
+    row_ptr.push(0);
+    for &global_row in subdomain_rows {
+        for nz in global.row_ptr()[global_row]..global.row_ptr()[global_row + 1] {
+            let global_col = global.col_idx()[nz];
+            if let Some(&local_col) = global_to_local.get(&global_col) {
+                col_idx.push(local_col);
+                values.push(global.values()[nz]);
+            }
+        }
+        row_ptr.push(col_idx.len());
+    }
+    Ok((
+        CsrMatrix::from_csr(
+            subdomain_rows.len(),
+            subdomain_rows.len(),
+            row_ptr,
+            col_idx,
+            values,
+        ),
+        global_to_local,
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::parallel::NoComm;
+
+    fn four_by_four_chain() -> CsrMatrix<S> {
+        CsrMatrix::from_csr(
+            4,
+            4,
+            vec![0, 2, 5, 8, 10],
+            vec![0, 1, 0, 1, 2, 1, 2, 3, 2, 3],
+            vec![
+                S::from_real(4.0),
+                S::from_real(-1.0),
+                S::from_real(-1.0),
+                S::from_real(4.0),
+                S::from_real(-1.0),
+                S::from_real(-1.0),
+                S::from_real(4.0),
+                S::from_real(-1.0),
+                S::from_real(-1.0),
+                S::from_real(4.0),
+            ],
+        )
+    }
+
+    fn owned_block_0_2(global: &CsrMatrix<S>) -> CsrMatrix<S> {
+        CsrMatrix::from_csr(
+            2,
+            2,
+            vec![0, 2, 4],
+            vec![0, 1, 0, 1],
+            vec![
+                global.values()[0],
+                global.values()[1],
+                global.values()[2],
+                global.values()[3],
+            ],
+        )
+    }
+
+    #[test]
+    fn overlap_zero_matches_owned_block_ilu0_apply() {
+        let global = four_by_four_chain();
+        let mut cfg = IluCsrConfig::default();
+        cfg.kind = IluKind::Ilu0;
+        let mut local = IluCsr::new_with_config(cfg.clone());
+        local
+            .setup(&owned_block_0_2(&global))
+            .expect("setup local ILU0");
+
+        let pc = OverlapIluPc::setup_from_global_csr(
+            &global,
+            UniverseComm::NoComm(NoComm),
+            0,
+            2,
+            0,
+            IluKind::Ilu0,
+            cfg,
+            OverlapRestriction::Ras,
+        )
+        .expect("setup overlap ILU0");
+
+        let x = vec![S::from_real(1.0), S::from_real(2.0)];
+        let mut y_local = vec![S::zero(); 2];
+        let mut y_overlap = vec![S::zero(); 2];
+        let mut scratch = BridgeScratch::default();
+        local
+            .apply_s(PcSide::Right, &x, &mut y_local, &mut scratch)
+            .expect("apply local ILU0");
+        pc.apply_s(PcSide::Right, &x, &mut y_overlap, &mut scratch)
+            .expect("apply overlap ILU0");
+        for (a, b) in y_local.iter().zip(&y_overlap) {
+            assert!((*a - *b).abs() < 1e-12);
+        }
+    }
+
+    #[test]
+    fn overlap_one_adds_ghost_rows_and_columns() {
+        let global = four_by_four_chain();
+        let cfg = IluCsrConfig::default();
+        let pc = OverlapIluPc::setup_from_global_csr(
+            &global,
+            UniverseComm::NoComm(NoComm),
+            0,
+            2,
+            1,
+            IluKind::Ilu0,
+            cfg,
+            OverlapRestriction::Ras,
+        )
+        .expect("setup overlap ILU0");
+        let diag = pc.diagnostics();
+        assert_eq!(diag.subdomain_rows, vec![0, 1, 2]);
+        assert_eq!(diag.ghost_rows, vec![2]);
+        assert_eq!(diag.ghost_columns, vec![2]);
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide reusable overlapping ILU support for complex distributed CSR demos to enable ASM/RAS variants that include one or more graph-overlap layers for improved locality/accuracy. 
- Expose convenient CLI aliases and descriptive labels so the complex Matrix Market demo can request ASM/RAS overlap runs and export meaningful semantics for benchmarking.

### Description
- Add a new module `src/preconditioner/overlap_ilu.rs` implementing `OverlapIluPc` that: expands owned rows by graph overlap layers, extracts the induced subdomain CSR, builds and factors the subdomain with `IluCsr`, gathers ghost values with the communicator, and restricts the correction back to owned rows (`OverlapRestriction::Asm`/`Ras`).
- Extend `examples/complex_matrix_market_demo.rs` with new `PcKind` variants `AsmIlu0Overlap { overlap }`, `RasIlu0Overlap { overlap }`, and `RasIlukOverlap { k, overlap }`, add parsing for `asm-ilu0-overlap1`, `asm-ilu0-overlap2`, `ras-ilu0-overlap1`, and `ras-iluk1-overlap1`, and add labels/semantic keys and pc-domain/apply descriptions for these rows.
- Wire the demo to retain the full global CSR (`Problem.global_csr`) and construct either an `OverlapIluPc` via `OverlapIluPc::setup_from_global_csr(...)` (ILU(0)/ILU(k)) or fall back to existing local ILU paths; include row-scaling support for the global CSR used by the overlap builder.
- Add small correctness tests in `src/preconditioner/overlap_ilu.rs` that verify overlap-0 matches the owned-block ILU(0) apply and overlap-1 yields expected ghost rows/columns, plus example unit tests in the demo that validate parsing and metadata label snapshots.
- Gate the new module behind the feature combination `all(feature = "complex", feature = "backend-faer")` and add a short manual MPI smoke command to the example header for running the new rows.

### Testing
- Ran `cargo test --features complex overlap_ilu` and the new `overlap_ilu` unit tests passed (2 passed, 0 failed).
- Ran `cargo test --features complex --example complex_matrix_market_demo parse_pc_accepts_overlap_aliases` and `cargo test --features complex --example complex_matrix_market_demo metadata_labels_snapshot_mpi`, and those example tests passed.
- Ran `rustfmt` on modified files and `git diff --check` to ensure formatting and no whitespace errors (both OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fbc45220808329b441865280da0929)