### PR TITLE
docs: add complex Matrix Market sweep commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -940,6 +940,12 @@ cargo run --example dense_direct
 
 # Matrix market file demonstration
 cargo run --example matrix_market_demo
+
+# Complex Matrix Market correctness sweep (requires MPI + complex support)
+cargo mpirun -n 4 --example complex_matrix_market_demo --features=complex,mpi,mpi_examples -- --mode correctness --dist-policy off --maxits 2000 --restarts 150,250,324 --pcs replicated-full-ilu0,none,jacobi,block-jacobi-ilu0 --fgmres-orthog modified --fgmres-reorth always
+
+# Complex Matrix Market scalability sweep (requires MPI + complex support)
+cargo mpirun -n 4 --example complex_matrix_market_demo --features=complex,mpi,mpi_examples -- --mode scalability --dist-policy auto --maxits 1000 --restarts 50,100 --pcs none,jacobi,block-jacobi-ilu0
 ```
 
 ### Advanced Feature Examples  

--- a/examples/complex_matrix_market_demo.rs
+++ b/examples/complex_matrix_market_demo.rs
@@ -1,8 +1,17 @@
-//! to run:
-//! cargo mpirun -n 4 --example complex_matrix_market_demo --features=complex,mpi,mpi_examples
+//! Complex Matrix Market benchmark/demo for FGMRES on generated and file-backed
+//! complex systems. Run it with MPI enabled when comparing replicated correctness
+//! checks against distributed scalability behavior.
+//!
+//! Correctness sweep (replicated operator/preconditioner checks, long iteration
+//! budget, and stricter modified Gram-Schmidt reorthogonalization):
+//! cargo mpirun -n 4 --example complex_matrix_market_demo --features=complex,mpi,mpi_examples -- --mode correctness --dist-policy off --maxits 2000 --restarts 150,250,324 --pcs replicated-full-ilu0,none,jacobi,block-jacobi-ilu0 --fgmres-orthog modified --fgmres-reorth always
+//!
+//! Scalability sweep (automatic distributed policy with lightweight local-block
+//! preconditioners):
+//! cargo mpirun -n 4 --example complex_matrix_market_demo --features=complex,mpi,mpi_examples -- --mode scalability --dist-policy auto --maxits 1000 --restarts 50,100 --pcs none,jacobi,block-jacobi-ilu0
 //!
 //! Manual MPI smoke commands for overlapping ILU rows (enable once MPI execution is available):
-//! cargo mpirun -n 2 --example complex_matrix_market_demo --features=complex,mpi,mpi_examples -- --pcs asm-ilu0-overlap1,asm-ilu0-overlap2,ras-ilu0-overlap1,ras-iluk1-overlap1 --run-mode correctness --warmup-runs 0 --measured-runs 1
+//! cargo mpirun -n 2 --example complex_matrix_market_demo --features=complex,mpi,mpi_examples -- --pcs asm-ilu0-overlap1,asm-ilu0-overlap2,ras-ilu0-overlap1,ras-iluk1-overlap1 --mode correctness --warmup-runs 0 --measured-runs 1
 
 #![cfg_attr(not(feature = "complex"), allow(dead_code))]
 
@@ -3635,6 +3644,32 @@ Defaults: --dist-policy is off for correctness and robustness, auto for scalabil
                 }
             }
         }
+    }
+
+    #[test]
+    fn parse_pc_accepts_documented_sweep_names() {
+        assert_eq!(
+            parse_pc_csv(
+                "--pcs",
+                "replicated-full-ilu0,none,jacobi,block-jacobi-ilu0"
+            )
+            .expect("parse documented correctness preconditioners"),
+            vec![
+                PcKind::ReplicatedFullIlu0,
+                PcKind::None,
+                PcKind::JacobiWeak,
+                PcKind::MpiBlockJacobiIlu0Local,
+            ]
+        );
+        assert_eq!(
+            parse_pc_csv("--pcs", "none,jacobi,block-jacobi-ilu0")
+                .expect("parse documented scalability preconditioners"),
+            vec![
+                PcKind::None,
+                PcKind::JacobiWeak,
+                PcKind::MpiBlockJacobiIlu0Local,
+            ]
+        );
     }
 
     #[test]


### PR DESCRIPTION
### Motivation
- Make it easy to run canonical correctness and scalability MPI sweeps for the complex Matrix Market FGMRES demo with explicit flags for preconditioner lists, restarts, iteration limits and FGMRES orthog/reorth settings.
- Ensure the preconditioner names shown in the documentation are actually accepted by the example's parser to avoid user confusion and regressions.

### Description
- Update the top-level doc comment in `examples/complex_matrix_market_demo.rs` to include an explicit correctness sweep command and a scalability sweep command with the requested flags (`--mode correctness`, `--dist-policy off`, `--maxits 2000`, `--restarts 150,250,324`, `--pcs replicated-full-ilu0,none,jacobi,block-jacobi-ilu0`, `--fgmres-orthog modified`, `--fgmres-reorth always`; and `--mode scalability`, `--dist-policy auto`, `--maxits 1000`, `--restarts 50,100`, `--pcs none,jacobi,block-jacobi-ilu0`).
- Add the same two example `cargo mpirun` commands to the README example command index so they are discoverable from the repo landing page.
- Add a unit test `parse_pc_accepts_documented_sweep_names` to `examples/complex_matrix_market_demo.rs` that exercises `parse_pc_csv(...)` against the documented PC CSV lists and verifies the expected `PcKind` vector is returned.

### Testing
- Ran `cargo test --example complex_matrix_market_demo --features complex parse_pc_accepts_documented_sweep_names`, and the new test passed (`1 passed; 0 failed`).
- Ran `git diff --check`, which reported no new whitespace/errors from these edits.
- Ran `cargo fmt --check` and `rustfmt --check examples/complex_matrix_market_demo.rs`, which reported existing formatting differences outside the intent of this change (no functional regressions introduced by this PR).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcc6ecb9188329a39dae6c6be89731)