### PR TITLE
Fix docs build for complex ASM dense blocks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1147,7 +1147,7 @@ dependencies = [
 
 [[package]]
 name = "kryst"
-version = "4.0.3"
+version = "4.0.5"
 dependencies = [
  "approx 0.5.1",
  "bitflags",

--- a/src/preconditioner/asm/distributed.rs
+++ b/src/preconditioner/asm/distributed.rs
@@ -17,7 +17,8 @@ use crate::matrix::op::CsrOp;
 #[cfg(all(
     feature = "mpi",
     feature = "backend-faer",
-    feature = "legacy-pc-bridge"
+    feature = "legacy-pc-bridge",
+    not(feature = "complex")
 ))]
 use crate::matrix::op::DenseOp;
 use crate::matrix::op::{DistLayout, LinOp, StructureId, ValuesId};
@@ -819,7 +820,11 @@ fn dense_solve_with_diagonal_shift(
 #[cfg(feature = "mpi")]
 enum SubdomainSolver {
     Csr(Box<dyn Preconditioner>),
-    #[cfg(all(feature = "backend-faer", feature = "legacy-pc-bridge"))]
+    #[cfg(all(
+        feature = "backend-faer",
+        feature = "legacy-pc-bridge",
+        not(feature = "complex")
+    ))]
     Dense(Box<dyn Preconditioner>),
 }
 
@@ -831,7 +836,11 @@ impl std::fmt::Debug for SubdomainSolver {
                 .debug_struct("SubdomainSolver")
                 .field("backend", &"csr")
                 .finish(),
-            #[cfg(all(feature = "backend-faer", feature = "legacy-pc-bridge"))]
+            #[cfg(all(
+                feature = "backend-faer",
+                feature = "legacy-pc-bridge",
+                not(feature = "complex")
+            ))]
             SubdomainSolver::Dense(_) => f
                 .debug_struct("SubdomainSolver")
                 .field("backend", &"dense")
@@ -849,11 +858,18 @@ impl SubdomainSolver {
                 let pc = build_jacobi()?;
                 Ok(match block_solver {
                     AsmBlockSolver::LuDense => {
-                        #[cfg(all(feature = "backend-faer", feature = "legacy-pc-bridge"))]
+                        #[cfg(all(
+                            feature = "backend-faer",
+                            feature = "legacy-pc-bridge",
+                            not(feature = "complex")
+                        ))]
                         {
                             SubdomainSolver::Dense(pc)
                         }
-                        #[cfg(not(all(feature = "backend-faer", feature = "legacy-pc-bridge")))]
+                        #[cfg(any(
+                            feature = "complex",
+                            not(all(feature = "backend-faer", feature = "legacy-pc-bridge"))
+                        ))]
                         {
                             SubdomainSolver::Csr(pc)
                         }
@@ -925,11 +941,19 @@ impl SubdomainSolver {
                         None,
                         conditioning,
                     )?;
-                    #[cfg(all(feature = "backend-faer", feature = "legacy-pc-bridge"))]
+                    #[cfg(all(
+                        feature = "backend-faer",
+                        feature = "legacy-pc-bridge",
+                        not(feature = "complex")
+                    ))]
                     {
                         Ok(SubdomainSolver::Dense(pc))
                     }
-                    #[cfg(not(all(feature = "backend-faer", feature = "legacy-pc-bridge")))]
+                    #[cfg(not(all(
+                        feature = "backend-faer",
+                        feature = "legacy-pc-bridge",
+                        not(feature = "complex")
+                    )))]
                     {
                         let _ = pc;
                         Err(KError::Unsupported(
@@ -948,7 +972,11 @@ impl SubdomainSolver {
                 let op = CsrOp::new(mat.clone());
                 pc.setup(&op)
             }
-            #[cfg(all(feature = "backend-faer", feature = "legacy-pc-bridge"))]
+            #[cfg(all(
+                feature = "backend-faer",
+                feature = "legacy-pc-bridge",
+                not(feature = "complex")
+            ))]
             SubdomainSolver::Dense(pc) => {
                 let dense = mat.to_dense()?;
                 let op = DenseOp::new(Arc::new(dense));
@@ -960,7 +988,11 @@ impl SubdomainSolver {
     fn solve(&self, rhs: &[S], x: &mut [S]) -> Result<(), KError> {
         match self {
             SubdomainSolver::Csr(pc) => pc.apply(PcSide::Left, rhs, x),
-            #[cfg(all(feature = "backend-faer", feature = "legacy-pc-bridge"))]
+            #[cfg(all(
+                feature = "backend-faer",
+                feature = "legacy-pc-bridge",
+                not(feature = "complex")
+            ))]
             SubdomainSolver::Dense(pc) => pc.apply(PcSide::Left, rhs, x),
         }
     }
@@ -971,7 +1003,11 @@ impl SubdomainSolver {
                 let op = CsrOp::new(mat.clone());
                 pc.update_numeric(&op)
             }
-            #[cfg(all(feature = "backend-faer", feature = "legacy-pc-bridge"))]
+            #[cfg(all(
+                feature = "backend-faer",
+                feature = "legacy-pc-bridge",
+                not(feature = "complex")
+            ))]
             SubdomainSolver::Dense(pc) => {
                 let dense = mat.to_dense()?;
                 let op = DenseOp::new(Arc::new(dense));
@@ -983,7 +1019,11 @@ impl SubdomainSolver {
     fn supports_numeric_update(&self) -> bool {
         match self {
             SubdomainSolver::Csr(pc) => pc.supports_numeric_update(),
-            #[cfg(all(feature = "backend-faer", feature = "legacy-pc-bridge"))]
+            #[cfg(all(
+                feature = "backend-faer",
+                feature = "legacy-pc-bridge",
+                not(feature = "complex")
+            ))]
             SubdomainSolver::Dense(pc) => pc.supports_numeric_update(),
         }
     }


### PR DESCRIPTION
### Motivation
- Avoid a type-mismatch when building documentation with `--all-features` where real-only `DenseOp<f64>` paths are compiled into contexts expecting complex scalars, causing `LinOp` scalar mismatch errors.

### Description
- Gate the `DenseOp` import and the `Dense` `SubdomainSolver` variant behind `not(feature = "complex")` so the real-only dense legacy bridge is excluded from complex builds.
- Fall back to the CSR subdomain solver when `AsmBlockSolver::LuDense` would otherwise select the real-only dense path and the `complex` feature is enabled.
- Apply the same `not(feature = "complex")` gating to ILUTP/dense construction and the dense `setup` / `solve` / `update_numeric` match arms so dense behavior is preserved only for real builds.
- Refresh the `Cargo.lock` package entry to match the crate version recorded in `Cargo.toml`.

### Testing
- Ran `cargo check --all-features`, which completed successfully.
- Ran `DOCS_RS=1 cargo +nightly rustdoc --lib --all-features --config 'build.rustdocflags=["--cfg","docsrs"]'`, which completed successfully and generated documentation.
- Ran `rustfmt --check src/preconditioner/asm/distributed.rs --edition 2024`, which succeeded.
- Ran `cargo fmt --check`, which failed due to unrelated pre-existing formatting differences in `src/matrix/backend/sprs.rs`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e245a09f88329bb04e3aa69c529db)