### PR TITLE
Avoid heap allocations in degraded complex IluCsr::apply_mut

### DIFF
--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -1835,13 +1835,37 @@ impl IluCsr {
             let mut xi = std::mem::take(&mut self.c_xi);
             let mut yr = std::mem::take(&mut self.c_yr);
             let mut yi = std::mem::take(&mut self.c_yi);
+            let mut x_perm = std::mem::take(&mut self.tmp);
+            let mut y_perm = std::mem::take(&mut self.tmp2);
+            let mut right_tmp = std::mem::take(&mut self.tmp3);
             let result = (|| {
+                let xr = &mut xr[..n];
+                let xi = &mut xi[..n];
+                let yr = &mut yr[..n];
+                let yi = &mut yi[..n];
+                let x_perm = &mut x_perm[..n];
+                let y_perm = &mut y_perm[..n];
+                let right_tmp = &mut right_tmp[..n];
                 for i in 0..n {
                     xr[i] = x[i].real();
                     xi[i] = x[i].imag();
                 }
-                self.apply_op_scalar_mut(Op::NoTrans, &xr[..n], &mut yr[..n])?;
-                self.apply_op_scalar_mut(Op::NoTrans, &xi[..n], &mut yi[..n])?;
+                self.apply_op_scalar_with_workspace(
+                    Op::NoTrans,
+                    xr,
+                    yr,
+                    x_perm,
+                    y_perm,
+                    right_tmp,
+                )?;
+                self.apply_op_scalar_with_workspace(
+                    Op::NoTrans,
+                    xi,
+                    yi,
+                    x_perm,
+                    y_perm,
+                    right_tmp,
+                )?;
                 for i in 0..n {
                     y[i] = S::from_parts(yr[i], yi[i]);
                 }
@@ -1851,6 +1875,9 @@ impl IluCsr {
             self.c_xi = xi;
             self.c_yr = yr;
             self.c_yi = yi;
+            self.tmp = x_perm;
+            self.tmp2 = y_perm;
+            self.tmp3 = right_tmp;
             result
         }
     }


### PR DESCRIPTION
### Motivation

- The degraded complex `IluCsr::apply_mut` path could perform heap allocations in steady-state because it repeatedly took and left real workspace buffers empty when calling the scalar mut apply, causing reallocation on the second call.

### Description

- In `src/preconditioner/ilu_csr/mod.rs` the degraded complex `apply_mut` now takes the shared real work buffers (`tmp`, `tmp2`, `tmp3`) once and reuses them for both the real and imaginary projected solves via `apply_op_scalar_with_workspace` instead of calling `apply_op_scalar_mut` twice.
- The code binds slice views into the taken buffers and the temporary real/imag buffers to avoid intermediate Vec allocations during the two projections.
- After the two projected solves the implementation restores the taken real workspace buffers (`tmp`, `tmp2`, `tmp3`) and the complex projection buffers (`c_xr`, `c_xi`, `c_yr`, `c_yi`) back into the struct to preserve allocation-free steady-state behavior.

### Testing

- Ran `cargo test --all-features --test ilu_apply_no_alloc -- --nocapture` and the two tests in that file passed (both allocation checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e4e2722c483298c12a97848c39ad4)