### PR TITLE
Serialize ILU allocation counter tests

### DIFF
--- a/tests/ilu_apply_no_alloc.rs
+++ b/tests/ilu_apply_no_alloc.rs
@@ -1,11 +1,15 @@
 #![cfg(feature = "backend-faer")]
 use std::alloc::{GlobalAlloc, Layout, System};
 use std::sync::atomic::{AtomicUsize, Ordering::*};
+use std::sync::Mutex;
 
 use kryst::algebra::prelude::*;
 
 pub struct CountingAlloc;
 static ALLOCS: AtomicUsize = AtomicUsize::new(0);
+// The global allocation counter is process-wide, so keep these assertions isolated
+// even when the Rust test harness runs tests concurrently.
+static ALLOC_TEST_LOCK: Mutex<()> = Mutex::new(());
 
 unsafe impl GlobalAlloc for CountingAlloc {
     unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
@@ -29,9 +33,10 @@ fn allocs() -> usize {
 #[cfg(not(feature = "complex"))]
 #[test]
 fn ilu_apply_has_no_allocations() {
-    use kryst::preconditioner::PcSide;
+    let _alloc_guard = ALLOC_TEST_LOCK.lock().unwrap();
     use kryst::preconditioner::ilu::{IluBuilder, IluType, TriSolveType};
     use kryst::preconditioner::legacy::Preconditioner;
+    use kryst::preconditioner::PcSide;
 
     let n = 32;
     let a = faer::Mat::from_fn(n, n, |i, j| {
@@ -63,6 +68,7 @@ fn ilu_apply_has_no_allocations() {
 #[cfg(all(feature = "complex", feature = "complex_ilu"))]
 #[test]
 fn ilu_csr_complex_native_apply_mut_has_no_allocations() {
+    let _alloc_guard = ALLOC_TEST_LOCK.lock().unwrap();
     use kryst::matrix::sparse::CsrMatrix;
     use kryst::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind};
     use kryst::preconditioner::{PcSide, Preconditioner};
@@ -111,6 +117,7 @@ fn ilu_csr_complex_native_apply_mut_has_no_allocations() {
 #[cfg(all(feature = "complex", feature = "complex_ilu"))]
 #[test]
 fn ilu_csr_complex_degraded_apply_mut_has_no_allocations() {
+    let _alloc_guard = ALLOC_TEST_LOCK.lock().unwrap();
     use kryst::matrix::sparse::CsrMatrix;
     use kryst::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind};
     use kryst::preconditioner::{PcSide, Preconditioner};


### PR DESCRIPTION
### Motivation
- The global allocation counter used by the ILU no-allocation tests is process-wide and can be contaminated when the Rust test harness runs tests concurrently.  
- During investigation of spurious allocations in the complex-degraded ILU path temporary tracing was used; the root cause was test concurrency rather than steady-state allocations in production code.

### Description
- Add a process-wide test lock `static ALLOC_TEST_LOCK: Mutex<()>` and explanatory comment to `tests/ilu_apply_no_alloc.rs`.  
- Acquire the lock at the start of each ILU allocation assertion test to serialize snapshots (`let _alloc_guard = ALLOC_TEST_LOCK.lock().unwrap();`) so the allocation counter is measured in isolation.  
- Remove temporary checkpoint/tracing instrumentation used during the investigation and keep the final change scoped to the test harness (no production `IluCsr` behavior was changed).

### Testing
- Ran `cargo test --features backend-faer,complex,complex_ilu --test ilu_apply_no_alloc -- --nocapture` and the ILU allocation tests passed.  
- Ran `cargo test --no-default-features --features backend-faer --test ilu_apply_no_alloc -- --nocapture` and the non-complex allocation test passed.  
- Ran `rustfmt` and `git diff --check` to verify formatting and absence of whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6eddff808329afaff6efe031c5b3)