### PR TITLE
Add apply_vec_into / apply_vec_t_into destination-buffer APIs to Permutation

### DIFF
--- a/src/utils/permutation.rs
+++ b/src/utils/permutation.rs
@@ -25,18 +25,50 @@ impl Permutation {
         self.p.len()
     }
 
-    /// Apply permutation to a vector: `y(new) = x(old)[p[new]]`
-    pub fn apply_vec<S: KrystScalar>(&self, x_old: &[S], y_new: &mut [S]) {
-        for (i, y) in y_new.iter_mut().enumerate() {
-            *y = x_old[self.p[i]];
+    /// Returns true if this is the identity permutation.
+    #[inline]
+    pub fn is_identity(&self) -> bool {
+        self.p.iter().enumerate().all(|(i, &p_i)| i == p_i)
+    }
+
+    /// Apply permutation to a vector: `y(new) = x(old)[p[new]]`.
+    pub fn apply_vec_into<T: Copy>(&self, x: &[T], y: &mut [T]) {
+        debug_assert_eq!(x.len(), self.len());
+        debug_assert_eq!(y.len(), self.len());
+
+        if self.is_identity() {
+            y.copy_from_slice(x);
+            return;
+        }
+
+        for i in 0..self.len() {
+            y[i] = x[self.p[i]];
         }
     }
 
-    /// Apply transpose permutation to a vector: `y(old) = x(new)[pinv[old]]`
-    pub fn apply_vec_t<S: KrystScalar>(&self, x_new: &[S], y_old: &mut [S]) {
-        for (i, y) in y_old.iter_mut().enumerate() {
-            *y = x_new[self.pinv[i]];
+    /// Apply transpose/inverse permutation to a vector: `y(old) = x(new)[pinv[old]]`.
+    pub fn apply_vec_t_into<T: Copy>(&self, x: &[T], y: &mut [T]) {
+        debug_assert_eq!(x.len(), self.len());
+        debug_assert_eq!(y.len(), self.len());
+
+        if self.is_identity() {
+            y.copy_from_slice(x);
+            return;
         }
+
+        for i in 0..self.len() {
+            y[self.p[i]] = x[i];
+        }
+    }
+
+    /// Apply permutation to a vector: `y(new) = x(old)[p[new]]`.
+    pub fn apply_vec<S: KrystScalar>(&self, x_old: &[S], y_new: &mut [S]) {
+        self.apply_vec_into(x_old, y_new);
+    }
+
+    /// Apply transpose permutation to a vector: `y(old) = x(new)[pinv[old]]`.
+    pub fn apply_vec_t<S: KrystScalar>(&self, x_new: &[S], y_old: &mut [S]) {
+        self.apply_vec_t_into(x_new, y_old);
     }
 }
 
@@ -244,7 +276,45 @@ pub(crate) fn cuthill_mckee_from_adj(adj: &mut [Vec<usize>]) -> Vec<usize> {
 mod tests {
     use super::*;
     use crate::matrix::sparse::CsrMatrix;
-    use faer::Mat;
+    #[test]
+    fn apply_vec_into_uses_destination_buffer() {
+        let perm = Permutation {
+            p: vec![2, 0, 1],
+            pinv: vec![1, 2, 0],
+        };
+        let x = [10, 20, 30];
+        let mut y = [0; 3];
+
+        perm.apply_vec_into(&x, &mut y);
+
+        assert_eq!(y, [30, 10, 20]);
+    }
+
+    #[test]
+    fn apply_vec_t_into_uses_destination_buffer() {
+        let perm = Permutation {
+            p: vec![2, 0, 1],
+            pinv: vec![1, 2, 0],
+        };
+        let x = [30, 10, 20];
+        let mut y = [0; 3];
+
+        perm.apply_vec_t_into(&x, &mut y);
+
+        assert_eq!(y, [10, 20, 30]);
+    }
+
+    #[test]
+    fn identity_apply_vec_into_copies_input() {
+        let perm = Permutation::identity(3);
+        let x = [1.5, 2.5, 3.5];
+        let mut y = [0.0; 3];
+
+        perm.apply_vec_into(&x, &mut y);
+
+        assert_eq!(y, x);
+    }
+
     #[test]
     fn permute_csr_symmetric_matches_dense() {
         // 3x3 matrix


### PR DESCRIPTION
### Motivation
- Provide explicit destination-buffer APIs for `Permutation` so callers can reuse preallocated buffers and avoid allocations. 
- Make permutation application safer by adding debug length checks and an identity fast path to accelerate the common no-op case. 
- Preserve backward compatibility by keeping `apply_vec` and `apply_vec_t` as lightweight wrappers that do not allocate. 

### Description
- Added `pub fn apply_vec_into<T: Copy>(&self, x: &[T], y: &mut [T])` with `debug_assert_eq!` checks for `x.len()`, `y.len()`, and `self.len()`, an identity fast path that calls `y.copy_from_slice(x)`, and the forward apply loop `y[i] = x[self.p[i]]`.
- Added `pub fn apply_vec_t_into<T: Copy>(&self, x: &[T], y: &mut [T])` with the same length checks and identity fast path, and the transpose/inverse apply loop `y[self.p[i]] = x[i]`.
- Added `pub fn is_identity(&self) -> bool` used by the fast paths, and kept `apply_vec` / `apply_vec_t` as allocation-free wrappers that call the new `*_into` methods.
- Added unit tests validating forward application, transpose/inverse application, and the identity fast-path copy behavior. 

### Testing
- Ran `cargo test permutation --lib` which executed the permutation-related unit tests and all tests passed (7 passed, 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efbd74b5083298bd5575bdd57558c)