### PR TITLE
Use explicit ILU CSR permutation buffers

### DIFF
--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -1935,7 +1935,7 @@ impl IluCsr {
     }
 
     fn pipeline_apply_left(&self, x: &[Real], y: &mut [Real]) {
-        self.pipeline_meta.left_perm.apply_vec(x, y);
+        self.pipeline_meta.left_perm.apply_vec_into(x, y);
         if let Some(scale) = &self.pipeline_meta.row_scaling {
             for i in 0..y.len() {
                 y[i] /= scale[i];
@@ -1944,7 +1944,7 @@ impl IluCsr {
     }
 
     fn pipeline_apply_right_inverse_with_tmp(&self, x: &[Real], tmp: &mut [Real], y: &mut [Real]) {
-        self.pipeline_meta.right_perm.apply_vec_t(x, tmp);
+        self.pipeline_meta.right_perm.apply_vec_t_into(x, tmp);
         if let Some(scale) = &self.pipeline_meta.col_scaling {
             for i in 0..y.len() {
                 y[i] = tmp[i] / scale[i];


### PR DESCRIPTION
### Motivation
- Replace implicit permutation helpers with the destination-buffer APIs to avoid hidden copies and make buffer usage explicit in ILU CSR pipeline steps.

### Description
- Updated `IluCsr::pipeline_apply_left` to call `self.pipeline_meta.left_perm.apply_vec_into(x, y)` instead of `apply_vec(x, y)` and kept existing row-scaling after the permutation write.
- Updated `IluCsr::pipeline_apply_right_inverse_with_tmp` to call `self.pipeline_meta.right_perm.apply_vec_t_into(x, tmp)` instead of `apply_vec_t(x, tmp)` and preserved the existing column-scaling / copy-back logic that follows the permutation write.
- Verified these helpers are exercised by the existing call chain through `IluCsr::apply_op_scalar_with_workspace()` and `IluCsr::apply_op_scalar_mut()` so runtime behavior is preserved.

### Testing
- Ran the full test suite with `cargo test`, which completed successfully (589 passed, 0 failed, 6 ignored). 
- Ran `git diff --check` to ensure no whitespace or diff issues; no problems found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efd6440a48329b15a3be24eb20f1e)