### PR TITLE
Use no-allocation permutation buffers in ILU complex apply

### DIFF
--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -1805,7 +1805,7 @@ impl IluCsr {
             let result = (|| {
                 let w = &mut w[..n];
                 let y_perm = &mut y_perm[..n];
-                self.pipeline_meta.left_perm.apply_vec(x, w);
+                self.pipeline_meta.left_perm.apply_vec_into(x, w);
                 for i in 0..n {
                     let mut s = w[i];
                     for p in self.l_row[i]..self.l_row[i + 1] {
@@ -1823,7 +1823,7 @@ impl IluCsr {
                     }
                     w[i] = s / self.c_u_val[self.u_diag_ix[i]];
                 }
-                self.pipeline_meta.right_perm.apply_vec_t(w, y_perm);
+                self.pipeline_meta.right_perm.apply_vec_t_into(w, y_perm);
                 y.copy_from_slice(y_perm);
                 Ok(())
             })();


### PR DESCRIPTION
### Motivation
- Reduce temporary allocations during the native-complex ILU apply by using the explicit destination-buffer permutation APIs from `src/utils/permutation.rs` for in-place/per-buffer permutations.

### Description
- In `IluCsr::apply_complex_mut()` (native complex branch) replaced `self.pipeline_meta.left_perm.apply_vec(x, w)` with `apply_vec_into(x, w)` and `self.pipeline_meta.right_perm.apply_vec_t(w, y_perm)` with `apply_vec_t_into(w, y_perm)` in `src/preconditioner/ilu_csr/mod.rs`.
- Kept the existing native-complex forward/backward triangular solve loops and the final `y.copy_from_slice(y_perm)` behavior unchanged.
- Uses the no-allocation `Permuation` destination-buffer helpers defined in `src/utils/permutation.rs`.

### Testing
- Ran `cargo test -q --no-run`, which completed (compiler warnings only).
- Ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0384334483299f3b7d382fc3c58c)