### PR TITLE
Document ILU CSR apply workspace contract

### DIFF
--- a/src/preconditioner/ilu_csr/mod.rs
+++ b/src/preconditioner/ilu_csr/mod.rs
@@ -1963,6 +1963,8 @@ impl IluCsr {
                 y.len()
             )));
         }
+        // Immutable apply helper: it cannot borrow the cached scratch buffers, so
+        // this path may allocate temporary vectors for the permutation pipeline.
         let mut x_perm = vec![Real::zero(); self.n];
         let mut y_perm = vec![Real::zero(); self.n];
         let mut right_tmp = vec![Real::zero(); self.n];
@@ -1973,6 +1975,10 @@ impl IluCsr {
         if self.tmp.len() != self.n || self.tmp2.len() != self.n || self.tmp3.len() != self.n {
             self.resize_apply_workspace(self.n);
         }
+        // Mutable apply helper: keep this route on preallocated workspace.  The
+        // `std::mem::take` calls temporarily move out the scratch vectors so
+        // `apply_mut()` can preserve its no-allocation steady-state contract by
+        // routing through `apply_op_scalar_mut()` / `apply_op_scalar_with_workspace()`.
         let mut x_perm = std::mem::take(&mut self.tmp);
         let mut y_perm = std::mem::take(&mut self.tmp2);
         let mut right_tmp = std::mem::take(&mut self.tmp3);


### PR DESCRIPTION
### Motivation
- Clarify the allocation/workspace contract for ILU CSR apply paths so callers and mainteners understand that immutable applies may allocate temporaries while mutable applies must reuse preallocated scratch to preserve a no-allocation steady-state for iterative solvers.

### Description
- Add brief comments in `src/preconditioner/ilu_csr/mod.rs` near the vector allocation in `apply_op_scalar()` and the `std::mem::take()` usage in `apply_op_scalar_mut()` explaining that `apply_op_scalar()` is the immutable helper that may allocate temporaries, `apply_op_scalar_mut()` uses preallocated workspace, and `apply_mut()` must continue routing through the workspace-preserving helpers (`apply_op_scalar_mut()` / `apply_op_scalar_with_workspace()`).

### Testing
- Ran `cargo fmt` and `git diff --check`, both completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0556ce58832981d6cee920df0f44)