### PR TITLE
Add permutation identity allocation-guard test

### DIFF
--- a/tests/ilu_apply_no_alloc.rs
+++ b/tests/ilu_apply_no_alloc.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "backend-faer")]
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::atomic::{AtomicUsize, Ordering::*};
 use std::sync::Mutex;
+use std::sync::atomic::{AtomicUsize, Ordering::*};
 
 use kryst::algebra::prelude::*;
 
@@ -30,13 +30,39 @@ fn allocs() -> usize {
     ALLOCS.load(SeqCst)
 }
 
+#[test]
+fn permutation_identity_apply_vec_into_has_no_allocations() {
+    let _alloc_guard = ALLOC_TEST_LOCK.lock().unwrap();
+    use kryst::utils::permutation::Permutation;
+
+    let n = 32;
+    let perm = Permutation::identity(n);
+    let x: Vec<_> = (0..n).map(|i| i as f64 + 0.5).collect();
+    let mut y = vec![0.0; n];
+
+    let before = allocs();
+    perm.apply_vec_into(&x, &mut y);
+    let after_apply = allocs();
+    perm.apply_vec_t_into(&x, &mut y);
+    let after_apply_t = allocs();
+
+    assert_eq!(
+        before, after_apply,
+        "identity apply_vec_into() performed heap allocations"
+    );
+    assert_eq!(
+        before, after_apply_t,
+        "identity apply_vec_t_into() performed heap allocations"
+    );
+}
+
 #[cfg(not(feature = "complex"))]
 #[test]
 fn ilu_apply_has_no_allocations() {
     let _alloc_guard = ALLOC_TEST_LOCK.lock().unwrap();
+    use kryst::preconditioner::PcSide;
     use kryst::preconditioner::ilu::{IluBuilder, IluType, TriSolveType};
     use kryst::preconditioner::legacy::Preconditioner;
-    use kryst::preconditioner::PcSide;
 
     let n = 32;
     let a = faer::Mat::from_fn(n, n, |i, j| {


### PR DESCRIPTION
### Motivation
- Prevent regressions by verifying that `Permutation::identity(n)` fast-paths for `apply_vec_into` and `apply_vec_t_into` do not perform heap allocations at runtime.

### Description
- Add `permutation_identity_apply_vec_into_has_no_allocations` to `tests/ilu_apply_no_alloc.rs` which reuses the existing `CountingAlloc`, `allocs()` counter and `ALLOC_TEST_LOCK` to isolate allocation checks.
- The test constructs `Permutation::identity(n)`, preallocates input and output vectors, measures `allocs()` before and after `perm.apply_vec_into(&x, &mut y)` and `perm.apply_vec_t_into(&x, &mut y)`, and asserts the allocation count is unchanged.

### Testing
- Ran `cargo test --features backend-faer --test ilu_apply_no_alloc permutation_identity_apply_vec_into_has_no_allocations` and the test passed.
- Ran `cargo fmt --check` which reported unrelated formatting diffs in other files (pre-existing), not caused by this test addition.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0619cccc8329903ee3a9bce19139)