### PR TITLE
Add ILU CSR real apply_mut no-allocation test

### DIFF
--- a/tests/ilu_apply_no_alloc.rs
+++ b/tests/ilu_apply_no_alloc.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "backend-faer")]
 use std::alloc::{GlobalAlloc, Layout, System};
-use std::sync::Mutex;
 use std::sync::atomic::{AtomicUsize, Ordering::*};
+use std::sync::Mutex;
 
 use kryst::algebra::prelude::*;
 
@@ -60,9 +60,9 @@ fn permutation_identity_apply_vec_into_has_no_allocations() {
 #[test]
 fn ilu_apply_has_no_allocations() {
     let _alloc_guard = ALLOC_TEST_LOCK.lock().unwrap();
-    use kryst::preconditioner::PcSide;
     use kryst::preconditioner::ilu::{IluBuilder, IluType, TriSolveType};
     use kryst::preconditioner::legacy::Preconditioner;
+    use kryst::preconditioner::PcSide;
 
     let n = 32;
     let a = faer::Mat::from_fn(n, n, |i, j| {
@@ -89,6 +89,54 @@ fn ilu_apply_has_no_allocations() {
     ilu.apply(PcSide::Left, &x, &mut y).unwrap();
     let after = allocs();
     assert_eq!(before, after, "apply() performed heap allocations");
+}
+
+#[test]
+fn ilu_csr_real_apply_mut_has_no_allocations() {
+    let _alloc_guard = ALLOC_TEST_LOCK.lock().unwrap();
+    use kryst::matrix::sparse::CsrMatrix;
+    use kryst::preconditioner::ilu_csr::{IluCsr, IluCsrConfig, IluKind};
+    use kryst::preconditioner::{PcSide, Preconditioner};
+
+    let n = 32;
+    let mut row_ptr = Vec::with_capacity(n + 1);
+    let mut col_idx = Vec::with_capacity(3 * n - 2);
+    let mut values = Vec::with_capacity(3 * n - 2);
+    row_ptr.push(0);
+    for i in 0..n {
+        if i > 0 {
+            col_idx.push(i - 1);
+            values.push(R::from(-1.0));
+        }
+        col_idx.push(i);
+        values.push(R::from(4.0));
+        if i + 1 < n {
+            col_idx.push(i + 1);
+            values.push(R::from(-1.0));
+        }
+        row_ptr.push(col_idx.len());
+    }
+    let a = CsrMatrix::from_csr(n, n, row_ptr, col_idx, values);
+
+    let mut cfg = IluCsrConfig::default();
+    cfg.kind = IluKind::Ilu0;
+    cfg.level_sched = false;
+    let mut ilu = IluCsr::new_with_config(cfg);
+    ilu.setup(&a).unwrap();
+
+    let x = vec![R::from(1.0); n];
+    let mut y = vec![R::default(); n];
+
+    // Exercise any one-time runtime initialization before measuring steady-state apply.
+    ilu.apply_mut(PcSide::Left, &x, &mut y).unwrap();
+
+    let before = allocs();
+    ilu.apply_mut(PcSide::Left, &x, &mut y).unwrap();
+    let after = allocs();
+    assert_eq!(
+        before, after,
+        "real CSR apply_mut() performed heap allocations"
+    );
 }
 
 #[cfg(all(feature = "complex", feature = "complex_ilu"))]


### PR DESCRIPTION
### Motivation
- Ensure `IluCsr::apply_mut` for real-valued CSR ILU0 preconditioners does not perform heap allocations in steady-state.
- Add a regression test that mirrors existing complex-valued tests to cover the real scalar code path.

### Description
- Add test `ilu_csr_real_apply_mut_has_no_allocations` to `tests/ilu_apply_no_alloc.rs` which builds a tridiagonal `CsrMatrix<R>` and configures `IluCsrConfig` with `kind = IluKind::Ilu0` and `level_sched = false`.
- Create the preconditioner via `IluCsr::new_with_config(cfg)` and call `setup(&a)` before exercising `apply_mut`.
- Perform one warm-up `apply_mut(PcSide::Left, &x, &mut y)` then measure a second steady-state `apply_mut()` using the existing `allocs()` helper and assert the allocation count is unchanged.

### Testing
- Ran `rustfmt --check tests/ilu_apply_no_alloc.rs` which passed for the modified test file.
- Ran `git diff --check` which reported no problems for the change.
- Ran `cargo test --test ilu_apply_no_alloc --features backend-faer ilu_csr_real_apply_mut_has_no_allocations` and the new test passed (`ok`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f300035208329867903410d5731cc)