### PR TITLE
Clarify ILU CSR no-allocation solve path

### DIFF
--- a/tests/ilu_apply_no_alloc.rs
+++ b/tests/ilu_apply_no_alloc.rs
@@ -120,6 +120,9 @@ fn ilu_csr_real_apply_mut_has_no_allocations() {
 
     let mut cfg = IluCsrConfig::default();
     cfg.kind = IluKind::Ilu0;
+    // Guard the serial triangular solve no-allocation contract; the
+    // level-scheduled path needs separate scratch-buffer work first
+    // before this assertion can cover it too.
     cfg.level_sched = false;
     let mut ilu = IluCsr::new_with_config(cfg);
     ilu.setup(&a).unwrap();
@@ -169,6 +172,9 @@ fn ilu_csr_complex_native_apply_mut_has_no_allocations() {
 
     let mut cfg = IluCsrConfig::default();
     cfg.kind = IluKind::Ilu0;
+    // Guard the serial triangular solve no-allocation contract; the
+    // level-scheduled path needs separate scratch-buffer work first
+    // before this assertion can cover it too.
     cfg.level_sched = false;
     let mut ilu = IluCsr::new_with_config(cfg);
     ilu.setup(&a).unwrap();
@@ -206,6 +212,9 @@ fn ilu_csr_complex_degraded_apply_mut_has_no_allocations() {
 
     let mut cfg = IluCsrConfig::default();
     cfg.kind = IluKind::Ilu0;
+    // Guard the serial triangular solve no-allocation contract; the
+    // level-scheduled path needs separate scratch-buffer work first
+    // before this assertion can cover it too.
     cfg.level_sched = false;
     let mut ilu = IluCsr::new_with_config(cfg);
     ilu.set_complex_force_degraded(true);


### PR DESCRIPTION
### Motivation
- The ILU CSR no-allocation tests assert a no-heap-allocation contract for the serial triangular solve path, so they must explicitly disable the level-scheduled path which has different scratch-buffer requirements.

### Description
- Added a short explanatory comment immediately before each `cfg.level_sched = false` in `tests/ilu_apply_no_alloc.rs` to state that the tests guard the serial triangular solve no-allocation contract and that the level-scheduled path requires separate scratch-buffer work before it can be covered by the same assertion.
- The edits appear in the three CSR ILU tests: real, complex native, and complex degraded, and do not change test logic or behavior.

### Testing
- Ran `cargo test --features backend-faer --test ilu_apply_no_alloc` and the test binary completed successfully with all tests passing (3 passed; 0 failed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f346413048329938ccb4754c93f0f)