### PR TITLE
Fix ILU allocation test feature gating

### DIFF
--- a/tests/ilu_apply_no_alloc.rs
+++ b/tests/ilu_apply_no_alloc.rs
@@ -91,6 +91,7 @@ fn ilu_apply_has_no_allocations() {
     assert_eq!(before, after, "apply() performed heap allocations");
 }
 
+#[cfg(not(feature = "complex"))]
 #[test]
 fn ilu_csr_real_apply_mut_has_no_allocations() {
     let _alloc_guard = ALLOC_TEST_LOCK.lock().unwrap();


### PR DESCRIPTION
### Motivation
- Prevent a real-valued CSR ILU allocation test from being compiled against the complex `Preconditioner` API when `--all-features` enables `complex`, which caused type-mismatch compile errors.

### Description
- Gate the real-valued test `ilu_csr_real_apply_mut_has_no_allocations` with `#[cfg(not(feature = "complex"))]` in `tests/ilu_apply_no_alloc.rs` so it is only compiled for the real-scalar build.

### Testing
- Ran `RUSTFLAGS="-Awarnings" RUST_BACKTRACE=full cargo test --all-features` and the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f360189d883299f8233ced5593b8a)