### PR TITLE
Fix no-default-features test build

### DIFF
--- a/src/solver/bicgstab.rs
+++ b/src/solver/bicgstab.rs
@@ -44,6 +44,7 @@ use log::trace;
 enum RealDispatchRoute {
     DistCsrBorrowed,
     CsrBorrowed,
+    #[cfg(feature = "backend-faer")]
     CsrMaterialized,
     Generic,
 }
@@ -308,6 +309,7 @@ impl BiCgStabSolver {
         let pc_wants_csr = pc
             .map(|p| p.required_format() == OpFormat::Csr)
             .unwrap_or(false);
+        #[cfg(feature = "backend-faer")]
         if a.format() == OpFormat::Csr
             && pc_wants_csr
             && any_op
@@ -1168,6 +1170,7 @@ impl BiCgStabSolver {
                         .solve_csr(csr, pc_ref, b_s, x_s, pc_side, comm, monitors, work)
                         .map(|stats| stats.with_reduction_model(self.reduction_model()));
                 }
+                #[cfg(feature = "backend-faer")]
                 RealDispatchRoute::CsrMaterialized => {
                     let generic = a
                         .as_any()

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,6 +15,7 @@ pub mod metrics;
 pub mod monitor;
 pub mod partition;
 pub mod permutation;
+#[cfg(feature = "backend-faer")]
 pub mod preconditioning_pipeline;
 pub mod profiling;
 pub mod reduction;

--- a/tests/cg_screening_contract.rs
+++ b/tests/cg_screening_contract.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "backend-faer")]
+
 use kryst::utils::matrix_market::read_matrix_market;
 use kryst::utils::matrix_screening::{
     SYMMETRY_MAX_ASYMMETRY_RATE, assess_symmetry, cg_compatibility_screen,

--- a/tests/gmres_residual_regressions.rs
+++ b/tests/gmres_residual_regressions.rs
@@ -4,7 +4,6 @@ use kryst::algebra::prelude::*;
 use kryst::context::ksp_context::{KspContext, SolverType};
 use kryst::context::pc_context::PcType;
 use kryst::matrix::LinOp;
-use kryst::matrix::op::CsrOp;
 use kryst::matrix::sparse::CsrMatrix;
 use kryst::solver::MonitorAction;
 
@@ -110,8 +109,7 @@ fn gmres_sparse_no_pc_reports_true_residual_in_stats() {
     .map(S::from_real)
     .collect();
 
-    let csr = Arc::new(CsrMatrix::from_csr(n, n, row_ptr, col_idx, vals));
-    let op = Arc::new(CsrOp::new(csr));
+    let op = Arc::new(CsrMatrix::from_csr(n, n, row_ptr, col_idx, vals));
 
     let x_true: Vec<S> = (0..n)
         .map(|i| S::from_real(1.0 + (i as f64) * 0.2))


### PR DESCRIPTION
### Motivation
- The no-default-features test build failed due to references to backend-faer-only types and modules (e.g., `ilu_csr`, `GenericCsrOp`) that are disabled when `backend-faer` is not enabled.

### Description
- Gate the preconditioning pipeline export behind `backend-faer` to match its ILU CSR dependencies by adding `#[cfg(feature = "backend-faer")]` to `src/utils/mod.rs` for `preconditioning_pipeline`.
- Prevent no-default builds from referencing `GenericCsrOp` by guarding the BiCGStab CSR-materialization dispatch and the corresponding match arm with `#[cfg(feature = "backend-faer")]` in `src/solver/bicgstab.rs`.
- Update tests that referenced backend-only helpers so they compile under no-default-features: add `#![cfg(feature = "backend-faer")]` to `tests/cg_screening_contract.rs` and replace `CsrOp` usage with plain `CsrMatrix` in `tests/gmres_residual_regressions.rs`.

### Testing
- Ran `RUSTFLAGS="-Awarnings" RUST_BACKTRACE=full cargo test --no-default-features --no-run` which completed successfully.
- Ran `RUSTFLAGS="-Awarnings" RUST_BACKTRACE=full cargo test --no-default-features` and the test suite completed successfully (all automated tests passed for the no-default-features configuration).
- Ran `RUSTFLAGS="-Awarnings" cargo test --no-run` to validate the default-feature build artifacts, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3984b07483299523dd8e19e44a60)